### PR TITLE
Remove explicit metaclass definitions

### DIFF
--- a/doc/_static/PowerSupplyDS.py
+++ b/doc/_static/PowerSupplyDS.py
@@ -7,23 +7,21 @@ import time
 import numpy
 
 from tango import AttrQuality, AttrWriteType, DispLevel, DevState, DebugIt
-from tango.server import Device, DeviceMeta, attribute, command, pipe, run
-from tango.server import device_property
+from tango.server import Device, attribute, command, pipe, device_property
 
 
 class PowerSupply(Device):
-    __metaclass__ = DeviceMeta
 
     voltage = attribute(label="Voltage", dtype=float,
                         display_level=DispLevel.OPERATOR,
                         access=AttrWriteType.READ,
-                        unit="V",format="8.4f",
+                        unit="V", format="8.4f",
                         doc="the power supply voltage")
 
     current = attribute(label="Current", dtype=float,
                         display_level=DispLevel.EXPERT,
                         access=AttrWriteType.READ_WRITE,
-                        unit="A",format="8.4f",
+                        unit="A", format="8.4f",
                         min_value=0.0, max_value=8.5,
                         min_alarm=0.1, max_alarm=8.4,
                         min_warning=0.5, max_warning=8.0,
@@ -39,16 +37,16 @@ class PowerSupply(Device):
 
     host = device_property(dtype=str)
     port = device_property(dtype=int, default_value=9788)
-    
+
     def init_device(self):
         Device.init_device(self)
         self.__current = 0.0
         self.set_state(DevState.STANDBY)
-    
+
     def read_voltage(self):
         self.info_stream("read_voltage(%s, %d)", self.host, self.port)
         return 9.99, time.time(), AttrQuality.ATTR_WARNING
-    
+
     def get_current(self):
         return self.__current
 
@@ -76,12 +74,12 @@ class PowerSupply(Device):
         self.set_state(DevState.OFF)
 
     @command(dtype_in=float, doc_in="Ramp target current",
-             dtype_out=bool, doc_out="True if ramping went well, False otherwise")
+             dtype_out=bool, doc_out="True if ramping went well, "
+             "False otherwise")
     def Ramp(self, target_current):
         # should do the ramping
         return True
-    
-    
-if __name__ == "__main__":
-    run([PowerSupply])
 
+
+if __name__ == "__main__":
+    PowerSupply.run_server()

--- a/doc/_templates/index.html
+++ b/doc/_templates/index.html
@@ -87,7 +87,6 @@
 
 
 <span class="k">class</span> <span class="nc">Clock</span><span class="p">(</span><span class="n">Device</span><span class="p">):</span>
-    <span class="n">__metaclass__</span> <span class="o">=</span> <span class="n">DeviceMeta</span>
 
     <span class="n">time</span> <span class="o">=</span> <span class="n">attribute</span><span class="p">()</span>
 

--- a/doc/howto.rst
+++ b/doc/howto.rst
@@ -307,13 +307,10 @@ high level API
    :linenos:
 
     import time
-    from tango.server import run
-    from tango.server import Device, DeviceMeta
-    from tango.server import attribute, command, pipe
+    from tango.server import Device, attribute, command, pipe
 
 
     class Clock(Device):
-        __metaclass__ = DeviceMeta
 
         @attribute
         def time(self):
@@ -332,37 +329,32 @@ high level API
 
 
     if __name__ == "__main__":
-        run([Clock])
+        Clock.run_server()
 
 
-**line 2-4**
+**line 2**
     import the necessary symbols
 
-**line 7**
+**line 5**
     tango device class definition. A Tango device must inherit from
     :class:`tango.server.Device`
 
-**line 8**
-    mandatory *magic* line. A Tango device must define the metaclass as
-    :class:`tango.server.DeviceClass`. This has to be done due to a limitation
-    on boost-python
-
-**line 10-12**
+**line 7-9**
     definition of the *time* attribute. By default, attributes are double, scalar,
     read-only. Check the :class:`~tango.server.attribute` for the complete
     list of attribute options.
 
-**line 14-16**
+**line 11-13**
     the method *strftime* is exported as a Tango command. In receives a string
     as argument and it returns a string. If a method is to be exported as a
     Tango command, it must be decorated as such with the
     :func:`~tango.server.command` decorator
 
-**line 18-23**
+**line 15-20**
     definition of the *info* pipe. Check the :class:`~tango.server.pipe`
     for the complete list of pipe options.
 
-**line 28**
+**line 24**
     start the Tango run loop. The mandatory argument is a list of python classes
     that are to be exported as Tango classes. Check :func:`~tango.server.run`
     for the complete list of options
@@ -383,13 +375,12 @@ using the high level API. The example contains:
     from time import time
     from numpy.random import random_sample
 
-    from tango import AttrQuality, AttrWriteType, DispLevel, run
-    from tango.server import Device, DeviceMeta, attribute, command
+    from tango import AttrQuality, AttrWriteType, DispLevel
+    from tango.server import Device, attribute, command
     from tango.server import class_property, device_property
 
 
     class PowerSupply(Device):
-        __metaclass__ = DeviceMeta
 
         current = attribute(label="Current", dtype=float,
                             display_level=DispLevel.EXPERT,
@@ -428,17 +419,7 @@ using the high level API. The example contains:
 
 
     if __name__ == "__main__":
-        run([PowerSupply])
-
-
-.. note::
-    the ``__metaclass__`` statement is mandatory due to a limitation in the
-    *boost-python* library used by PyTango.
-
-    If you are using python 3 you can write instead::
-
-        class PowerSupply(Device, metaclass=DeviceMeta)
-            pass
+        PowerSupply.run_server()
 
 .. _logging:
 
@@ -573,29 +554,27 @@ separated python files: A :class:`PLC` class in a :file:`PLC.py`::
 
     # PLC.py
 
-    from tango.server import Device, DeviceMeta, run
+    from tango.server import Device
 
     class PLC(Device):
-        __metaclass__ = DeviceMeta
 
         # bla, bla my PLC code
 
     if __name__ == "__main__":
-        run([PLC])
+        PLC.run_server()
 
 ... and a :class:`IRMirror` in a :file:`IRMirror.py`::
 
     # IRMirror.py
 
-    from tango.server import Device, DeviceMeta, run
+    from tango.server import Device
 
     class IRMirror(Device):
-        __metaclass__ = DeviceMeta
 
         # bla, bla my IRMirror code
 
     if __name__ == "__main__":
-        run([IRMirror])
+        IRMirror.run_server()
 
 You want to create a Tango server called `PLCMirror` that is able to contain
 devices from both PLC and IRMirror classes. All you have to do is write
@@ -683,10 +662,9 @@ point attribute with the specified name::
 
 
     from tango import Util, Attr
-    from tango.server import DeviceMeta, Device, command
+    from tango.server import Device, command
 
     class MyDevice(Device):
-    	__metaclass__ = DeviceMeta
 
 	@command(dtype_in=str)
         def CreateFloatAttribute(self, attr_name):
@@ -730,10 +708,9 @@ creates a device of some arbitrary class (the example assumes the tango commands
 with two strings. No error processing was done on the code for simplicity sake)::
 
     from tango import Util
-    from tango.server import DeviceMeta, Device, command
+    from tango.server import Device, command
 
     class MyDevice(Device):
-    	__metaclass__ = DeviceMeta
 
 	@command(dtype_in=[str])
         def CreateDevice(self, pars):

--- a/doc/server_api/server.rst
+++ b/doc/server_api/server.rst
@@ -25,15 +25,14 @@ device server.
 
 Here is a simple example on how to write a *Clock* device server using the
 high level API::
-    
+
     import time
     from tango.server import run
-    from tango.server import Device, DeviceMeta
-    from tango.server import attribute, command   
+    from tango.server import Device
+    from tango.server import attribute, command
 
 
     class Clock(Device):
-        __metaclass__ = DeviceMeta
 
         time = attribute()
 
@@ -65,12 +64,11 @@ using the high level API. The example contains:
     from time import time
     from numpy.random import random_sample
 
-    from tango import AttrQuality, AttrWriteType, DispLevel, server_run
-    from tango.server import Device, DeviceMeta, attribute, command
+    from tango import AttrQuality, AttrWriteType, DispLevel
+    from tango.server import Device, attribute, command
     from tango.server import class_property, device_property
 
     class PowerSupply(Device):
-        __metaclass__ = DeviceMeta
 
         voltage = attribute()
 
@@ -83,11 +81,11 @@ using the high level API. The example contains:
                             min_warning=0.5, max_warning=8.0,
                             fget="get_current", fset="set_current",
                             doc="the power supply current")
-    
+
         noise = attribute(label="Noise", dtype=((float,),),
                           max_dim_x=1024, max_dim_y=1024,
                           fget="get_noise")
- 
+
         host = device_property(dtype=str)
         port = class_property(dtype=int, default_value=9788)
 
@@ -97,10 +95,10 @@ using the high level API. The example contains:
 
         def get_current(self):
             return 2.3456, time(), AttrQuality.ATTR_WARNING
-    
+
         def set_current(self, current):
             print("Current set to %f" % current)
-    
+
         def get_noise(self):
             return random_sample((1024, 1024))
 
@@ -109,18 +107,9 @@ using the high level API. The example contains:
             print("Ramping up...")
 
     if __name__ == "__main__":
-        server_run((PowerSupply,))
+        PowerSupply.run_server()
 
 *Pretty cool, uh?*
-
-.. note::
-    the ``__metaclass__`` statement is mandatory due to a limitation in the
-    *boost-python* library used by PyTango.
-    
-    If you are using python 3 you can write instead::
-        
-        class PowerSupply(Device, metaclass=DeviceMeta)
-            pass
 
 .. _pytango-hlapi-datatypes:
 
@@ -137,9 +126,9 @@ attribute you have several possibilities:
 #. :obj:`int`
 #. 'int'
 #. 'int32'
-#. 'integer' 
+#. 'integer'
 #. :obj:`tango.CmdArgType.DevLong`
-#. 'DevLong' 
+#. 'DevLong'
 #. :obj:`numpy.int32`
 
 To define a *SPECTRUM* attribute simply wrap the scalar data type in any
@@ -159,15 +148,15 @@ python sequence of sequences:
 Below is the complete table of equivalences.
 
 ========================================  ========================================
-dtype argument                            converts to tango type                             
+dtype argument                            converts to tango type
 ========================================  ========================================
  ``None``                                  ``DevVoid``
  ``'None'``                                ``DevVoid``
  ``DevVoid``                               ``DevVoid``
  ``'DevVoid'``                             ``DevVoid``
 
- ``DevState``                              ``DevState``                           
- ``'DevState'``                            ``DevState``                           
+ ``DevState``                              ``DevState``
+ ``'DevState'``                            ``DevState``
 
  :py:obj:`bool`                            ``DevBoolean``
  ``'bool'``                                ``DevBoolean``
@@ -211,20 +200,20 @@ dtype argument                            converts to tango type
  ``DevLong64``                             ``DevLong64``
  ``'DevLong64'``                           ``DevLong64``
  :py:obj:`numpy.int64`                     ``DevLong64``
- 
+
  ``'uint64'``                              ``DevULong64``
  ``DevULong64``                            ``DevULong64``
  ``'DevULong64'``                          ``DevULong64``
  :py:obj:`numpy.uint64`                    ``DevULong64``
 
- ``DevInt``                                ``DevInt``                             
- ``'DevInt'``                              ``DevInt``                             
- 
+ ``DevInt``                                ``DevInt``
+ ``'DevInt'``                              ``DevInt``
+
  ``'float32'``                             ``DevFloat``
  ``DevFloat``                              ``DevFloat``
  ``'DevFloat'``                            ``DevFloat``
  :py:obj:`numpy.float32`                   ``DevFloat``
- 
+
  :py:obj:`float`                           ``DevDouble``
  ``'double'``                              ``DevDouble``
  ``'float'``                               ``DevDouble``
@@ -232,14 +221,14 @@ dtype argument                            converts to tango type
  ``DevDouble``                             ``DevDouble``
  ``'DevDouble'``                           ``DevDouble``
  :py:obj:`numpy.float64`                   ``DevDouble``
- 
+
  :py:obj:`str`                             ``DevString``
  ``'str'``                                 ``DevString``
  ``'string'``                              ``DevString``
  ``'text'``                                ``DevString``
  ``DevString``                             ``DevString``
  ``'DevString'``                           ``DevString``
- 
+
  :py:obj:`bytearray`                       ``DevEncoded``
  ``'bytearray'``                           ``DevEncoded``
  ``'bytes'``                               ``DevEncoded``
@@ -248,40 +237,40 @@ dtype argument                            converts to tango type
 
  ``DevVarBooleanArray``                    ``DevVarBooleanArray``
  ``'DevVarBooleanArray'``                  ``DevVarBooleanArray``
- 
+
  ``DevVarCharArray``                       ``DevVarCharArray``
  ``'DevVarCharArray'``                     ``DevVarCharArray``
- 
+
  ``DevVarShortArray``                      ``DevVarShortArray``
  ``'DevVarShortArray'``                    ``DevVarShortArray``
- 
+
  ``DevVarLongArray``                       ``DevVarLongArray``
  ``'DevVarLongArray'``                     ``DevVarLongArray``
- 
+
  ``DevVarLong64Array``                     ``DevVarLong64Array``
  ``'DevVarLong64Array'``                   ``DevVarLong64Array``
- 
+
  ``DevVarULong64Array``                    ``DevVarULong64Array``
  ``'DevVarULong64Array'``                  ``DevVarULong64Array``
- 
+
  ``DevVarFloatArray``                      ``DevVarFloatArray``
  ``'DevVarFloatArray'``                    ``DevVarFloatArray``
- 
+
  ``DevVarDoubleArray``                     ``DevVarDoubleArray``
  ``'DevVarDoubleArray'``                   ``DevVarDoubleArray``
- 
+
  ``DevVarUShortArray``                     ``DevVarUShortArray``
  ``'DevVarUShortArray'``                   ``DevVarUShortArray``
- 
+
  ``DevVarULongArray``                      ``DevVarULongArray``
  ``'DevVarULongArray'``                    ``DevVarULongArray``
- 
+
  ``DevVarStringArray``                     ``DevVarStringArray``
  ``'DevVarStringArray'``                   ``DevVarStringArray``
- 
+
  ``DevVarLongStringArray``                 ``DevVarLongStringArray``
  ``'DevVarLongStringArray'``               ``DevVarLongStringArray``
- 
+
  ``DevVarDoubleStringArray``               ``DevVarDoubleStringArray``
  ``'DevVarDoubleStringArray'``             ``DevVarDoubleStringArray``
 

--- a/examples/Clock/Clock.py
+++ b/examples/Clock/Clock.py
@@ -1,15 +1,11 @@
 import time
-from PyTango.server import run
-from PyTango.server import Device, DeviceMeta
-from PyTango.server import attribute, command   
+from PyTango.server import Device, attribute, command
 
 
 class Clock(Device):
-    __metaclass__ = DeviceMeta
 
     @attribute
     def time(self):
-	"""The time attribute"""
         return time.time()
 
     @command(dtype_in=str, dtype_out=str)
@@ -18,4 +14,4 @@ class Clock(Device):
 
 
 if __name__ == "__main__":
-    run([Clock])
+    Clock.run_server()

--- a/examples/Clock/ClockDS.py
+++ b/examples/Clock/ClockDS.py
@@ -1,14 +1,4 @@
 #!/usr/bin/env python
-# -*- coding: utf-8 -*-
-# ------------------------------------------------------------------------------
-# This file is part of PyTango (http://pytango.rtfd.io)
-#
-# Copyright 2013-2015 European Synchrotron Radiation Facility, Grenoble, France
-#
-# Distributed under the terms of the GNU Lesser General Public License,
-# either version 3 of the License, or (at your option) any later version.
-# See LICENSE.txt for more info.
-# ------------------------------------------------------------------------------
 
 """
 Clock Device server showing how to write a TANGO server with a Clock device
@@ -24,14 +14,10 @@ commands:
 """
 
 import time
-
-from PyTango.server import Device, DeviceMeta
-from PyTango.server import attribute, command
-from PyTango.server import run
+from PyTango.server import Device, attribute, command
 
 
 class Clock(Device):
-    __metaclass__ = DeviceMeta
 
     @attribute(dtype=float)
     def time(self):
@@ -57,4 +43,4 @@ class Clock(Device):
 
 
 if __name__ == "__main__":
-    run([Clock,])
+    Clock.run_server()

--- a/examples/TuringMachine/TuringMachine.py
+++ b/examples/TuringMachine/TuringMachine.py
@@ -1,14 +1,14 @@
 import json
 from PyTango import DevState
-from PyTango.server import Device, DeviceMeta, run
+from PyTango.server import Device
 from PyTango.server import attribute, command, device_property
 
+
 class TuringMachine(Device):
-    __metaclass__ = DeviceMeta
 
     blank_symbol = device_property(dtype=str, default_value=" ")
     initial_state = device_property(dtype=str, default_value="init")
-    
+
     def init_device(self):
         Device.init_device(self)
         self.__tape = {}
@@ -35,8 +35,8 @@ class TuringMachine(Device):
         self.__transition_function = tf = {}
         for k, v in json.loads(func_str).items():
             tf[tuple(str(k).split(","))] = map(str, v)
-        print tf
-        
+        print(tf)
+
     @attribute(dtype=str)
     def tape(self):
         s, keys = "", self.__tape.keys()
@@ -57,13 +57,14 @@ class TuringMachine(Device):
             elif y[2] == "L":
                 self.__head -= 1
             self.__state = y[0]
-        print self.__state
+        print(self.__state)
 
     def dev_state(self):
         if self.__state in self.__final_states:
             return DevState.ON
         else:
             return DevState.RUNNING
-            
-    
-run([TuringMachine])
+
+
+if __name__ == "__main__":
+    TuringMachine.run_server()

--- a/tango/databaseds/database.py
+++ b/tango/databaseds/database.py
@@ -132,7 +132,6 @@ class DataBase(Device):
     """
     DataBase TANGO device class
     """
-    __metaclass__ = DeviceMeta
 
     # --- attributes ---------------------------------------
 

--- a/tango/server.py
+++ b/tango/server.py
@@ -1668,10 +1668,10 @@ def _create_asyncio_worker():
 
         def execute(self, fn, *args, **kwargs):
             """Execute the callable fn as fn(*args **kwargs)."""
-            corofn = asyncio.coroutine(fn)
+            corofn = asyncio.coroutine(lambda: fn(*args, **kwargs))
             if self.loop._thread_id == get_ident():
-                return corofn(*args, **kwargs)
-            return self.submit(corofn, *args, **kwargs).result()
+                return corofn()
+            return self.submit(corofn).result()
 
     try:
         loop = asyncio.get_event_loop()

--- a/tango/server.py
+++ b/tango/server.py
@@ -642,7 +642,6 @@ class attribute(AttrData):
     *voltage* in a *PowerSupply* :class:`Device` do::
 
         class PowerSupply(Device):
-            __metaclass__ = DeviceMeta
 
             voltage = attribute()
 
@@ -652,7 +651,6 @@ class attribute(AttrData):
     The same can be achieved with::
 
         class PowerSupply(Device):
-            __metaclass__ = DeviceMeta
 
             @attribute
             def voltage(self):
@@ -711,7 +709,6 @@ class attribute(AttrData):
     unit and description::
 
         class PowerSupply(Device):
-            __metaclass__ = DeviceMeta
 
             current = attribute(label="Current", unit="mA", dtype=int,
                                 access=AttrWriteType.READ_WRITE,
@@ -730,7 +727,6 @@ class attribute(AttrData):
     The same, but using attribute as a decorator::
 
         class PowerSupply(Device):
-            __metaclass__ = DeviceMeta
 
             def init_device(self):
                 Device.init_device(self)
@@ -834,7 +830,6 @@ class pipe(PipeData):
     (for Region Of Interest), in a *Detector* :class:`Device` do::
 
         class Detector(Device):
-            __metaclass__ = DeviceMeta
 
             ROI = pipe()
 
@@ -848,7 +843,6 @@ class pipe(PipeData):
     to pass blob data)::
 
         class Detector(Device):
-            __metaclass__ = DeviceMeta
 
             @pipe
             def ROI(self):
@@ -876,7 +870,6 @@ class pipe(PipeData):
     The same example with a read-write ROI, a customized label and description::
 
         class Detector(Device):
-            __metaclass__ = DeviceMeta
 
             ROI = pipe(label='Region Of Interest', doc='The active region of interest',
                        access=PipeWriteType.PIPE_READ_WRITE)
@@ -895,7 +888,6 @@ class pipe(PipeData):
     The same, but using pipe as a decorator::
 
         class Detector(Device):
-            __metaclass__ = DeviceMeta
 
             def init_device(self):
                 Device.init_device(self)
@@ -1024,7 +1016,6 @@ def command(f=None, dtype_in=None, dformat_in=None, doc_in="",
     ::
 
         class PowerSupply(Device):
-            __metaclass__ = DeviceMeta
 
             @command
             def TurnOn(self):
@@ -1154,7 +1145,6 @@ class device_property(_BaseProperty):
         from tango.server import device_property
 
         class PowerSupply(Device):
-            __metaclass__ = DeviceMeta
 
             host = device_property(dtype=str)
 
@@ -1182,7 +1172,6 @@ class class_property(_BaseProperty):
         from tango.server import class_property
 
         class PowerSupply(Device):
-            __metaclass__ = DeviceMeta
 
             port = class_property(dtype=int, default_value=9788)
 
@@ -1371,7 +1360,7 @@ def run(classes, args=None, msg_stream=sys.stdout,
         from tango.server import Device, DeviceMeta, run
 
         class PowerSupply(Device):
-            __metaclass__ = DeviceMeta
+            pass
 
         run((PowerSupply,))
 
@@ -1396,7 +1385,7 @@ def run(classes, args=None, msg_stream=sys.stdout,
         from tango.server import Device, DeviceMeta, run
 
         class PowerSupply(Device):
-            __metaclass__ = DeviceMeta
+            pass
 
         class MyServer(Device_4Impl):
             pass

--- a/tango/server.py
+++ b/tango/server.py
@@ -1616,7 +1616,11 @@ def _create_gevent_worker():
 
 def _create_asyncio_worker():
     import concurrent.futures
-    from threading import get_ident
+
+    try:
+        from threading import get_ident
+    except:
+        from threading import _get_ident as get_ident
 
     try:
         import asyncio

--- a/tango/tango_object.py
+++ b/tango/tango_object.py
@@ -85,7 +85,6 @@ def create_tango_class(server, obj, tango_class_name=None, member_filter=None):
         tango_class_name = obj_klass_name
 
     class DeviceDispatcher(Device):
-        __metaclass__ = DeviceMeta
 
         TangoClassName = tango_class_name
 

--- a/tango/test_utils.py
+++ b/tango/test_utils.py
@@ -1,14 +1,9 @@
 """Test utilities"""
 
-__all__ = ['DeviceTestContext', 'SimpleDevice']
-
-# Imports
-from six import add_metaclass
-
 # Local imports
 from . import utils
 from . import DevState, CmdArgType, GreenMode
-from .server import Device, DeviceMeta
+from .server import Device
 from .test_context import DeviceTestContext
 
 # Conditional imports
@@ -17,10 +12,11 @@ try:
 except ImportError:
     pytest = None
 
+__all__ = ['DeviceTestContext', 'SimpleDevice']
+
 
 # Test devices
 
-@add_metaclass(DeviceMeta)
 class SimpleDevice(Device):
     def init_device(self):
         self.set_state(DevState.ON)

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -130,13 +130,14 @@ def get_proxy(host, port, device, green_mode):
     return device_proxy_map[green_mode](access)
 
 
-def wait_for_proxy(host, proc, device, green_mode, retries=50, delay=0.1):
+def wait_for_proxy(host, proc, device, green_mode, retries=100, delay=0.01):
     for i in range(retries):
         ports = get_ports(proc.pid)
-        for port in ports:
+        if ports:
             try:
-                proxy = get_proxy(host, port, device, green_mode)
+                proxy = get_proxy(host, ports[0], device, green_mode)
                 proxy.ping()
+                proxy.state()
                 return proxy
             except DevFailed:
                 pass
@@ -200,6 +201,11 @@ def test_info(tango_test):
 
 def test_read_attribute(tango_test, readable_attribute):
     "Check that readable attributes can be read"
+    # This is a hack:
+    # Without this sleep, the following error is very likely to be raised:
+    # -> MARSHAL CORBA system exception: MARSHAL_PassEndOfMessage
+    if readable_attribute == "string_image_ro":
+        sleep(0.05)
     tango_test.read_attribute(readable_attribute, wait=True)
 
 

--- a/tests/test_event.py
+++ b/tests/test_event.py
@@ -1,0 +1,84 @@
+
+# Imports
+
+import socket
+from functools import partial
+
+import pytest
+
+from tango import EventType, GreenMode, DeviceProxy
+from tango.server import Device
+from tango.server import command, attribute
+from tango.test_utils import DeviceTestContext
+
+from tango.gevent import DeviceProxy as gevent_DeviceProxy
+from tango.futures import DeviceProxy as futures_DeviceProxy
+from tango.asyncio import DeviceProxy as asyncio_DeviceProxy
+
+# Helpers
+
+device_proxy_map = {
+    GreenMode.Synchronous: DeviceProxy,
+    GreenMode.Futures: futures_DeviceProxy,
+    GreenMode.Asyncio: partial(asyncio_DeviceProxy, wait=True),
+    GreenMode.Gevent: gevent_DeviceProxy}
+
+
+def get_open_port():
+    s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    s.bind(("", 0))
+    s.listen(1)
+    port = s.getsockname()[1]
+    s.close()
+    return port
+
+
+# Test device
+
+class EventDevice(Device):
+
+    def init_device(self):
+        self.set_change_event("attr", True, False)
+
+    @attribute
+    def attr(self):
+        return 0.
+
+    @command
+    def send_event(self):
+        self.push_change_event("attr", 1.)
+
+
+# Device fixture
+
+@pytest.fixture(params=[GreenMode.Synchronous,
+                        GreenMode.Futures,
+                        GreenMode.Asyncio,
+                        GreenMode.Gevent],
+                scope="module")
+def event_device(request):
+    green_mode = request.param
+    # Hack: a port have to be specified explicitely for events to work
+    port = get_open_port()
+    context = DeviceTestContext(EventDevice, port=port, process=True)
+    with context:
+        yield device_proxy_map[green_mode](context.get_device_access())
+
+
+# Tests
+
+def test_subscribe_event(event_device):
+    results = []
+
+    def callback(evt):
+        results.append(evt.attr_value.value)
+
+    event_device.subscribe_event(
+        "attr", EventType.CHANGE_EVENT, callback, wait=True)
+    event_device.command_inout("send_event", wait=True)
+    # Wait for tango event
+    event_device.read_attribute("state", wait=True)
+    event_device.read_attribute("state", wait=True)
+    event_device.read_attribute("state", wait=True)
+    # Test the event values
+    assert results == [0., 1.]

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,9 +1,7 @@
 # -*- coding: utf-8 -*-
 
 import pytest
-from six import add_metaclass
 
-from tango import GreenMode
 from tango import DevState, AttrWriteType
 from tango.server import Device, DeviceMeta
 from tango.server import command, attribute, device_property
@@ -18,7 +16,6 @@ state, typed_values, server_green_mode
 
 def test_empty_device(server_green_mode):
 
-    @add_metaclass(DeviceMeta)
     class TestDevice(Device):
         green_mode = server_green_mode
 
@@ -30,7 +27,6 @@ def test_empty_device(server_green_mode):
 def test_set_state(state, server_green_mode):
     status = 'The device is in {0!s} state.'.format(state)
 
-    @add_metaclass(DeviceMeta)
     class TestDevice(Device):
         green_mode = server_green_mode
 
@@ -49,7 +45,6 @@ def test_set_status(server_green_mode):
         "with special characters such as",
         "Café à la crème"))
 
-    @add_metaclass(DeviceMeta)
     class TestDevice(Device):
         green_mode = server_green_mode
 
@@ -67,7 +62,6 @@ def test_set_status(server_green_mode):
 def test_identity_command(typed_values, server_green_mode):
     dtype, values = typed_values
 
-    @add_metaclass(DeviceMeta)
     class TestDevice(Device):
         green_mode = server_green_mode
 
@@ -86,7 +80,6 @@ def test_identity_command(typed_values, server_green_mode):
 def test_read_write_attribute(typed_values, server_green_mode):
     dtype, values = typed_values
 
-    @add_metaclass(DeviceMeta)
     class TestDevice(Device):
         green_mode = server_green_mode
 
@@ -112,7 +105,6 @@ def test_device_property(typed_values, server_green_mode):
     default = values[0]
     value = values[1]
 
-    @add_metaclass(DeviceMeta)
     class TestDevice(Device):
         green_mode = server_green_mode
 


### PR DESCRIPTION
This PR makes `DeviceMeta` a subclass of `Boost.Python.class`, so the metaclass definition is automatically propagated to the subclasses of `Device`.

It also fixes a fundamental issue with asyncio servers that I hadn't noticed until today, see 995db76.

The docs and examples have been simplified (1890f6c and 64c8cc9 promote the `run_server` method and remove the metaclass definitions).

It also fixes issue #74, see 38e1eec  (unrelated, but it made my debugging easier).