### PR TITLE
Filter badges from the long description

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -93,11 +93,12 @@ You can get support from the `Tango forums`_, for both Tango_ and PyTango_ quest
 
 All contributions,  `PR and bug reports`_ are welcome!
 
+
 .. |Doc Status| image:: https://readthedocs.org/projects/pytango/badge/?version=latest
                 :target: http://pytango.readthedocs.io/en/latest
                 :alt:
 
-.. |Build Status| image:: https://travis-ci.org/tango-controls/pytango.svg?branch=master
+.. |Build Status| image:: https://travis-ci.org/tango-controls/pytango.svg
                   :target: https://travis-ci.org/tango-controls/pytango
                   :alt:
 

--- a/setup.py
+++ b/setup.py
@@ -59,6 +59,15 @@ GENTOO = distribution_match(['gentoo'])
 TESTING = any(x in sys.argv for x in ['test', 'pytest'])
 
 
+def get_readme(name='README.rst'):
+    """Get readme file contents without the badges."""
+    with open(name) as f:
+        return '\n'.join(
+            line for line in f.read().splitlines()
+            if not line.startswith('|')
+            or not line.endswith('|'))
+
+
 def pkg_config(*packages, **config):
     config_map = {
         "-I": "include_dirs",
@@ -519,7 +528,7 @@ def setup_args():
     if sphinx:
         cmdclass['build_doc'] = build_doc
 
-    long_description = open('README.rst').read()
+    long_description = get_readme()
 
     opts = dict(
         name='pytango',


### PR DESCRIPTION
This PR prevents badges from appearing on the pypi webpage.

The badges can be confusing since they link to the latest and not package version.