### PR TITLE
Use _DeviceClass as tango device class constructor

### DIFF
--- a/tango/server.py
+++ b/tango/server.py
@@ -481,7 +481,7 @@ def __create_tango_deviceclass_klass(tango_device_klass, attrs=None):
                           device_property_list=device_property_list,
                           cmd_list=cmd_list, attr_list=attr_list,
                           pipe_list=pipe_list)
-    return type(devclass_name, (_DeviceClass,), devclass_attrs)
+    return type(_DeviceClass)(devclass_name, (_DeviceClass,), devclass_attrs)
 
 
 def _init_tango_device_klass(tango_device_klass, attrs=None,


### PR DESCRIPTION
Since ```DeviceMeta``` has been update (see #90 ), HL API classes and methods links in the documentation are broken ([here in the documentation](http://pytango.readthedocs.io/en/latest/server_api/server.html))

According to issue #111 traceback, the mocking system used to generate the documentation creates some metaclass issue:
```python
File "/home/tango/PycharmProjects/pytango/tango/server.py", line 484, in __create_tango_deviceclass_klass
    return type(devclass_name, (_DeviceClass,), devclass_attrs)
TypeError: metaclass conflict: the metaclass of a derived class must be a (non-strict) subclass of the metaclasses of all its bases
```

This small fix should solve issue #111 and the missing links issue. 