### PR TITLE
Fix building with python 3 on openSUSE

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,7 @@ PYTHON3 = ('3',) <= PYTHON_VERSION < ('4',)
 distribution = platform.linux_distribution()[0].lower() if POSIX else ""
 distribution_match = lambda names: any(x in distribution for x in names)
 DEBIAN = distribution_match(['debian', 'ubuntu', 'mint'])
-REDHAT = distribution_match(['redhat', 'fedora', 'centos'])
+REDHAT = distribution_match(['redhat', 'fedora', 'centos', 'opensuse'])
 GENTOO = distribution_match(['gentoo'])
 
 # Arguments


### PR DESCRIPTION
* Use same scheme as REDHAT for boost_python naming.
* Tested on openSUSE 42.2 and 42.3 with package libboost_python3-1_61_0
installed