### PR TITLE
Easier access to DevEnum attributes

### DIFF
--- a/doc/data_types.rst
+++ b/doc/data_types.rst
@@ -50,6 +50,14 @@ much more efficient.
 |                         |                                                                           |    In this case it is :py:obj:`str` (decoded with default python          |
 |                         |                                                                           |    encoding *utf-8*))                                                     |
 +-------------------------+---------------------------------------------------------------------------+---------------------------------------------------------------------------+
+|                         | * :py:obj:`int` (for value)                                               | * :py:obj:`int` (for value)                                               |
+|                         | * :py:class:`list` <:py:obj:`str`> (for enum_labels)                      | * :py:class:`list` <:py:obj:`str`>  (for enum_labels)                     |
+|        DEV_ENUM         |                                                                           |                                                                           |
+| (*New in PyTango 9.0*)  | Note:  direct attribute access via DeviceProxy will return enumerated     | Note:  direct attribute access via DeviceProxy will return enumerated     |
+|                         |        type :py:obj:`enum.IntEnum`.                                       |        type :py:obj:`enum.IntEnum`.                                       |
+|                         |        This type uses the package enum34.                                 |        Python < 3.4, uses the package enum34.                             |
+|                         |                                                                           |        Python >= 3.4, uses standard package enum.                         |
++-------------------------+---------------------------------------------------------------------------+---------------------------------------------------------------------------+
 
 **For array types (SPECTRUM/IMAGE)**
 

--- a/doc/utilities.rst
+++ b/doc/utilities.rst
@@ -9,6 +9,8 @@ The Utilities API
     :members:
     :undoc-members:
 
+.. autofunction:: tango.utils.get_enum_labels
+
 .. autofunction:: tango.utils.is_pure_str
 
 .. autofunction:: tango.utils.is_seq

--- a/examples/Clock/ClockDS.py
+++ b/examples/Clock/ClockDS.py
@@ -6,6 +6,7 @@ which has attributes:
 
   - time: read-only scalar float
   - gmtime: read-only sequence (spectrum) of integers
+  - noon:  read-only enumerated type
 
 commands:
 
@@ -14,7 +15,14 @@ commands:
 """
 
 import time
-from PyTango.server import Device, attribute, command
+from enum import IntEnum
+from tango.server import Device, attribute, command
+from tango.utils import get_enum_labels
+
+
+class Noon(IntEnum):
+    AM = 0  # DevEnum's must start at 0
+    PM = 1  # and increment by 1
 
 
 class Clock(Device):
@@ -27,6 +35,12 @@ class Clock(Device):
 
     def read_gmtime(self):
         return time.gmtime()
+
+    @attribute(dtype='DevEnum', enum_labels=get_enum_labels(Noon))
+    def noon(self):
+        time_struct = time.gmtime(time.time())
+        result = Noon.AM if time_struct.tm_hour < 12 else Noon.PM
+        return int(result)
 
     @command(dtype_in=float, dtype_out=str)
     def ctime(self, seconds):

--- a/examples/Clock/ClockDS.py
+++ b/examples/Clock/ClockDS.py
@@ -39,8 +39,7 @@ class Clock(Device):
     @attribute(dtype='DevEnum', enum_labels=get_enum_labels(Noon))
     def noon(self):
         time_struct = time.gmtime(time.time())
-        result = Noon.AM if time_struct.tm_hour < 12 else Noon.PM
-        return int(result)
+        return Noon.AM if time_struct.tm_hour < 12 else Noon.PM
 
     @command(dtype_in=float, dtype_out=str)
     def ctime(self, seconds):

--- a/examples/Clock/client.py
+++ b/examples/Clock/client.py
@@ -26,11 +26,11 @@ if len(sys.argv) != 2:
 clock = PyTango.DeviceProxy(sys.argv[1])
 t = clock.time
 gmt = clock.gmtime
+noon = clock.noon
 print(t)
 print(gmt)
+print(noon, noon.name, noon.value)
+if noon == noon.AM:
+    print('Good morning!')
 print(clock.ctime(t))
 print(clock.mktime(gmt))
-
-
-
-

--- a/setup.py
+++ b/setup.py
@@ -428,6 +428,7 @@ def setup_args():
 
     install_requires = [
         'six',
+        'enum34;python_version<"3.4"',
     ]
 
     setup_requires = []

--- a/tango/test_utils.py
+++ b/tango/test_utils.py
@@ -1,5 +1,7 @@
 """Test utilities"""
 
+import enum
+
 # Local imports
 from . import DevState, GreenMode
 from .server import Device
@@ -28,11 +30,36 @@ class SimpleDevice(Device):
 
 # Helpers
 
+class GoodEnum(enum.IntEnum):
+    START = 0
+    MIDDLE = 1
+    END = 2
+
+
+class BadEnumNonZero(enum.IntEnum):
+    START = 1
+    MIDDLE = 2
+    END = 3
+
+
+class BadEnumSkipValues(enum.IntEnum):
+    START = 0
+    MIDDLE = 2
+    END = 4
+
+
+class BadEnumDuplicates(enum.IntEnum):
+    START = 0
+    MIDDLE = 1
+    END = 1
+
+
 TYPED_VALUES = {
     int: (1, 2),
     float: (2.71, 3.14),
     str: ('hey hey', 'my my'),
     bool: (False, True),
+    'DevEnum': (GoodEnum.START, GoodEnum.MIDDLE, GoodEnum.END),
     (int,): ([1, 2, 3], [9, 8, 7]),
     (float,): ([0.1, 0.2, 0.3], [0.9, 0.8, 0.7]),
     (str,): (['ab', 'cd', 'ef'], ['gh', 'ij', 'kl']),

--- a/tango/test_utils.py
+++ b/tango/test_utils.py
@@ -28,7 +28,7 @@ class SimpleDevice(Device):
         self.set_state(DevState.ON)
 
 
-# Helpers
+# Test enums
 
 class GoodEnum(enum.IntEnum):
     START = 0
@@ -54,12 +54,13 @@ class BadEnumDuplicates(enum.IntEnum):
     END = 1
 
 
+# Helpers
+
 TYPED_VALUES = {
     int: (1, 2),
     float: (2.71, 3.14),
     str: ('hey hey', 'my my'),
     bool: (False, True),
-    'DevEnum': (GoodEnum.START, GoodEnum.MIDDLE, GoodEnum.END),
     (int,): ([1, 2, 3], [9, 8, 7]),
     (float,): ([0.1, 0.2, 0.3], [0.9, 0.8, 0.7]),
     (str,): (['ab', 'cd', 'ef'], ['gh', 'ij', 'kl']),


### PR DESCRIPTION
TANGO implements DevEnum attributes as an integer value combined with a list label strings.  The current PyTango implementation  requires the clients to fetch the labels separately from the values,
and match them up manually.  This makes it difficult to use.  This new implementation combines the information to create proper enumerated types.

#### Client-side changes
When the `DeviceProxy` reads a DevEnum attribute, a Python `enum.IntEnum` object is returned instead of just an integer.  This object can be compared to integers directly so no changes are expected for old code, but if required, they should be minimal.  The benefit is that new code using the enumerations directly will be more readable.

#### Server-side changes
Not much was required here.  Added a utility function that extracts the labels from an `enum.Enum` class and verifies that the values will work with the core TANGO implementation.

#### Warnings
- The `DeviceProxy` maintains a cache of the attributes, which includes the enumeration class.  If the device server changes the enum_labels for an attribute that the DeviceProxy has already cached,
then the DeviceProxy will not know about it.  A new instance of the DeviceProxy will have to be created after any significant interface change on the server.
- If a server has enum labels that are not valid Python identifiers it will  cause problems.
  - Leading spaces will break all attribute access for the `DeviceProxy`.
  - Other invalid labels can be accessed in the `IntEnum` class via item lookup, e.g. `proxy.my_enum['has a bad name!']` will work, while `proxy.my_enum.has a bad name!` obviously won't.

Issue: #188