### PR TITLE
Make __all__ definitions immutable

### DIFF
--- a/doc/mock_tango_extension.py
+++ b/doc/mock_tango_extension.py
@@ -27,7 +27,7 @@ version older than 3.5 (failed with 2.7 and 3.4)
 import sys
 from mock import MagicMock
 
-__all__ = ['tango']
+__all__ = ('tango',)
 
 
 # Constants

--- a/doc/tep/database.py
+++ b/doc/tep/database.py
@@ -26,7 +26,7 @@
 
 """This class manage the TANGO database."""
 
-__all__ = ["DataBase", "DataBaseClass", "main"]
+__all__ = ("DataBase", "DataBaseClass", "main")
 
 __docformat__ = 'restructuredtext'
 

--- a/examples/asyncio_green_mode/__init__.py
+++ b/examples/asyncio_green_mode/__init__.py
@@ -1,1 +1,1 @@
-__all__ = ['asyncio_device_example']
+__all__ = ('asyncio_device_example',)

--- a/examples/fwdAttr/FwdServer.py
+++ b/examples/fwdAttr/FwdServer.py
@@ -2,7 +2,7 @@ import tango
 from tango.server import Device
 from tango.server import attribute
 
-__all__ = ["FwdServer", "main"]
+__all__ = ("FwdServer", "main")
 
 
 class FwdServer(Device):

--- a/tango/__init__.py
+++ b/tango/__init__.py
@@ -18,7 +18,7 @@ http://pytango.readthedocs.io
 
 from __future__ import print_function
 
-__all__ = [
+__all__ = (
     'AccessControlType', 'ApiUtil', 'ArchiveEventInfo',
     'ArchiveEventProp', 'ArgType', 'AsynCall', 'AsynReplyNotArrived', 'AttReqType',
     'Attr', 'AttrConfEventData', 'AttrData', 'AttrDataFormat', 'AttrList',
@@ -76,7 +76,7 @@ __all__ = [
     'set_green_mode', 'get_green_mode', 'get_device_proxy',
     'is_scalar_type', 'is_array_type', 'is_numerical_type',
     'is_int_type', 'is_float_type', 'is_bool_type', 'is_str_type',
-    'obj_2_str', 'str_2_obj', 'seqStr_2_obj']
+    'obj_2_str', 'str_2_obj', 'seqStr_2_obj')
 
 __docformat__ = "restructuredtext"
 

--- a/tango/api_util.py
+++ b/tango/api_util.py
@@ -13,7 +13,7 @@
 This is an internal PyTango module.
 """
 
-__all__ = ["api_util_init"]
+__all__ = ("api_util_init",)
 
 __docformat__ = "restructuredtext"
 

--- a/tango/asyncio.py
+++ b/tango/asyncio.py
@@ -19,7 +19,7 @@ from ._tango import GreenMode
 from .device_proxy import get_device_proxy
 from .attribute_proxy import get_attribute_proxy
 
-__all__ = ["DeviceProxy", "AttributeProxy", "check_requirements"]
+__all__ = ("DeviceProxy", "AttributeProxy", "check_requirements")
 
 
 def check_requirements():

--- a/tango/asyncio_executor.py
+++ b/tango/asyncio_executor.py
@@ -28,7 +28,7 @@ except ImportError:
 # Tango imports
 from .green import AbstractExecutor
 
-__all__ = ["AsyncioExecutor", "get_global_executor", "set_global_executor"]
+__all__ = ("AsyncioExecutor", "get_global_executor", "set_global_executor")
 
 # Asyncio compatibility
 

--- a/tango/asyncio_tools.py
+++ b/tango/asyncio_tools.py
@@ -8,7 +8,7 @@ try:
 except ImportError:
     import trollius as asyncio
 
-__all__ = ["run_coroutine_threadsafe"]
+__all__ = ("run_coroutine_threadsafe",)
 
 
 def _set_concurrent_future_state(concurrent, source):

--- a/tango/attr_data.py
+++ b/tango/attr_data.py
@@ -16,7 +16,7 @@ This is an internal PyTango module.
 from __future__ import with_statement
 from __future__ import print_function
 
-__all__ = ["AttrData"]
+__all__ = ("AttrData",)
 
 __docformat__ = "restructuredtext"
 

--- a/tango/attribute_proxy.py
+++ b/tango/attribute_proxy.py
@@ -26,7 +26,7 @@ from .utils import is_pure_str, is_non_str_seq
 from .green import green, get_green_mode
 from .device_proxy import __init_device_proxy_internals as init_device_proxy
 
-__all__ = ["AttributeProxy", "attribute_proxy_init", "get_attribute_proxy"]
+__all__ = ("AttributeProxy", "attribute_proxy_init", "get_attribute_proxy")
 
 
 @green(consume_green_mode=False)

--- a/tango/auto_monitor.py
+++ b/tango/auto_monitor.py
@@ -13,7 +13,7 @@
 This is an internal PyTango module.
 """
 
-__all__ = ["auto_monitor_init"]
+__all__ = ("auto_monitor_init",)
 
 __docformat__ = "restructuredtext"
 

--- a/tango/base_types.py
+++ b/tango/base_types.py
@@ -13,7 +13,7 @@
 This is an internal PyTango module.
 """
 
-__all__ = ["base_types_init"]
+__all__ = ("base_types_init",)
 
 __docformat__ = "restructuredtext"
 

--- a/tango/callback.py
+++ b/tango/callback.py
@@ -13,7 +13,7 @@
 This is an internal PyTango module.
 """
 
-__all__ = ["callback_init"]
+__all__ = ("callback_init",)
 
 __docformat__ = "restructuredtext"
 

--- a/tango/codec.py
+++ b/tango/codec.py
@@ -1,4 +1,4 @@
-__all__ = ["loads", "dumps"]
+__all__ = ("loads", "dumps")
 
 
 def loads(fmt, data):

--- a/tango/connection.py
+++ b/tango/connection.py
@@ -13,7 +13,7 @@
 This is an internal PyTango module.
 """
 
-__all__ = ["connection_init"]
+__all__ = ("connection_init",)
 
 __docformat__ = "restructuredtext"
 

--- a/tango/databaseds/db_access/__init__.py
+++ b/tango/databaseds/db_access/__init__.py
@@ -1,4 +1,4 @@
-__all__ = []
+__all__list__ = []
 def _init_module() :
     import os
     for root,dirs,files in os.walk(__path__[0]) :
@@ -9,6 +9,6 @@ def _init_module() :
                 subdir = root[len(__path__[0]) + 1:]
                 if subdir:
                     base = '%s.%s' % (subdir,base)
-                __all__.append(base)
+                __all__list__.append(base)
 _init_module()
-
+__all__ = tuple(__all__list__)

--- a/tango/db.py
+++ b/tango/db.py
@@ -13,7 +13,7 @@
 This is an internal PyTango module.
 """
 
-__all__ = ["db_init"]
+__all__ = ("db_init",)
 
 __docformat__ = "restructuredtext"
 

--- a/tango/device_attribute.py
+++ b/tango/device_attribute.py
@@ -13,7 +13,7 @@
 This is an internal PyTango module.
 """
 
-__all__ = ["device_attribute_init"]
+__all__ = ("device_attribute_init",)
 
 __docformat__ = "restructuredtext"
 

--- a/tango/device_class.py
+++ b/tango/device_class.py
@@ -15,7 +15,7 @@ This is an internal PyTango module.
 
 from __future__ import print_function
 
-__all__ = ["DeviceClass", "device_class_init"]
+__all__ = ("DeviceClass", "device_class_init")
 
 __docformat__ = "restructuredtext"
 

--- a/tango/device_data.py
+++ b/tango/device_data.py
@@ -13,7 +13,7 @@
 This is an internal PyTango module.
 """
 
-__all__ = ["device_data_init"]
+__all__ = ("device_data_init",)
 
 __docformat__ = "restructuredtext"
 

--- a/tango/device_proxy.py
+++ b/tango/device_proxy.py
@@ -34,7 +34,7 @@ from .utils import dir2
 from .green import green, green_callback
 from .green import get_green_mode
 
-__all__ = ["device_proxy_init", "get_device_proxy"]
+__all__ = ("device_proxy_init", "get_device_proxy")
 
 __docformat__ = "restructuredtext"
 

--- a/tango/device_server.py
+++ b/tango/device_server.py
@@ -32,11 +32,11 @@ from .log4tango import TangoStream
 
 __docformat__ = "restructuredtext"
 
-__all__ = ["ChangeEventProp", "PeriodicEventProp",
+__all__ = ("ChangeEventProp", "PeriodicEventProp",
            "ArchiveEventProp", "AttributeAlarm", "EventProperties",
            "AttributeConfig", "AttributeConfig_2",
            "AttributeConfig_3", "AttributeConfig_5",
-           "MultiAttrProp", "device_server_init"]
+           "MultiAttrProp", "device_server_init")
 
 
 class LatestDeviceImpl(get_latest_device_class()):

--- a/tango/encoded_attribute.py
+++ b/tango/encoded_attribute.py
@@ -13,7 +13,7 @@
 This is an internal PyTango module.
 """
 
-__all__ = ["encoded_attribute_init"]
+__all__ = ("encoded_attribute_init",)
 
 __docformat__ = "restructuredtext"
 

--- a/tango/exception.py
+++ b/tango/exception.py
@@ -13,7 +13,7 @@
 This is an internal PyTango module.
 """
 
-__all__ = ["exception_init"]
+__all__ = ("exception_init",)
 
 __docformat__ = "restructuredtext"
 

--- a/tango/futures.py
+++ b/tango/futures.py
@@ -12,7 +12,7 @@
 """This module exposes a futures version of :class:`tango.DeviceProxy` and
 :class:`tango.AttributeProxy"""
 
-__all__ = ["DeviceProxy", "AttributeProxy", "check_requirements"]
+__all__ = ("DeviceProxy", "AttributeProxy", "check_requirements")
 
 from functools import partial
 

--- a/tango/futures_executor.py
+++ b/tango/futures_executor.py
@@ -18,7 +18,7 @@ from concurrent.futures import ProcessPoolExecutor, ThreadPoolExecutor
 # Tango imports
 from .green import AbstractExecutor
 
-__all__ = ["FuturesExecutor", "get_global_executor", "set_global_executor"]
+__all__ = ("FuturesExecutor", "get_global_executor", "set_global_executor")
 
 # Global executor
 

--- a/tango/gevent.py
+++ b/tango/gevent.py
@@ -19,7 +19,7 @@ from ._tango import GreenMode
 from .device_proxy import get_device_proxy
 from .attribute_proxy import get_attribute_proxy
 
-__all__ = ["DeviceProxy", "AttributeProxy", "check_requirements"]
+__all__ = ("DeviceProxy", "AttributeProxy", "check_requirements")
 
 
 def check_requirements():

--- a/tango/gevent_executor.py
+++ b/tango/gevent_executor.py
@@ -29,7 +29,7 @@ ThreadSafeEvent = gevent.monkey.get_original('threading', 'Event')
 from .green import AbstractExecutor
 
 
-__all__ = ["get_global_executor", "set_global_executor", "GeventExecutor"]
+__all__ = ("get_global_executor", "set_global_executor", "GeventExecutor")
 
 # Global executor
 

--- a/tango/globals.py
+++ b/tango/globals.py
@@ -13,10 +13,10 @@
 This is an internal PyTango module.
 """
 
-__all__ = ["get_class", "get_classes", "get_cpp_class", "get_cpp_classes",
+__all__ = ("get_class", "get_classes", "get_cpp_class", "get_cpp_classes",
            "get_constructed_class", "get_constructed_classes",
            "class_factory", "delete_class_list",
-           "class_list", "cpp_class_list", "constructed_class"]
+           "class_list", "cpp_class_list", "constructed_class")
 
 __docformat__ = "restructuredtext"
 

--- a/tango/green.py
+++ b/tango/green.py
@@ -23,8 +23,8 @@ except:
 # Tango imports
 from ._tango import GreenMode
 
-__all__ = ['get_green_mode', 'set_green_mode', 'green', 'green_callback',
-           'get_executor', 'get_object_executor']
+__all__ = ('get_green_mode', 'set_green_mode', 'green', 'green_callback',
+           'get_executor', 'get_object_executor')
 
 # Handle current green mode
 

--- a/tango/group.py
+++ b/tango/group.py
@@ -13,7 +13,7 @@
 This is an internal PyTango module.
 """
 
-__all__ = ["Group", "group_init"]
+__all__ = ("Group", "group_init")
 
 __docformat__ = "restructuredtext"
 

--- a/tango/group_reply.py
+++ b/tango/group_reply.py
@@ -13,7 +13,7 @@
 This is an internal PyTango module.
 """
 
-__all__ = ["group_reply_init"]
+__all__ = ("group_reply_init",)
 
 __docformat__ = "restructuredtext"
 

--- a/tango/group_reply_list.py
+++ b/tango/group_reply_list.py
@@ -13,7 +13,7 @@
 This is an internal PyTango module.
 """
 
-__all__ = ["group_reply_list_init"]
+__all__ = ("group_reply_list_init",)
 
 __docformat__ = "restructuredtext"
 

--- a/tango/log4tango.py
+++ b/tango/log4tango.py
@@ -26,8 +26,8 @@ Example::
             attr.set_value(self._current)
 """
 
-__all__ = ["TangoStream", "LogIt", "DebugIt", "InfoIt", "WarnIt",
-           "ErrorIt", "FatalIt"]
+__all__ = ("TangoStream", "LogIt", "DebugIt", "InfoIt", "WarnIt",
+           "ErrorIt", "FatalIt")
 
 __docformat__ = "restructuredtext"
 

--- a/tango/pipe.py
+++ b/tango/pipe.py
@@ -9,7 +9,7 @@
 # See LICENSE.txt for more info.
 # ------------------------------------------------------------------------------
 
-__all__ = ['PipeConfig']
+__all__ = ('PipeConfig',)
 
 from ._tango import Pipe, PipeWriteType, UserDefaultPipeProp, \
     CmdArgType, DevState, DispLevel, constants

--- a/tango/pipe_data.py
+++ b/tango/pipe_data.py
@@ -16,7 +16,7 @@ This is an internal PyTango module.
 from __future__ import with_statement
 from __future__ import print_function
 
-__all__ = ["PipeData"]
+__all__ = ("PipeData",)
 
 __docformat__ = "restructuredtext"
 

--- a/tango/pytango_init.py
+++ b/tango/pytango_init.py
@@ -13,7 +13,7 @@
 This is an internal PyTango module.
 """
 
-__all__ = ['init']
+__all__ = ('init',)
 
 __docformat__ = "restructuredtext"
 

--- a/tango/pytango_pprint.py
+++ b/tango/pytango_pprint.py
@@ -13,7 +13,7 @@
 This is an internal PyTango module.
 """
 
-__all__ = ["pytango_pprint_init"]
+__all__ = ("pytango_pprint_init",)
 
 __docformat__ = "restructuredtext"
 

--- a/tango/pyutil.py
+++ b/tango/pyutil.py
@@ -13,7 +13,7 @@
 This is an internal PyTango module.
 """
 
-__all__ = ["Util", "pyutil_init"]
+__all__ = ("Util", "pyutil_init")
 
 __docformat__ = "restructuredtext"
 

--- a/tango/release.py
+++ b/tango/release.py
@@ -13,7 +13,7 @@
 This is an internal PyTango module.
 """
 
-__all__ = ["Release"]
+__all__ = ("Release",)
 
 __docformat__ = "restructuredtext"
 

--- a/tango/server.py
+++ b/tango/server.py
@@ -34,9 +34,9 @@ from .utils import scalar_to_array_type, TO_TANGO_TYPE
 from .green import get_green_mode, get_executor
 from .pyutil import Util
 
-__all__ = ["DeviceMeta", "Device", "LatestDeviceImpl", "attribute",
+__all__ = ("DeviceMeta", "Device", "LatestDeviceImpl", "attribute",
            "command", "pipe", "device_property", "class_property",
-           "run", "server_run", "Server"]
+           "run", "server_run", "Server")
 
 API_VERSION = 2
 

--- a/tango/tango_numpy.py
+++ b/tango/tango_numpy.py
@@ -13,7 +13,7 @@
 This is an internal PyTango module.
 """
 
-__all__ = ["NumpyType", "numpy_type", "numpy_spectrum", "numpy_image"]
+__all__ = ("NumpyType", "numpy_type", "numpy_spectrum", "numpy_image")
 
 __docformat__ = "restructuredtext"
 

--- a/tango/tango_object.py
+++ b/tango/tango_object.py
@@ -28,7 +28,7 @@ from .server import Device, _to_classes, _add_classes
 from .server import get_worker, set_worker
 from .green import get_executor
 
-__all__ = ['Server']
+__all__ = ('Server',)
 
 _CLEAN_UP_TEMPLATE = """
 import sys

--- a/tango/test_context.py
+++ b/tango/test_context.py
@@ -27,7 +27,7 @@ from argparse import ArgumentParser
 from .server import run
 from . import DeviceProxy, Database, Util
 
-__all__ = ["DeviceTestContext", "run_device_test_context"]
+__all__ = ("DeviceTestContext", "run_device_test_context")
 
 # Helpers
 

--- a/tango/test_utils.py
+++ b/tango/test_utils.py
@@ -18,7 +18,7 @@ try:
 except ImportError:
     numpy = None
 
-__all__ = ['DeviceTestContext', 'SimpleDevice']
+__all__ = ('DeviceTestContext', 'SimpleDevice')
 
 
 # Test devices

--- a/tango/time_val.py
+++ b/tango/time_val.py
@@ -13,7 +13,7 @@
 This is an internal PyTango module.
 """
 
-__all__ = ["time_val_init"]
+__all__ = ("time_val_init",)
 
 __docformat__ = "restructuredtext"
 

--- a/tango/utils.py
+++ b/tango/utils.py
@@ -33,7 +33,7 @@ from . import _tango
 from .constants import AlrmValueNotSpec, StatusNotSet, TgLibVers
 from .release import Release
 
-__all__ = [
+__all__ = (
     "requires_pytango", "requires_tango",
     "is_pure_str", "is_seq", "is_non_str_seq", "is_integer",
     "is_number", "is_scalar_type", "is_array_type", "is_numerical_type",
@@ -44,7 +44,7 @@ __all__ = [
     "CaselessList", "CaselessDict", "EventCallBack", "get_home",
     "from_version_str_to_hex_str", "from_version_str_to_int",
     "seq_2_StdStringVector", "StdStringVector_2_seq",
-    "dir2", "TO_TANGO_TYPE"]
+    "dir2", "TO_TANGO_TYPE")
 
 __docformat__ = "restructuredtext"
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,4 +2,4 @@
 
 from tango.test_utils import state, typed_values, server_green_mode
 
-__all__ = ['state', 'typed_values', 'server_green_mode']
+__all__ = ('state', 'typed_values', 'server_green_mode')


### PR DESCRIPTION
Minor change.  The flake8 linter complains (via pydocstyle) if `__all__` isn't immutable, so changing to tuples. 

This is the warning message:
```
WARNING: __all__ is defined as a list, this means pydocstyle cannot
reliably detect contents of the __all__ variable, because it can be
mutated. Change __all__ to be an (immutable) tuple, to remove this
warning. Note, pydocstyle uses __all__ to detect which definitions
are public, to warn if public definitions are missing docstrings.
If __all__ is a (mutable) list, pydocstyle cannot reliably assume
its contents. pydocstyle will proceed assuming __all__ is not mutated.
```