### PR TITLE
Support Python enum as dtype argument for attributes

### DIFF
--- a/examples/Clock/ClockDS.py
+++ b/examples/Clock/ClockDS.py
@@ -36,7 +36,7 @@ class Clock(Device):
     def read_gmtime(self):
         return time.gmtime()
 
-    @attribute(dtype='DevEnum', enum_labels=get_enum_labels(Noon))
+    @attribute(dtype=Noon)
     def noon(self):
         time_struct = time.gmtime(time.time())
         return Noon.AM if time_struct.tm_hour < 12 else Noon.PM

--- a/examples/Clock/ClockDS.py
+++ b/examples/Clock/ClockDS.py
@@ -17,7 +17,6 @@ commands:
 import time
 from enum import IntEnum
 from tango.server import Device, attribute, command
-from tango.utils import get_enum_labels
 
 
 class Noon(IntEnum):

--- a/tango/test_context.py
+++ b/tango/test_context.py
@@ -10,6 +10,7 @@ import time
 import struct
 import socket
 import tempfile
+import traceback
 import collections
 from functools import partial
 
@@ -21,7 +22,7 @@ from six.moves import queue
 # CLI imports
 from ast import literal_eval
 from importlib import import_module
-from argparse import ArgumentParser
+from argparse import ArgumentParser, ArgumentTypeError
 
 # Local imports
 from .server import run
@@ -70,7 +71,12 @@ def literal_dict(arg):
 def device(path):
     """Get the device class from a given module."""
     module_name, device_name = path.rsplit(".", 1)
-    module = import_module(module_name)
+    try:
+        module = import_module(module_name)
+    except Exception:
+        raise ArgumentTypeError("Error importing {0}.{1}:\n{2}"
+                                .format(module_name, device_name,
+                                        traceback.format_exc()))
     return getattr(module, device_name)
 
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -151,6 +151,11 @@ def test_read_write_attribute_enum(server_green_mode):
     class TestDevice(Device):
         green_mode = server_green_mode
 
+        def __init__(self, *args, **kwargs):
+            super(TestDevice, self).__init__(*args, **kwargs)
+            self.attr_from_enum_value = 0
+            self.attr_from_labels_value = 0
+
         @attribute(dtype=GoodEnum, access=AttrWriteType.READ_WRITE)
         def attr_from_enum(self):
             return self.attr_from_enum_value
@@ -187,10 +192,16 @@ def test_read_write_attribute_enum(server_green_mode):
         class BadTestDevice(Device):
             green_mode = server_green_mode
 
+            def __init__(self, *args, **kwargs):
+                super(TestDevice, self).__init__(*args, **kwargs)
+                self.attr_value = 0
+
             # enum_labels may not be specified if dtype is an enum.Enum
             @attribute(dtype=GoodEnum, enum_labels=enum_labels)
             def bad_attr(self):
                 return self.attr_value
+
+        BadTestDevice()  # dummy instance for Codacy
     assert 'enum_labels' in str(context.value)
 
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -145,30 +145,53 @@ def test_read_write_attribute(typed_values, server_green_mode):
 
 
 def test_read_write_attribute_enum(server_green_mode):
-    dtype = 'DevEnum'
     values = (member.value for member in GoodEnum)
     enum_labels = get_enum_labels(GoodEnum)
 
     class TestDevice(Device):
         green_mode = server_green_mode
 
-        @attribute(dtype=dtype, enum_labels=enum_labels,
-                   access=AttrWriteType.READ_WRITE)
-        def attr(self):
-            return self.attr_value
+        @attribute(dtype=GoodEnum, access=AttrWriteType.READ_WRITE)
+        def attr_from_enum(self):
+            return self.attr_from_enum_value
 
-        @attr.write
-        def attr(self, value):
-            self.attr_value = value
+        @attr_from_enum.write
+        def attr_from_enum(self, value):
+            self.attr_from_enum_value = value
+
+        @attribute(dtype='DevEnum', enum_labels=enum_labels,
+                   access=AttrWriteType.READ_WRITE)
+        def attr_from_labels(self):
+            return self.attr_from_labels_value
+
+        @attr_from_labels.write
+        def attr_from_labels(self, value):
+            self.attr_from_labels_value = value
 
     with DeviceTestContext(TestDevice) as proxy:
         for value, label in zip(values, enum_labels):
-            proxy.attr = value
-            read_attr = proxy.attr
+            proxy.attr_from_enum = value
+            read_attr = proxy.attr_from_enum
             assert read_attr == value
             assert isinstance(read_attr, enum.IntEnum)
             assert read_attr.value == value
             assert read_attr.name == label
+            proxy.attr_from_labels = value
+            read_attr = proxy.attr_from_labels
+            assert read_attr == value
+            assert isinstance(read_attr, enum.IntEnum)
+            assert read_attr.value == value
+            assert read_attr.name == label
+
+    with pytest.raises(TypeError) as context:
+        class BadTestDevice(Device):
+            green_mode = server_green_mode
+
+            # enum_labels may not be specified if dtype is an enum.Enum
+            @attribute(dtype=GoodEnum, enum_labels=enum_labels)
+            def bad_attr(self):
+                return self.attr_value
+    assert 'enum_labels' in str(context.value)
 
 
 # Test properties

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -193,7 +193,7 @@ def test_read_write_attribute_enum(server_green_mode):
             green_mode = server_green_mode
 
             def __init__(self, *args, **kwargs):
-                super(TestDevice, self).__init__(*args, **kwargs)
+                super(BadTestDevice, self).__init__(*args, **kwargs)
                 self.attr_value = 0
 
             # enum_labels may not be specified if dtype is an enum.Enum


### PR DESCRIPTION
Device server attributes can now be specified very succinctly, using the Python enum as the `dtype` directly.  The old methods of defining them still work as well.

Minor improvement to the `test_context` for better error reporting, noticed during development of this feature.

Resolves issue #195