### PR TITLE
Yet another fix to the gevent threadpool error wrapping

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -449,7 +449,7 @@ def setup_args():
     ]
 
     if PYTHON2:
-        tests_require += ['trollius']
+        tests_require += ['trollius', 'futures']
 
     package_data = {
         'tango.databaseds': ['*.xmi', '*.sql', '*.sh', 'DataBaseds'],

--- a/tango/gevent_executor.py
+++ b/tango/gevent_executor.py
@@ -16,8 +16,10 @@ from __future__ import absolute_import
 import sys
 import six
 import functools
+from collections import namedtuple
 
 # Gevent imports
+import gevent.event
 import gevent.queue
 import gevent.monkey
 import gevent.threadpool
@@ -56,11 +58,7 @@ def get_global_threadpool():
     return _THREAD_POOL
 
 
-class ExceptionWrapper:
-    def __init__(self, exception, error_string, tb):
-        self.exception = exception
-        self.error_string = error_string
-        self.tb = tb
+ExceptionInfo = namedtuple('ExceptionInfo', 'type value traceback')
 
 
 def wrap_error(func):
@@ -69,25 +67,31 @@ def wrap_error(func):
         try:
             return func(*args, **kwargs)
         except:
-            return ExceptionWrapper(*sys.exc_info())
+            return ExceptionInfo(*sys.exc_info())
 
     return wrapper
 
 
 def unwrap_error(source):
-    result = source.get()
-    if isinstance(result, ExceptionWrapper):
-        # Raise the exception using the caller context
-        six.reraise(result.exception, result.error_string, result.tb)
-    return result
+    destination = gevent.event.AsyncResult()
+
+    def link(source):
+        if isinstance(source.value, ExceptionInfo):
+            destination.set_exception(
+                source.value.value, exc_info=source.value)
+            return
+        destination(source)
+
+    source.rawlink(link)
+    return destination
 
 
 class ThreadPool(gevent.threadpool.ThreadPool):
 
     def spawn(self, fn, *args, **kwargs):
-        fn = wrap_error(fn)
-        fn_result = super(ThreadPool, self).spawn(fn, *args, **kwargs)
-        return gevent.spawn(unwrap_error, fn_result)
+        wrapped = wrap_error(fn)
+        raw = super(ThreadPool, self).spawn(wrapped, *args, **kwargs)
+        return unwrap_error(raw)
 
 
 # Gevent task and event loop

--- a/tango/gevent_executor.py
+++ b/tango/gevent_executor.py
@@ -77,8 +77,12 @@ def unwrap_error(source):
 
     def link(source):
         if isinstance(source.value, ExceptionInfo):
-            destination.set_exception(
-                source.value.value, exc_info=source.value)
+            try:
+                destination.set_exception(
+                    source.value.value, exc_info=source.value)
+            # Gevent 1.0 compatibility
+            except TypeError:
+                destination.set_exception(source.value.value)
             return
         destination(source)
 

--- a/tango/test_context.py
+++ b/tango/test_context.py
@@ -178,7 +178,7 @@ class DeviceTestContext(object):
             # because the it might segfault while cleaning up the
             # the tango resources
             if process:
-                time.sleep(0.01)
+                time.sleep(0.1)
 
     def post_init(self):
         try:
@@ -228,8 +228,7 @@ class DeviceTestContext(object):
 
     def connect(self):
         try:
-            args = self.queue.get(
-                timeout=self.timeout)
+            args = self.queue.get(timeout=self.timeout)
         except queue.Empty:
             if self.thread.is_alive():
                 raise RuntimeError(

--- a/tango/test_utils.py
+++ b/tango/test_utils.py
@@ -1,6 +1,8 @@
 """Test utilities"""
 
+import six
 import enum
+import collections
 
 # Local imports
 from . import DevState, GreenMode
@@ -78,6 +80,12 @@ def repr_type(x):
 if numpy and pytest:
 
     def assert_close(a, b):
+        if isinstance(a, six.string_types):
+            assert a == b
+            return
+        if isinstance(a, collections.Sequence) and len(a) and isinstance(a[0], six.string_types):
+            assert list(a) == list(b)
+            return
         try:
             assert a == pytest.approx(b)
         except ValueError:


### PR DESCRIPTION
Following up on #171.

It turns out `gevent.spawn` also prints to standard output when an exception is raised (I wrongly assumed it was only `threadpool.spawn`). So we're replacing `gevent.spawn` greenlet with an async result.