### PR TITLE
Skip databaseds backends in PyTango compatibility module

### DIFF
--- a/PyTango.py
+++ b/PyTango.py
@@ -17,6 +17,9 @@ def alias_package(package, alias, extra_modules={}):
     prefix = package.__name__ + '.'
     # Alias all importable modules recursively
     for _, name, _ in pkgutil.walk_packages(path, prefix):
+        # Skip databaseds backends
+        if name.startswith('tango.databaseds.db_access.'):
+            continue
         try:
             if name not in sys.modules:
                 __import__(name)


### PR DESCRIPTION
The `PyTango` module exists for backward-compatibility reasons. In order to manage different import statements (e.g. `from PyTango import [...]`, `import PyTango.[...]`), all the pytango modules are imported and aliased in `sys.modules`. Any `ImportError` is ignored since some dependencies are optional.

This approach is fine as long as the modules don't show side effects on import. It turns out `tango.databaseds.db_access.beacon` imports `bliss` which, when it exists, uses gevent to monkey patch the python standard library. This can lead to issues that are quite hard to debug.

For this reason, the `db_access` modules are now filtered from this import routine. It shouldn't cause any backward compatibility issue since those modules are not really meant to be imported directly. They're usually imported by the `tango.databaseds.database` module on the fly, depending on the current configuration.

In the long run, the `databaseds` module should be refactored and properly documented. It should also provide a proper plugin system for the different database backends. Then, the most common database backends might stay in the project but the specific ones (such as beacon) should move to dedicated projects.