### PR TITLE
DevEnum attributes can now be directly assigned labels

### DIFF
--- a/examples/Clock/ClockDS.py
+++ b/examples/Clock/ClockDS.py
@@ -16,6 +16,7 @@ commands:
 
 import time
 from enum import IntEnum
+from tango import AttrWriteType
 from tango.server import Device, attribute, command
 
 
@@ -24,7 +25,14 @@ class Noon(IntEnum):
     PM = 1  # and increment by 1
 
 
+class DisplayType(IntEnum):
+    ANALOG = 0  # DevEnum's must start at 0
+    DIGITAL = 1  # and increment by 1
+
+
 class Clock(Device):
+
+    display_type = DisplayType(0)
 
     @attribute(dtype=float)
     def time(self):
@@ -39,6 +47,14 @@ class Clock(Device):
     def noon(self):
         time_struct = time.gmtime(time.time())
         return Noon.AM if time_struct.tm_hour < 12 else Noon.PM
+
+    display = attribute(dtype=DisplayType, access=AttrWriteType.READ_WRITE)
+
+    def read_display(self):
+        return self.display_type
+
+    def write_display(self, display_type):
+        self.display_type = display_type
 
     @command(dtype_in=float, dtype_out=str)
     def ctime(self, seconds):

--- a/examples/Clock/client.py
+++ b/examples/Clock/client.py
@@ -17,16 +17,17 @@ usage: client clock_dev_name
 """
 
 import sys
-import PyTango
+import tango
 
 if len(sys.argv) != 2:
     print("must provide one and only one clock device name")
     sys.exit(1)
 
-clock = PyTango.DeviceProxy(sys.argv[1])
+clock = tango.DeviceProxy(sys.argv[1])
 t = clock.time
 gmt = clock.gmtime
 noon = clock.noon
+display = clock.display
 print(t)
 print(gmt)
 print(noon, noon.name, noon.value)
@@ -34,3 +35,13 @@ if noon == noon.AM:
     print('Good morning!')
 print(clock.ctime(t))
 print(clock.mktime(gmt))
+print(display, display.name, display.value)
+clock.display = display.ANALOG
+clock.display = 'DIGITAL'  # you can use a valid string to set the value
+print(clock.display, clock.display.name, clock.display.value)
+display_type = type(display)  # or even create your own IntEnum type
+analog = display_type(0)
+clock.display = analog
+print(clock.display, clock.display.name, clock.display.value)
+clock.display = clock.display.DIGITAL
+print(clock.display, clock.display.name, clock.display.value)

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -187,6 +187,19 @@ def test_read_write_attribute_enum(server_green_mode):
             assert isinstance(read_attr, enum.IntEnum)
             assert read_attr.value == value
             assert read_attr.name == label
+        for value, label in zip(values, enum_labels):
+            proxy.attr_from_enum = label
+            read_attr = proxy.attr_from_enum
+            assert read_attr == value
+            assert isinstance(read_attr, enum.IntEnum)
+            assert read_attr.value == value
+            assert read_attr.name == label
+            proxy.attr_from_labels = label
+            read_attr = proxy.attr_from_labels
+            assert read_attr == value
+            assert isinstance(read_attr, enum.IntEnum)
+            assert read_attr.value == value
+            assert read_attr.name == label
 
     with pytest.raises(TypeError) as context:
         class BadTestDevice(Device):


### PR DESCRIPTION
Following #194 I think that it would be nice to allow directly assigning labels to DevEnum attributes. For example if you have a "Planet" DevEnum attribute with labels ('Mercury', 'Saturn', 'Mars') it would be nice to allow writing:
```
dev.Planet = 'Mercury'
```
I you agree please wait to merge: I will update documentation and create a new test.