### PR TITLE
Improve Python version check for enum34 install

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -434,8 +434,9 @@ def setup_args():
 
     install_requires = [
         'six',
-        'enum34;python_version<"3.4"',
     ]
+    if PYTHON_VERSION < (3, 4):
+        install_requires.append('enum34')
 
     setup_requires = []
 


### PR DESCRIPTION
Older versions of distutils don't handle the extended version dependency syntax.  E.g. default packages on Ubuntu 14.04 fail, while Ubuntu 16.04 works.  Use the `sys` module's version instead.

Failures look like this when trying to build a Debian package:
```
error in pytango setup command: 'install_requires' must be a string or list of strings containing valid project/version requirement specifiers
E: pybuild pybuild:256: clean: plugin distutils failed with: exit code=1: python2.7 setup.py clean 
dh_auto_clean: pybuild --clean -i python{version} -p 2.7 --dir . returned exit code 13
```