### PR TITLE
Change for collections abstract base class

### DIFF
--- a/tango/attribute_proxy.py
+++ b/tango/attribute_proxy.py
@@ -17,7 +17,10 @@ To access these members use directly :mod:`tango` module and NOT
 tango.attribute_proxy.
 """
 
-import collections
+try:
+    import collections.abc as collections_abc  # python 3.3+
+except ImportError:
+    import collections as collections_abc
 
 from ._tango import StdStringVector, DbData, DbDatum, DeviceProxy
 from ._tango import __AttributeProxy as _AttributeProxy
@@ -127,7 +130,7 @@ def __AttributeProxy__get_property(self, propname, value=None):
         new_value.append(propname)
         self._get_property(new_value)
         return DbData_2_dict(new_value)
-    elif isinstance(propname, collections.Sequence):
+    elif isinstance(propname, collections_abc.Sequence):
         if isinstance(propname, DbData):
             self._get_property(propname)
             return DbData_2_dict(propname)
@@ -184,7 +187,7 @@ def __AttributeProxy__put_property(self, value):
         value = new_value
     elif is_non_str_seq(value):
         new_value = seq_2_DbData(value)
-    elif isinstance(value, collections.Mapping):
+    elif isinstance(value, collections_abc.Mapping):
         new_value = DbData()
         for k, v in value.items():
             if isinstance(v, DbDatum):
@@ -245,14 +248,14 @@ def __AttributeProxy__delete_property(self, value):
     elif isinstance(value, DbDatum):
         new_value = DbData()
         new_value.append(value)
-    elif isinstance(value, collections.Sequence):
+    elif isinstance(value, collections_abc.Sequence):
         new_value = DbData()
         for e in value:
             if isinstance(e, DbDatum):
                 new_value.append(e)
             else:
                 new_value.append(DbDatum(str(e)))
-    elif isinstance(value, collections.Mapping):
+    elif isinstance(value, collections_abc.Mapping):
         new_value = DbData()
         for k, v in value.items():
             if isinstance(v, DbDatum):

--- a/tango/connection.py
+++ b/tango/connection.py
@@ -17,7 +17,11 @@ __all__ = ("connection_init",)
 
 __docformat__ = "restructuredtext"
 
-import collections
+
+try:
+    import collections.abc as collections_abc  # python 3.3+
+except ImportError:
+    import collections as collections_abc
 
 from ._tango import Connection, DeviceData, __CallBackAutoDie, CmdArgType, \
     DeviceProxy, Database, ExtractAs
@@ -59,7 +63,7 @@ def __get_command_inout_param(self, cmd_name, cmd_param=None):
         if isinstance(cmd_param, str):
             param.insert(CmdArgType.DevString, cmd_param)
             return param
-        elif isinstance(cmd_param, collections.Sequence) and all([isinstance(x, str) for x in cmd_param]):
+        elif isinstance(cmd_param, collections_abc.Sequence) and all([isinstance(x, str) for x in cmd_param]):
             param.insert(CmdArgType.DevVarStringArray, cmd_param)
             return param
         else:
@@ -187,7 +191,7 @@ def __Connection__command_inout_asynch(self, cmd_name, *args):
         forget = False
         return self.__command_inout_asynch_id(cmd_name, argin, forget)
     elif len(args) == 1:
-        if isinstance(args[0], collections.Callable):  # command_inout_asynch(lambda)
+        if isinstance(args[0], collections_abc.Callable):  # command_inout_asynch(lambda)
             cb = __CallBackAutoDie()
             cb.cmd_ended = __CallBackAutoDie__cmd_ended_aux(self, args[0])
             argin = __get_command_inout_param(self, cmd_name)
@@ -202,7 +206,7 @@ def __Connection__command_inout_asynch(self, cmd_name, *args):
             forget = False
             return self.__command_inout_asynch_id(cmd_name, argin, forget)
     elif len(args) == 2:
-        if isinstance(args[1], collections.Callable):  # command_inout_asynch( value, lambda)
+        if isinstance(args[1], collections_abc.Callable):  # command_inout_asynch( value, lambda)
             cb = __CallBackAutoDie()
             cb.cmd_ended = __CallBackAutoDie__cmd_ended_aux(self, args[1])
             argin = __get_command_inout_param(self, cmd_name, args[0])

--- a/tango/db.py
+++ b/tango/db.py
@@ -17,7 +17,10 @@ __all__ = ("db_init",)
 
 __docformat__ = "restructuredtext"
 
-import collections
+try:
+    import collections.abc as collections_abc  # python 3.3+
+except ImportError:
+    import collections as collections_abc
 
 from ._tango import StdStringVector, Database, DbDatum, DbData, \
     DbDevInfo, DbDevInfos, DbDevImportInfo, DbDevExportInfo, DbDevExportInfos, \
@@ -125,7 +128,7 @@ def __Database__add_server(self, servname, dev_info, with_dserver=False):
             Throws     : ConnectionFailed, CommunicationFailed, DevFailed from device (DB_SQLError)
     """
 
-    if not isinstance(dev_info, collections.Sequence) and \
+    if not isinstance(dev_info, collections_abc.Sequence) and \
             not isinstance(dev_info, DbDevInfo):
         raise TypeError(
             'Value must be a DbDevInfos, a seq<DbDevInfo> or a DbDevInfo')
@@ -165,7 +168,7 @@ def __Database__export_server(self, dev_info):
             Throws     : ConnectionFailed, CommunicationFailed, DevFailed from device (DB_SQLError)
     """
 
-    if not isinstance(dev_info, collections.Sequence) and \
+    if not isinstance(dev_info, collections_abc.Sequence) and \
             not isinstance(dev_info, DbDevExportInfo):
         raise TypeError(
             'Value must be a DbDevExportInfos, a seq<DbDevExportInfo> or '
@@ -191,14 +194,14 @@ def __Database__generic_get_property(self, obj_name, value, f):
     elif is_pure_str(value):
         new_value = DbData()
         new_value.append(DbDatum(value))
-    elif isinstance(value, collections.Sequence):
+    elif isinstance(value, collections_abc.Sequence):
         new_value = DbData()
         for e in value:
             if isinstance(e, DbDatum):
                 new_value.append(e)
             else:
                 new_value.append(DbDatum(str(e)))
-    elif isinstance(value, collections.Mapping):
+    elif isinstance(value, collections_abc.Mapping):
         new_value = DbData()
         for k, v in value.items():
             if isinstance(v, DbDatum):
@@ -227,7 +230,7 @@ def __Database__generic_put_property(self, obj_name, value, f):
         value = new_value
     elif is_non_str_seq(value):
         new_value = seq_2_DbData(value)
-    elif isinstance(value, collections.Mapping):
+    elif isinstance(value, collections_abc.Mapping):
         new_value = DbData()
         for k, v in value.items():
             if isinstance(v, DbDatum):
@@ -257,14 +260,14 @@ def __Database__generic_delete_property(self, obj_name, value, f):
     elif is_pure_str(value):
         new_value = DbData()
         new_value.append(DbDatum(value))
-    elif isinstance(value, collections.Sequence):
+    elif isinstance(value, collections_abc.Sequence):
         new_value = DbData()
         for e in value:
             if isinstance(e, DbDatum):
                 new_value.append(e)
             else:
                 new_value.append(DbDatum(str(e)))
-    elif isinstance(value, collections.Mapping):
+    elif isinstance(value, collections_abc.Mapping):
         new_value = DbData()
         for k, v in value.items():
             if isinstance(v, DbDatum):
@@ -509,14 +512,14 @@ def __Database__get_device_attribute_property(self, dev_name, value):
     elif is_pure_str(value):
         new_value = DbData()
         new_value.append(DbDatum(value))
-    elif isinstance(value, collections.Sequence):
+    elif isinstance(value, collections_abc.Sequence):
         new_value = DbData()
         for e in value:
             if isinstance(e, DbDatum):
                 new_value.append(e)
             else:
                 new_value.append(DbDatum(str(e)))
-    elif isinstance(value, collections.Mapping):
+    elif isinstance(value, collections_abc.Mapping):
         new_value = DbData()
         for k, v in value.items():
             if isinstance(v, DbDatum):
@@ -575,7 +578,7 @@ def __Database__put_device_attribute_property(self, dev_name, value):
         pass
     elif is_non_str_seq(value):
         new_value = seq_2_DbData(value)
-    elif isinstance(value, collections.Mapping):
+    elif isinstance(value, collections_abc.Mapping):
         new_value = DbData()
         for k1, v1 in value.items():
             attr = DbDatum(k1)
@@ -623,7 +626,7 @@ def __Database__delete_device_attribute_property(self, dev_name, value):
         new_value = value
     elif is_non_str_seq(value):
         new_value = seq_2_DbData(value)
-    elif isinstance(value, collections.Mapping):
+    elif isinstance(value, collections_abc.Mapping):
         new_value = DbData()
         for k1, v1 in value.items():
             attr = DbDatum(k1)
@@ -754,14 +757,14 @@ def __Database__get_class_attribute_property(self, class_name, value):
     elif is_pure_str(value):
         new_value = DbData()
         new_value.append(DbDatum(value))
-    elif isinstance(value, collections.Sequence):
+    elif isinstance(value, collections_abc.Sequence):
         new_value = DbData()
         for e in value:
             if isinstance(e, DbDatum):
                 new_value.append(e)
             else:
                 new_value.append(DbDatum(str(e)))
-    elif isinstance(value, collections.Mapping):
+    elif isinstance(value, collections_abc.Mapping):
         new_value = DbData()
         for k, v in value.items():
             if isinstance(v, DbDatum):
@@ -821,7 +824,7 @@ def __Database__put_class_attribute_property(self, class_name, value):
         pass
     elif is_non_str_seq(value):
         new_value = seq_2_DbData(value)
-    elif isinstance(value, collections.Mapping):
+    elif isinstance(value, collections_abc.Mapping):
         new_value = DbData()
         for k1, v1 in value.items():
             attr = DbDatum(k1)
@@ -870,7 +873,7 @@ def __Database__delete_class_attribute_property(self, class_name, value):
         new_value = value
     elif is_non_str_seq(value):
         new_value = seq_2_DbData(value)
-    elif isinstance(value, collections.Mapping):
+    elif isinstance(value, collections_abc.Mapping):
         new_value = DbData()
         for k1, v1 in value.items():
             attr = DbDatum(k1)

--- a/tango/device_class.py
+++ b/tango/device_class.py
@@ -19,7 +19,10 @@ __all__ = ("DeviceClass", "device_class_init")
 
 __docformat__ = "restructuredtext"
 
-import collections
+try:
+    import collections.abc as collections_abc  # python 3.3+
+except ImportError:
+    import collections as collections_abc
 
 from ._tango import Except, DevFailed, DeviceClass, CmdArgType, \
     DispLevel, UserDefaultAttrProp
@@ -170,7 +173,7 @@ class PropUtil:
                     - v : (object) the object to be analysed
 
                 Return     : (bool) True if the object is a sequence or False otherwise"""
-        return isinstance(v, collections.Sequence)
+        return isinstance(v, collections_abc.Sequence)
 
     def is_empty_seq(self, v):
         """
@@ -233,7 +236,7 @@ class PropUtil:
         except:
             val = []
 
-        if is_array(tg_type) or (isinstance(val, collections.Sequence) and not len(val)):
+        if is_array(tg_type) or (isinstance(val, collections_abc.Sequence) and not len(val)):
             return val
         else:
             if is_non_str_seq(val):
@@ -393,7 +396,7 @@ def __create_command(self, deviceimpl_class, cmd_name, cmd_info):
     # check for well defined command info
 
     # check parameter
-    if not isinstance(cmd_info, collections.Sequence):
+    if not isinstance(cmd_info, collections_abc.Sequence):
         msg = "Wrong data type for value for describing command %s in " \
               "class %s\nMust be a sequence with 2 or 3 elements" % (cmd_name, name)
         __throw_create_command_exception(msg)
@@ -405,7 +408,7 @@ def __create_command(self, deviceimpl_class, cmd_name, cmd_info):
 
     param_info, result_info = cmd_info[0], cmd_info[1]
 
-    if not isinstance(param_info, collections.Sequence):
+    if not isinstance(param_info, collections_abc.Sequence):
         msg = "Wrong data type in command argument for command %s in " \
               "class %s\nCommand parameter (first element) must be a sequence" % (cmd_name, name)
         __throw_create_command_exception(msg)
@@ -435,7 +438,7 @@ def __create_command(self, deviceimpl_class, cmd_name, cmd_info):
             __throw_create_command_exception(msg)
 
     # Check result
-    if not isinstance(result_info, collections.Sequence):
+    if not isinstance(result_info, collections_abc.Sequence):
         msg = "Wrong data type in command result for command %s in " \
               "class %s\nCommand result (second element) must be a sequence" % (cmd_name, name)
         __throw_create_command_exception(msg)
@@ -469,7 +472,7 @@ def __create_command(self, deviceimpl_class, cmd_name, cmd_info):
 
     if len(cmd_info) == 3:
         extra_info = cmd_info[2]
-        if not isinstance(extra_info, collections.Mapping):
+        if not isinstance(extra_info, collections_abc.Mapping):
             msg = "Wrong data type in command information for command %s in " \
                   "class %s\nCommand information (third element in sequence), " \
                   "when given, must be a dictionary" % (cmd_name, name)
@@ -516,7 +519,7 @@ def __create_command(self, deviceimpl_class, cmd_name, cmd_info):
     # check that the method to be executed exists
     try:
         cmd = getattr(deviceimpl_class, cmd_name)
-        if not isinstance(cmd, collections.Callable):
+        if not isinstance(cmd, collections_abc.Callable):
             msg = "Wrong definition of command %s in " \
                   "class %s\nThe object exists in class but is not " \
                   "a method!" % (cmd_name, name)
@@ -529,7 +532,7 @@ def __create_command(self, deviceimpl_class, cmd_name, cmd_info):
     is_allowed_name = "is_%s_allowed" % cmd_name
     try:
         is_allowed = getattr(deviceimpl_class, is_allowed_name)
-        if not isinstance(is_allowed, collections.Callable):
+        if not isinstance(is_allowed, collections_abc.Callable):
             msg = "Wrong definition of command %s in " \
                   "class %s\nThe object '%s' exists in class but is " \
                   "not a method!" % (cmd_name, name, is_allowed_name)

--- a/tango/device_proxy.py
+++ b/tango/device_proxy.py
@@ -14,8 +14,11 @@
 import time
 import textwrap
 import threading
-import collections
 import enum
+try:
+    import collections.abc as collections_abc  # python 3.3+
+except ImportError:
+    import collections as collections_abc
 
 from ._tango import StdStringVector, DbData, DbDatum, AttributeInfo
 from ._tango import AttributeInfoEx, AttributeInfoList, AttributeInfoListEx
@@ -437,7 +440,7 @@ def __DeviceProxy__read_attributes_asynch(self, attr_names, cb=None,
         return self.__read_attributes_asynch(attr_names)
 
     cb2 = __CallBackAutoDie()
-    if isinstance(cb, collections.Callable):
+    if isinstance(cb, collections_abc.Callable):
         cb2.attr_read = cb
     else:
         cb2.attr_read = cb.attr_read
@@ -508,7 +511,7 @@ def __DeviceProxy__write_attributes_asynch(self, attr_values, cb=None):
         return self.__write_attributes_asynch(attr_values)
 
     cb2 = __CallBackAutoDie()
-    if isinstance(cb, collections.Callable):
+    if isinstance(cb, collections_abc.Callable):
         cb2.attr_write = cb
     else:
         cb2.attr_write = cb.attr_write
@@ -584,7 +587,7 @@ def __DeviceProxy__get_property(self, propname, value=None):
         new_value.append(propname)
         self._get_property(new_value)
         return DbData_2_dict(new_value)
-    elif isinstance(propname, collections.Sequence):
+    elif isinstance(propname, collections_abc.Sequence):
         if isinstance(propname, DbData):
             self._get_property(propname)
             return DbData_2_dict(propname)
@@ -641,7 +644,7 @@ def __DeviceProxy__put_property(self, value):
         value = new_value
     elif is_non_str_seq(value):
         new_value = seq_2_DbData(value)
-    elif isinstance(value, collections.Mapping):
+    elif isinstance(value, collections_abc.Mapping):
         new_value = DbData()
         for k, v in value.items():
             if isinstance(v, DbDatum):
@@ -698,14 +701,14 @@ def __DeviceProxy__delete_property(self, value):
     elif isinstance(value, DbDatum):
         new_value = DbData()
         new_value.append(value)
-    elif isinstance(value, collections.Sequence):
+    elif isinstance(value, collections_abc.Sequence):
         new_value = DbData()
         for e in value:
             if isinstance(e, DbDatum):
                 new_value.append(e)
             else:
                 new_value.append(DbDatum(str(e)))
-    elif isinstance(value, collections.Mapping):
+    elif isinstance(value, collections_abc.Mapping):
         new_value = DbData()
         for k, v in value.items():
             if isinstance(v, DbDatum):
@@ -754,7 +757,7 @@ def __DeviceProxy__get_property_list(self, filter, array=None):
     if isinstance(array, StdStringVector):
         self._get_property_list(filter, array)
         return array
-    elif isinstance(array, collections.Sequence):
+    elif isinstance(array, collections_abc.Sequence):
         new_array = StdStringVector()
         self._get_property_list(filter, new_array)
         StdStringVector_2_seq(new_array, array)
@@ -796,7 +799,7 @@ def __DeviceProxy__get_attribute_config(self, value):
     """
     if isinstance(value, StdStringVector) or is_pure_str(value):
         return self._get_attribute_config(value)
-    elif isinstance(value, collections.Sequence):
+    elif isinstance(value, collections_abc.Sequence):
         v = seq_2_StdStringVector(value)
         return self._get_attribute_config(v)
 
@@ -837,7 +840,7 @@ def __DeviceProxy__get_attribute_config_ex(self, value):
         v = StdStringVector()
         v.append(value)
         return self._get_attribute_config_ex(v)
-    elif isinstance(value, collections.Sequence):
+    elif isinstance(value, collections_abc.Sequence):
         v = seq_2_StdStringVector(value)
         return self._get_attribute_config_ex(v)
 
@@ -882,7 +885,7 @@ def __DeviceProxy__get_command_config(self, value=(constants.AllCmd,)):
     """
     if isinstance(value, StdStringVector) or is_pure_str(value):
         return self._get_command_config(value)
-    elif isinstance(value, collections.Sequence):
+    elif isinstance(value, collections_abc.Sequence):
         v = seq_2_StdStringVector(value)
         return self._get_command_config(v)
 
@@ -934,7 +937,7 @@ def __DeviceProxy__get_pipe_config(self, value=None):
         value = [constants.AllPipe]
     if isinstance(value, StdStringVector) or is_pure_str(value):
         return self._get_pipe_config(value)
-    elif isinstance(value, collections.Sequence):
+    elif isinstance(value, collections_abc.Sequence):
         v = seq_2_StdStringVector(value)
         return self._get_pipe_config(v)
 
@@ -999,7 +1002,7 @@ def __DeviceProxy__set_attribute_config(self, value):
         v = value
     elif isinstance(value, AttributeInfoListEx):
         v = value
-    elif isinstance(value, collections.Sequence):
+    elif isinstance(value, collections_abc.Sequence):
         if not len(value):
             return
         if isinstance(value[0], AttributeInfoEx):
@@ -1049,7 +1052,7 @@ def __DeviceProxy__set_pipe_config(self, value):
         v.append(value)
     elif isinstance(value, PipeInfoList):
         v = value
-    elif isinstance(value, collections.Sequence):
+    elif isinstance(value, collections_abc.Sequence):
         if not len(value):
             return
         if isinstance(value[0], PipeInfo):
@@ -1194,12 +1197,12 @@ def __DeviceProxy__subscribe_event_global(self, event_type, cb,
     if event_type != EventType.INTERFACE_CHANGE_EVENT:
         raise TypeError("This method is only for Interface Change Events")
     else:
-        if isinstance(cb, collections.Callable):
+        if isinstance(cb, collections_abc.Callable):
             cbfn = __CallBackPushEvent()
             cbfn.push_event = green_callback(
                 cb, obj=self, green_mode=green_mode)
         elif hasattr(cb, "push_event") and isinstance(
-                cb.push_event, collections.Callable):
+                cb.push_event, collections_abc.Callable):
             cbfn = __CallBackPushEvent()
             cbfn.push_event = green_callback(
                 cb.push_event, obj=self, green_mode=green_mode)
@@ -1232,12 +1235,12 @@ def __DeviceProxy__subscribe_event_attrib(self, attr_name, event_type,
                                           extract_as=ExtractAs.Numpy,
                                           green_mode=None):
 
-    if isinstance(cb_or_queuesize, collections.Callable):
+    if isinstance(cb_or_queuesize, collections_abc.Callable):
         cb = __CallBackPushEvent()
         cb.push_event = green_callback(
             cb_or_queuesize, obj=self, green_mode=green_mode)
     elif hasattr(cb_or_queuesize, "push_event") and \
-            isinstance(cb_or_queuesize.push_event, collections.Callable):
+            isinstance(cb_or_queuesize.push_event, collections_abc.Callable):
         cb = __CallBackPushEvent()
         cb.push_event = green_callback(
             cb_or_queuesize.push_event, obj=self, green_mode=green_mode)
@@ -1367,11 +1370,11 @@ def __DeviceProxy__get_events(self, event_id, callback=None, extract_as=ExtractA
         else:
             assert (False)
             raise ValueError("Unknown event_type: " + str(event_type))
-    elif isinstance(callback, collections.Callable):
+    elif isinstance(callback, collections_abc.Callable):
         cb = __CallBackPushEvent()
         cb.push_event = callback
         return self.__get_callback_events(event_id, cb, extract_as)
-    elif hasattr(callback, 'push_event') and isinstance(callback.push_event, collections.Callable):
+    elif hasattr(callback, 'push_event') and isinstance(callback.push_event, collections_abc.Callable):
         cb = __CallBackPushEvent()
         cb.push_event = callback.push_event
         return self.__get_callback_events(event_id, cb, extract_as)

--- a/tango/group.py
+++ b/tango/group.py
@@ -17,7 +17,10 @@ __all__ = ("Group", "group_init")
 
 __docformat__ = "restructuredtext"
 
-import collections
+try:
+    import collections.abc as collections_abc  # python 3.3+
+except ImportError:
+    import collections as collections_abc
 from ._tango import __Group as _RealGroup, StdStringVector
 from .utils import seq_2_StdStringVector, is_pure_str
 from .utils import document_method as __document_method
@@ -79,7 +82,7 @@ class Group:
             return self.__group._add(patterns_or_group, timeout_ms)
         elif isinstance(patterns_or_group, str):
             return self.__group._add(patterns_or_group, timeout_ms)
-        elif isinstance(patterns_or_group, collections.Sequence):
+        elif isinstance(patterns_or_group, collections_abc.Sequence):
             patterns = seq_2_StdStringVector(patterns_or_group)
             return self.__group._add(patterns, timeout_ms)
         else:
@@ -88,7 +91,7 @@ class Group:
     def remove(self, patterns, forward=True):
         if isinstance(patterns, str):
             return self.__group._remove(patterns, forward)
-        elif isinstance(patterns, collections.Sequence):
+        elif isinstance(patterns, collections_abc.Sequence):
             std_patterns = seq_2_StdStringVector(patterns)
             return self.__group._remove(std_patterns, forward)
         else:

--- a/tango/pytango_pprint.py
+++ b/tango/pytango_pprint.py
@@ -36,13 +36,16 @@ from .device_server import AttributeAlarm, EventProperties
 from .device_server import ChangeEventProp, PeriodicEventProp, ArchiveEventProp
 from .device_server import AttributeConfig, AttributeConfig_2
 from .device_server import AttributeConfig_3, AttributeConfig_5
-import collections
+try:
+    import collections.abc as collections_abc  # python 3.3+
+except ImportError:
+    import collections as collections_abc
 
 
 def __inc_param(obj, name):
     ret = not name.startswith('_')
     ret &= name not in ('except_flags',)
-    ret &= not isinstance(getattr(obj, name), collections.Callable)
+    ret &= not isinstance(getattr(obj, name), collections_abc.Callable)
     return ret
 
 
@@ -106,7 +109,7 @@ def __registerSeqStr():
 
 
 def __str__DevFailed(self):
-    if isinstance(self.args, collections.Sequence):
+    if isinstance(self.args, collections_abc.Sequence):
         return 'DevFailed[\n%s]' % '\n'.join(map(str, self.args))
     return 'DevFailed[%s]' % (self.args)
 

--- a/tango/pyutil.py
+++ b/tango/pyutil.py
@@ -24,7 +24,10 @@ from ._tango import Util, Except, DevFailed, DbDevInfo
 from .utils import document_method as __document_method
 # from utils import document_static_method as __document_static_method
 from .globals import class_list, cpp_class_list, get_constructed_classes
-import collections
+try:
+    import collections.abc as collections_abc  # python 3.3+
+except ImportError:
+    import collections as collections_abc
 
 
 def __simplify_device_name(dev_name):
@@ -81,7 +84,7 @@ def __Util__create_device(self, klass_name, device_name, alias=None, cb=None):
                    device name (str). Default value is None meaning no callback
 
         Return     : None"""
-    if cb is not None and not isinstance(cb, collections.Callable):
+    if cb is not None and not isinstance(cb, collections_abc.Callable):
         Except.throw_exception("PyAPI_InvalidParameter",
                                "The optional cb parameter must be a python callable",
                                "Util.create_device")

--- a/tango/server.py
+++ b/tango/server.py
@@ -19,9 +19,9 @@ import sys
 import copy
 import enum
 try:
-    from inspect import getfullargspec as getargspec  # python 3.0+
+    from inspect import getfullargspec as inspect_getargspec  # python 3.0+
 except ImportError:
-    from inspect import getargspec
+    from inspect import getargspec as inspect_getargspec
 import inspect
 import logging
 import functools
@@ -116,7 +116,7 @@ def set_complex_value(attr, value):
 
 
 def _get_wrapped_read_method(attribute, read_method):
-    read_args = getargspec(read_method)
+    read_args = inspect_getargspec(read_method)
     nb_args = len(read_args.args)
 
     green_mode = attribute.read_green_mode
@@ -1021,7 +1021,7 @@ class pipe(PipeData):
 def __build_command_doc(f, name, dtype_in, doc_in, dtype_out, doc_out):
     doc = "'{0}' TANGO command".format(name)
     if dtype_in is not None:
-        arg_spec = getargspec(f)
+        arg_spec = inspect_getargspec(f)
         if len(arg_spec.args) > 1:
             # arg[0] should be self and arg[1] the command argument
             param_name = arg_spec.args[1]

--- a/tango/server.py
+++ b/tango/server.py
@@ -238,7 +238,7 @@ def __patch_attr_methods(tango_device_klass, attribute):
 
 
 def _get_wrapped_pipe_read_method(pipe, read_method):
-    read_args = inspect.getargspec(read_method)
+    read_args = inspect_getargspec(read_method)
     nb_args = len(read_args.args)
 
     green_mode = pipe.read_green_mode

--- a/tango/server.py
+++ b/tango/server.py
@@ -18,6 +18,10 @@ from __future__ import absolute_import
 import sys
 import copy
 import enum
+try:
+    from inspect import getfullargspec as getargspec  # python 3.0+
+except ImportError:
+    from inspect import getargspec
 import inspect
 import logging
 import functools
@@ -112,7 +116,7 @@ def set_complex_value(attr, value):
 
 
 def _get_wrapped_read_method(attribute, read_method):
-    read_args = inspect.getargspec(read_method)
+    read_args = getargspec(read_method)
     nb_args = len(read_args.args)
 
     green_mode = attribute.read_green_mode
@@ -1017,7 +1021,7 @@ class pipe(PipeData):
 def __build_command_doc(f, name, dtype_in, doc_in, dtype_out, doc_out):
     doc = "'{0}' TANGO command".format(name)
     if dtype_in is not None:
-        arg_spec = inspect.getargspec(f)
+        arg_spec = getargspec(f)
         if len(arg_spec.args) > 1:
             # arg[0] should be self and arg[1] the command argument
             param_name = arg_spec.args[1]

--- a/tango/tango_numpy.py
+++ b/tango/tango_numpy.py
@@ -21,7 +21,10 @@ from ._tango import Except, Attribute, AttributeInfo, constants
 from ._tango import CmdArgType as ArgType
 
 from .attribute_proxy import AttributeProxy
-import collections
+try:
+    import collections.abc as collections_abc  # python 3.3+
+except ImportError:
+    import collections as collections_abc
 
 
 def _numpy_invalid(*args, **kwds):
@@ -102,7 +105,7 @@ def _define_numpy():
                         - sequence:
                 """
                 np_type = NumpyType.tango_to_numpy(tg_type)
-                if isinstance(dim_x, collections.Sequence):
+                if isinstance(dim_x, collections_abc.Sequence):
                     return numpy.array(dim_x, dtype=np_type)
                 else:
                     return numpy.ndarray(shape=(dim_x,), dtype=np_type)

--- a/tango/tango_object.py
+++ b/tango/tango_object.py
@@ -16,6 +16,10 @@ import sys
 import six
 import logging
 import weakref
+try:
+    from inspect import getfullargspec as inspect_getargspec  # python 3.0+
+except ImportError:
+    from inspect import getargspec as inspect_getargspec
 import inspect
 import functools
 
@@ -130,7 +134,7 @@ def create_tango_class(server, obj, tango_class_name=None, member_filter=None):
             in_type = CmdArgType.DevEncoded
             out_type = CmdArgType.DevEncoded
             try:
-                arg_spec = inspect.getargspec(member)
+                arg_spec = inspect_getargspec(member)
                 if not arg_spec.args:
                     in_type = CmdArgType.DevVoid
             except TypeError:

--- a/tango/test_utils.py
+++ b/tango/test_utils.py
@@ -2,7 +2,10 @@
 
 import six
 import enum
-import collections
+try:
+    import collections.abc as collections_abc  # python 3.3+
+except ImportError:
+    import collections as collections_abc
 
 # Local imports
 from . import DevState, GreenMode
@@ -83,7 +86,7 @@ if numpy and pytest:
         if isinstance(a, six.string_types):
             assert a == b
             return
-        if isinstance(a, collections.Sequence) and len(a) and isinstance(a[0], six.string_types):
+        if isinstance(a, collections_abc.Sequence) and len(a) and isinstance(a[0], six.string_types):
             assert list(a) == list(b)
             return
         try:

--- a/tango/utils.py
+++ b/tango/utils.py
@@ -21,8 +21,11 @@ import sys
 import six
 import types
 import numbers
-import collections
 import enum
+try:
+    import collections.abc as collections_abc  # python 3.3+
+except ImportError:
+    import collections as collections_abc
 
 from ._tango import StdStringVector, StdDoubleVector, \
     DbData, DbDevInfos, DbDevExportInfos, CmdArgType, AttrDataFormat, \
@@ -352,7 +355,7 @@ except NameError:
 
 __int_klasses = int,
 __number_klasses = numbers.Number,
-__seq_klasses = collections.Sequence, bytearray, StdStringVector
+__seq_klasses = collections_abc.Sequence, bytearray, StdStringVector
 
 __use_unicode = False
 try:


### PR DESCRIPTION
The `collections.abc` was introduced at python 3.3. This is a proactive change as the original collections code will be deprecated at python3.8.
`inspect.getargspec` is already deprecated.