### PR TITLE
Fix mapping of AttrWriteType WT_UNKNOWN

### DIFF
--- a/ext/enums.cpp
+++ b/ext/enums.cpp
@@ -175,7 +175,7 @@ void export_enums()
         .value("READ_WITH_WRITE", Tango::READ_WITH_WRITE)
         .value("WRITE", Tango::WRITE)
         .value("READ_WRITE", Tango::READ_WRITE)
-        .value("WT_UNKNOWN", Tango::READ_WRITE)
+        .value("WT_UNKNOWN", Tango::WT_UNKNOWN)
         .export_values()
     ;
 


### PR DESCRIPTION
Fixes issue #253.  Typo in mapping. 

Before change (READ_WRITE missing):
```
In [1]: import tango

In [2]: tango.AttrWriteType.values
Out[2]: 
{0: tango._tango.AttrWriteType.READ,
 1: tango._tango.AttrWriteType.READ_WITH_WRITE,
 2: tango._tango.AttrWriteType.WRITE,
 3: tango._tango.AttrWriteType.WT_UNKNOWN}
```

After change (READ_WRITE included):
```
In [1]: import tango

In [2]: tango.AttrWriteType.values
Out[2]: 
{0: tango._tango.AttrWriteType.READ,
 1: tango._tango.AttrWriteType.READ_WITH_WRITE,
 2: tango._tango.AttrWriteType.WRITE,
 3: tango._tango.AttrWriteType.READ_WRITE,
 4: tango._tango.AttrWriteType.WT_UNKNOWN}
```