### PR TITLE
 Change Travis CI builds to xenial

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@ var/
 *.egg
 *.eggs
 *.cfg
+!setup.cfg
 MANIFEST
 
 # Installer logs

--- a/.travis.yml
+++ b/.travis.yml
@@ -62,6 +62,8 @@ script:
   - python setup.py build
   # The build directory has been updated, cached_ext needs to be synchronized too
   - rsync -a --delete ext/ cached_ext/
+  # Show useful build information
+  - python -c "from tango.utils import info; print(info())"
   # Run the tests
   - python setup.py test
   # Kill all the hanging tango test processes

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
-sudo: false
+dist: xenial
 language: python
-os: linux
 branches:
   only:
     - stable

--- a/.travis.yml
+++ b/.travis.yml
@@ -62,8 +62,6 @@ script:
   - python setup.py build
   # The build directory has been updated, cached_ext needs to be synchronized too
   - rsync -a --delete ext/ cached_ext/
-  # Show useful build information
-  - python -c "from tango.utils import info; print(info())"
   # Run the tests
   - python setup.py test
   # Kill all the hanging tango test processes


### PR DESCRIPTION
Default was Ubuntu 14.04 (trusty), now switch to newer version of Linux - Ubuntu 16.04 (xenial).  Ubuntu 14.04 (trusty) is reaching end of life in 2019, and Travis have made some changes to their build infrastructure ([here](https://docs.travis-ci.com/user/reference/overview/#deprecated-virtualization-environments) and [here](https://changelog.travis-ci.com/the-container-based-build-environment-is-fully-deprecated-84517)).

Also make sure the `setup.cfg` file isn't ignored anymore.

(Still expect some event tests to fail, since this branch is still using cppTango 9.2.5)