### PR TITLE
add ApiUtil.cleanup()

### DIFF
--- a/doc/howto.rst
+++ b/doc/howto.rst
@@ -298,15 +298,15 @@ API should be accessed from Python::
 Using clients with multiprocessing
 ----------------------------------
 
-Since version 9.2.6 PyTango provides :func:`ApiUtil.cleanup()`
+Since version 9.2.6 PyTango provides :staticmethod:`~tango.ApiUtil.cleanup()`
 which resets CORBA connection.
 This static function is needed when you want to use :mod:`tango` with
 :mod:`multiprocessing` in your client code.
 
 In the case when both your parent process and your child process create
-:class:`tango.DeviceProxy`, :class:`tango.Database`
-or/and :class:`tango.AttributeProxy`
-your child process will inherit the context from your parent process,
+:class:`~tango.DeviceProxy`, :class:`~tango.Database`
+or/and :class:`~tango.AttributeProxy`
+your child process inherits the context from your parent process,
 i.e. open file descriptors, the TANGO and the CORBA state.
 Sharing the above objects between the processes may cause unpredictable
 errors, e.g. *TRANSIENT_CallTimedout*, *unidentifiable C++ exception*.

--- a/doc/howto.rst
+++ b/doc/howto.rst
@@ -298,7 +298,7 @@ API should be accessed from Python::
 Using clients with multiprocessing
 ----------------------------------
 
-Since version 9.2.6 PyTango provides :meth:`~tango.ApiUtil.cleanup()`
+Since version 9.3.0 PyTango provides :meth:`~tango.ApiUtil.cleanup()`
 which resets CORBA connection.
 This static function is needed when you want to use :mod:`tango` with
 :mod:`multiprocessing` in your client code.

--- a/doc/howto.rst
+++ b/doc/howto.rst
@@ -298,7 +298,7 @@ API should be accessed from Python::
 Using clients with multiprocessing
 ----------------------------------
 
-Since version 9.2.6 PyTango provides :staticmethod:`~tango.ApiUtil.cleanup()`
+Since version 9.2.6 PyTango provides :meth:`~tango.ApiUtil.cleanup()`
 which resets CORBA connection.
 This static function is needed when you want to use :mod:`tango` with
 :mod:`multiprocessing` in your client code.

--- a/doc/howto.rst
+++ b/doc/howto.rst
@@ -353,7 +353,11 @@ Therefore, when you start a new process you must reset CORBA connection::
     for i in range(4):
 	runworkers()
 
-
+After `cleanup()` all references to :class:`~tango.DeviceProxy`,
+:class:`~tango.AttributeProxy` or :class:`~tango.Database` objects
+in the current process become invalid
+and these objects need to be reconstructed.
+				       
 
 Write a server
 --------------

--- a/doc/howto.rst
+++ b/doc/howto.rst
@@ -298,17 +298,18 @@ API should be accessed from Python::
 Using clients with multiprocessing
 ----------------------------------
 
-Since version 9.2.6 PyTango provides `ApiUtil.cleanup()`
+Since version 9.2.6 PyTango provides :func:`ApiUtil.cleanup()`
 which resets CORBA connection.
-This static function is needed when you want to use `tango` with
-the `multiprocessing` module in your client code.
+This static function is needed when you want to use :mod:`tango` with
+:mod:`multiprocessing` in your client code.
 
 In the case when both your parent process and your child process create
-`tango.DeviceProxy`, `tango.Database` or/and `tango.AttributeProxy`
+:class:`tango.DeviceProxy`, :class:`tango.Database`
+or/and :class:`tango.AttributeProxy`
 your child process will inherit the context from your parent process,
 i.e. open file descriptors, the TANGO and the CORBA state.
 Sharing the above objects between the processes may cause unpredictable
-errors, e.g. `TRANSIENT_CallTimedout`, `unidentifiable C++ exception`.
+errors, e.g. *TRANSIENT_CallTimedout*, *unidentifiable C++ exception*.
 Therefore, when you start a new process you must reset CORBA connection::
 
     import time

--- a/doc/howto.rst
+++ b/doc/howto.rst
@@ -295,6 +295,65 @@ API should be accessed from Python::
     axis_properties["AxisNumber"] = ["6"]
     axis1.put_property(axis_properties)
 
+Using clients with multiprocessing
+----------------------------------
+
+Since version 9.2.6 PyTango provides `ApiUtil.cleanup()`
+which resets CORBA connection.
+This static function is needed when you want to use `tango` with
+the `multiprocessing` module in your client code.
+
+In the case when both your parent process and your child process create
+`tango.DeviceProxy`, `tango.Database` or/and `tango.AttributeProxy`
+your child process will inherit the context from your parent process,
+i.e. open file descriptors, the TANGO and the CORBA state.
+Sharing the above objects between the processes may cause unpredictable
+errors, e.g. `TRANSIENT_CallTimedout`, `unidentifiable C++ exception`.
+Therefore, when you start a new process you must reset CORBA connection::
+
+    import time
+    import tango
+
+    from multiprocessing import Process
+
+
+    class Worker(Process):
+
+	def __init__(self):
+	    Process.__init__(self)
+
+	def run(self):
+            # reset CORBA connection
+            tango.ApiUtil.cleanup()
+
+	    proxy = tango.DeviceProxy('test/tserver/1')
+
+	    stime = time.time()
+	    etime = stime
+	    while etime - stime < 1.:
+		try:
+		    proxy.read_attribute("Value")
+		except Exception as e:
+		    print(str(e))
+		etime = time.time()
+
+
+    def runworkers():
+	workers = [Worker() for _ in range(6)]
+	for wk in workers:
+	    wk.start()
+	for wk in workers:
+	    wk.join()
+
+
+    db = tango.Database()
+    dp = tango.DeviceProxy('test/tserver/1')
+
+    for i in range(4):
+	runworkers()
+
+
+
 Write a server
 --------------
 

--- a/ext/api_util.cpp
+++ b/ext/api_util.cpp
@@ -67,5 +67,7 @@ void export_api_util()
         .def("get_user_connect_timeout", &Tango::ApiUtil::get_user_connect_timeout)
 
         .def("get_ip_from_if", &Tango::ApiUtil::get_ip_from_if)
+        .def("cleanup", &Tango::ApiUtil::cleanup)
+        .staticmethod("cleanup")
     ;
 }

--- a/tango/api_util.py
+++ b/tango/api_util.py
@@ -133,6 +133,18 @@ def __doc_api_util():
     """)
 
 
+    document_method(ApiUtil, "cleanup", """
+    cleanup(self) -> None
+
+            Destroy the ApiUtil singleton instance.
+
+        Parameters : None
+        Return     : None
+
+        New in PyTango 9.2.6
+    """)
+
+
 def api_util_init(doc=True):
     __init_api_util()
     if doc:

--- a/tango/api_util.py
+++ b/tango/api_util.py
@@ -141,7 +141,7 @@ def __doc_api_util():
         Parameters : None
         Return     : None
 
-        New in PyTango 9.2.6
+        New in PyTango 9.3.0
     """)
 
 

--- a/tango/api_util.py
+++ b/tango/api_util.py
@@ -133,10 +133,14 @@ def __doc_api_util():
     """)
 
 
-    document_method(ApiUtil, "cleanup", """
-    cleanup(self) -> None
+    document_static_method(ApiUtil, "cleanup", """
+    cleanup() -> None
 
             Destroy the ApiUtil singleton instance.
+            After `cleanup()` all references to
+            `DeviceProxy`, `AttributeProxy` or `Database` objects
+            in the current process become invalid
+            and these objects need to be reconstructed.
 
         Parameters : None
         Return     : None


### PR DESCRIPTION
It adds `ApiUtil.cleanup()`. 

That  allows to workaround a problem when a user uses `tango` in parent and child `process` simultaneously, e.g. #259 . In the case one has to call `ApiUtil.cleanup()` on start of each new child process. 