### PR TITLE
Fix compile error under Linux

### DIFF
--- a/ext/device_data.cpp
+++ b/ext/device_data.cpp
@@ -182,7 +182,7 @@ namespace PyDeviceData {
         template <>
         object extract_array<Tango::DEVVAR_STATEARRAY>(Tango::DeviceData &self, object &py_self, PyTango::ExtractAs extract_as)
         {
-            assert(False);
+            assert(false);
             return object();
         }
     /// @}


### PR DESCRIPTION
when building pytango-9.2.5 under Gentoo with gcc 7.3.0 I get the following error:

```
/var/tmp/portage/dev-python/pytango-9.2.5/work/pytango-9.2.5/ext/device_data.cpp:185:20: error: ‘False’ was not declared in this scope
             assert(False);
                    ^
/var/tmp/portage/dev-python/pytango-9.2.5/work/pytango-9.2.5/ext/device_data.cpp:185:20: note: suggested alternative: ‘raise’
error: command 'x86_64-pc-linux-gnu-g++' failed with exit status 1
```
