### PR TITLE
Add six >= 1.12 requirement

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -429,11 +429,11 @@ def setup_args():
     requires = [
         'boost_python (>=1.33)',
         'numpy (>=1.1)',
-        'six',
+        'six (>=1.12)',
     ]
 
     install_requires = [
-        'six',
+        'six (>=1.12)',
     ]
     if PYTHON_VERSION < (3, 4):
         install_requires.append('enum34')


### PR DESCRIPTION
The method `six.ensure_binary` is only available since release 1.12.

Addresses issue #269