### PR TITLE
WIP: fix the documentation build on python2.7 #244

### DIFF
--- a/doc/mock_tango_extension.py
+++ b/doc/mock_tango_extension.py
@@ -25,7 +25,10 @@ version older than 3.5 (failed with 2.7 and 3.4)
 
 # Imports
 import sys
-from unittest.mock import MagicMock
+try:
+    from unittest.mock import MagicMock
+except ImportError:
+    from mock import MagicMock
 
 __all__ = ('tango',)
 


### PR DESCRIPTION
[python 2.7] ImportError: No module named mock #244