### PR TITLE
Fix DevEncoded commands on Python 3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ branches:
 
 env:
   global:
-    - TANGO_VERSION=9.3.2alpha.1
+    - TANGO_VERSION=9.2.5a
   matrix:
     - PYTHON_VERSION=2.7
     - PYTHON_VERSION=3.5

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ branches:
 
 env:
   global:
-    - TANGO_VERSION=9.2.5a
+    - TANGO_VERSION=9.3.2alpha.1
   matrix:
     - PYTHON_VERSION=2.7
     - PYTHON_VERSION=3.5

--- a/.travis.yml
+++ b/.travis.yml
@@ -55,7 +55,7 @@ before_script:
   # Make sure old_ext exists
   - mkdir -p cached_ext
   # Touch the .so files if the extension hasn't changed
-  - diff cached_ext ext && find build -name _tango*.so -printf "touching %p\n" -exec touch {} + || true
+  - diff -r cached_ext ext && find build -name _tango*.so -printf "touching %p\n" -exec touch {} + || true
 
 script:
   # Build the package

--- a/ext/server/command.cpp
+++ b/ext/server/command.cpp
@@ -222,9 +222,21 @@ void extract_scalar<Tango::DEV_ENCODED>(const CORBA::Any &any, boost::python::ob
         throw_bad_type(Tango::CmdArgTypeName[Tango::DEV_ENCODED]);
     
     bopy::str encoded_format(data[0].encoded_format);
+
+#if PY_MAJOR_VERSION >= 3
+    boost::python::object encoded_data(
+        boost::python::handle<>(
+            PyBytes_FromStringAndSize(
+                (char*)data[0].encoded_data.get_buffer(),
+                data[0].encoded_data.length()
+            )
+        )
+    );
+#else
     bopy::str encoded_data((const char*)data[0].encoded_data.get_buffer(),
                            data[0].encoded_data.length());
-    
+#endif
+
     o = boost::python::make_tuple(encoded_format, encoded_data);
 }
 

--- a/ext/server/command.cpp
+++ b/ext/server/command.cpp
@@ -220,22 +220,16 @@ void extract_scalar<Tango::DEV_ENCODED>(const CORBA::Any &any, boost::python::ob
 
     if ((any >>= data) == false)
         throw_bad_type(Tango::CmdArgTypeName[Tango::DEV_ENCODED]);
-    
-    bopy::str encoded_format(data[0].encoded_format);
 
-#if PY_MAJOR_VERSION >= 3
+    boost::python::str encoded_format(data[0].encoded_format);
     boost::python::object encoded_data(
         boost::python::handle<>(
             PyBytes_FromStringAndSize(
-                (char*)data[0].encoded_data.get_buffer(),
+                (const char*)data[0].encoded_data.get_buffer(),
                 data[0].encoded_data.length()
             )
         )
     );
-#else
-    bopy::str encoded_data((const char*)data[0].encoded_data.get_buffer(),
-                           data[0].encoded_data.length());
-#endif
 
     o = boost::python::make_tuple(encoded_format, encoded_data);
 }

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -425,11 +425,31 @@ def test_read_write_dev_encoded(server_green_mode):
         def attr(self, value):
             self.attr_value = value
 
+        @command(dtype_in=DevEncoded)
+        def cmd_in(self, value):
+            self.attr_value = value
+
+        @command(dtype_out=DevEncoded)
+        def cmd_out(self):
+            return self.attr_value
+
+        @command(dtype_in=DevEncoded, dtype_out=DevEncoded)
+        def cmd_in_out(self, value):
+            self.attr_value = value
+            return self.attr_value
+
     with DeviceTestContext(TestDevice) as proxy:
         assert proxy.attr == ("uint8", b"\xd2\xd3")
 
-        proxy.attr = ('uint8', b'\xde')
+        proxy.attr = ("uint8", b"\xde")
         assert proxy.attr == ("uint8", b"\xde")
+
+        proxy.cmd_in(("uint8", b"\xd4\xd5"))
+        assert proxy.cmd_out() == ("uint8", b"\xd4\xd5")
+
+        proxy.cmd_in_out(('uint8', b"\xd6\xd7"))
+        assert proxy.attr == ("uint8", b"\xd6\xd7")
+
 
 
 # Test Exception propagation


### PR DESCRIPTION
Work in progress.
- [x] Added unit test to ensure that DevEncoded (aka bytearray) commands work the same as the attributes.
- [x] Fix implementation so that tests pass. 

Fixes:  issue #280