### PR TITLE
Make sure we only convert to string python unicode/str/bytes objects

### DIFF
--- a/ext/pyutils.cpp
+++ b/ext/pyutils.cpp
@@ -96,12 +96,17 @@ char* from_str_to_char(PyObject* in)
 	out = strncpy(out, PyBytes_AsString(bytes_in), size);
         Py_DECREF(bytes_in);
     }
-    else
+    else if (PyBytes_Check(in))
     {
 	Py_ssize_t size = PyBytes_Size(in);
 	out = new char[size+1];
 	out[size] = '\0';
 	out = strncpy(out, PyBytes_AsString(in), size);
+    }
+    else
+    {
+        PyErr_SetString(PyExc_TypeError,
+            "can't translate python object to C char*");
     }
     return out;
 }

--- a/ext/pyutils.cpp
+++ b/ext/pyutils.cpp
@@ -105,8 +105,7 @@ char* from_str_to_char(PyObject* in)
     }
     else
     {
-        PyErr_SetString(PyExc_TypeError,
-            "can't translate python object to C char*");
+        raise_(PyExc_TypeError, "can't translate python object to C char*");
     }
     return out;
 }

--- a/ext/server/command.cpp
+++ b/ext/server/command.cpp
@@ -108,9 +108,13 @@ void insert_scalar<Tango::DEV_STRING>(boost::python::object &o, CORBA::Any &any)
 	any <<= PyBytes_AsString(bytes_o_ptr);
         Py_DECREF(bytes_o_ptr);
     }
-    else
+    else if (PyBytes_Check(o_ptr))
     {
         any <<= PyBytes_AsString(o_ptr);
+    }
+    else
+    {
+        raise_(PyExc_TypeError, "can't translate python object to C char*");
     }
 }
 

--- a/setup.py
+++ b/setup.py
@@ -450,7 +450,9 @@ def setup_args():
     ]
 
     if PYTHON2:
-        tests_require += ['trollius', 'futures']
+        tests_require += ['trollius', 'futures', 'pytest < 5']
+    else:
+        tests_require += ['pytest']
 
     package_data = {
         'tango.databaseds': ['*.xmi', '*.sql', '*.sh', 'DataBaseds'],

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -121,6 +121,33 @@ def test_polled_command(server_green_mode):
         assert dct[comm] == period
 
 
+def test_wrong_command_result(server_green_mode):
+
+    class TestDevice(Device):
+        green_mode = server_green_mode
+
+        @command(dtype_out=str)
+        def cmd_str_err(self):
+            return 1.2345
+
+        @command(dtype_out=int)
+        def cmd_int_err(self):
+            return "bla"
+
+        @command(dtype_out=[str])
+        def cmd_str_list_err(self):
+            return ['hello', 55]
+
+    with DeviceTestContext(TestDevice) as proxy:
+        with pytest.raises(DevFailed):
+            proxy.cmd_str_err()
+        with pytest.raises(DevFailed):
+            proxy.cmd_int_err()
+        with pytest.raises(DevFailed):
+            proxy.cmd_str_list_err()
+
+
+
 # Test attributes
 
 def test_read_write_attribute(typed_values, server_green_mode):
@@ -217,6 +244,31 @@ def test_read_write_attribute_enum(server_green_mode):
         BadTestDevice()  # dummy instance for Codacy
     assert 'enum_labels' in str(context.value)
 
+
+def test_wrong_attribute_read(server_green_mode):
+
+    class TestDevice(Device):
+        green_mode = server_green_mode
+
+        @attribute(dtype=str)
+        def attr_str_err(self):
+            return 1.2345
+
+        @attribute(dtype=int)
+        def attr_int_err(self):
+            return "bla"
+
+        @attribute(dtype=[str])
+        def attr_str_list_err(self):
+            return ['hello', 55]
+
+    with DeviceTestContext(TestDevice) as proxy:
+        with pytest.raises(DevFailed):
+            proxy.attr_str_err
+        with pytest.raises(DevFailed):
+            proxy.attr_int_err
+        with pytest.raises(DevFailed):
+            proxy.attr_str_list_err
 
 # Test properties
 


### PR DESCRIPTION
Fixes #285 

Only convert to C string python str/bytes/unicode objects.
On error raise TypeError