### PR TITLE
Add MultiDeviceTestContext for testing more than one Device

### DIFF
--- a/tango/test_context.py
+++ b/tango/test_context.py
@@ -176,10 +176,8 @@ class MultiDeviceTestContext(object):
                                  "to the same Tango class")
             tangoclass_list.append(tangoclass)
             # File
-            self.generate_db_file_tangoclass(server_name, instance_name,
-                                             tangoclass)
-            self.generate_db_file_device(device_info["devices"])
-
+            self.append_db_file(server_name, instance_name, tangoclass,
+                                device_info["devices"])
             if device_cls:
                 class_list.append((device_cls, device, tangoclass))
             else:
@@ -230,42 +228,16 @@ class MultiDeviceTestContext(object):
                 "The post_init routine failed to report anything")
             self.queue.put((None, exc, None))
 
-    def generate_db_file(self, server, instance, device,
-                         tangoclass=None, properties={}):
-        """Generate a database file corresponding to the given arguments."""
-        if not tangoclass:
-            tangoclass = server
-        self.generate_db_file_tangoclass(server, instance, tangoclass)
-        device_prop_info = (
-            {
-                "name": device,
-                "properties": properties
-            }
-        )
-        return self.generate_db_file_device(device_prop_info)
-
-    def generate_db_file_tangoclass(self, server, instance, tangoclass):
+    def append_db_file(self, server, instance, tangoclass, device_prop_info):
         """Generate a database file corresponding to the given arguments.
-
-        Only device server and device class information (no devices information)
         """
+        device_names = [info["name"] for info in device_prop_info]
         # Open the file
         with open(self.db, "a") as f:
             f.write("/".join((server, instance, "DEVICE", tangoclass)))
-            f.flush()
-
-    def generate_db_file_device(self, device_prop_info):
-        """Generate a database file corresponding to the given arguments.
-
-        Only devices information (neither device server nor device class
-        information)
-        """
-        # Open the file
-        device_names = [info["name"] for info in device_prop_info]
-        with open(self.db, "a") as f:
             for device_name in device_names:
                 f.write(': "' + device_name + '"\n')
-                f.flush()
+            f.flush()
         # Create database
         db = Database(self.db)
         # Write properties

--- a/tango/test_context.py
+++ b/tango/test_context.py
@@ -438,7 +438,49 @@ class MultiDeviceTestContext(object):
 # Single device test context
 
 class DeviceTestContext(MultiDeviceTestContext):
-    """ Context to run a device without a database."""
+    """Context to run a single device without a database.
+
+    The difference with respect to
+    :class:`~tango.test_context.MultiDeviceTestContext` is that it only
+    allows to export a single device.
+
+    Example usage::
+
+        from time import sleep
+
+        from tango.server import Device, attribute, command
+        from tango.test_context import DeviceTestContext
+
+        class PowerSupply(Device):
+
+            @attribute(dtype=float)
+            def voltage(self):
+                return 1.23
+
+            @command
+            def calibrate(self):
+                sleep(0.1)
+
+        def test_calibrate():
+            '''Test device calibration and voltage reading.'''
+            with DeviceTestContext(PowerSupply, process=True) as proxy:
+                proxy.calibrate()
+                assert proxy.voltage == 1.23
+
+    :param device:
+      Device class to be run.
+    :type device:
+      :class:`~tango.server.Device` or :class:`~tango.DeviceImpl`
+    :param device_cls:
+      The device class can be provided if using the low-level API.
+      Optional.  Not required for high-level API devices, of type
+      :class:`~tango.server.Device`.
+    :type device_cls:
+      :class:`~tango.DeviceClass`
+
+     The rest of the parameters are described in
+     :class:`~tango.test_context.MultiDeviceTestContext`.
+     """
 
     def __init__(self, device, device_cls=None, server_name=None,
                  instance_name=None, device_name=None, properties=None,

--- a/tango/test_context.py
+++ b/tango/test_context.py
@@ -535,7 +535,13 @@ class DeviceTestContext(MultiDeviceTestContext):
         self.device.ping()
 
     def __enter__(self):
-        """Enter method for context support."""
+        """Enter method for context support.
+
+        :return:
+          A device proxy to the device started by this context.
+        :rtype:
+          :class:`~tango.DeviceProxy`
+        """
         if not self.thread.is_alive():
             self.start()
         return self.device

--- a/tango/test_context.py
+++ b/tango/test_context.py
@@ -160,8 +160,8 @@ class MultiDeviceTestContext(object):
 
         class_list = []
         device_list = []
-        device_cls = None
         for device_info in devices_info:
+            device_cls = None
             cls = device_info["class"]
             if is_non_str_seq(cls):
                 device_cls = cls[0]

--- a/tango/test_context.py
+++ b/tango/test_context.py
@@ -374,10 +374,12 @@ class DeviceTestContext(MultiDeviceTestContext):
         self.device_name = device_name
         self.device = self.server = None
 
-    def get_device_access(self):
+    def get_device_access(self, device_name=None):
         """Return the full device name."""
+        if device_name is None:
+            device_name = self.device_name
         return super(DeviceTestContext, self).get_device_access(
-            self.device_name)
+            device_name)
 
     def connect(self):
         super(DeviceTestContext, self).connect()

--- a/tango/test_context.py
+++ b/tango/test_context.py
@@ -382,7 +382,7 @@ class DeviceTestContext(MultiDeviceTestContext):
     def connect(self):
         super(DeviceTestContext, self).connect()
         # Get device proxy
-        self.device = DeviceProxy(self.get_device_access())
+        self.device = self.get_device(self.device_name)
         self.device.ping()
 
     def __enter__(self):

--- a/tango/test_context.py
+++ b/tango/test_context.py
@@ -111,16 +111,14 @@ class MultiDeviceTestContext(object):
 
         class Device1(Device):
 
-            attr1 = attribute()
-
-            def read_attr1(self):
+            @attribute
+            def attr1(self):
                 return 1.0
 
 
         class Device2(Device):
 
-            attr2 = attribute()
-
+            @attribute
             def read_attr2(self):
                 return 2.0
 
@@ -128,28 +126,28 @@ class MultiDeviceTestContext(object):
         devices_info = (
             {
                 "class": Device1,
-                "devices": (
+                "devices": [
                     {
                         "name": "test/device1/1"
                     },
-                )
+                ]
             },
             {
                 "class": Device2,
-                "devices": (
+                "devices": [
                     {
                         "name": "test/device2/1",
-                    }
-                )
+                    },
+                ]
             }
         )
 
         def test_devices():
             with MultiDeviceTestContext(devices_info, process=True) as context:
-                device1 = context.get_device("test/device1/1")
-                device2 = context.get_device("test/device2/1")
-                assert device1.read_attribute("attr1").value == 1.0
-                assert device2.read_attribute("attr1").value == 2.0
+                proxy1 = context.get_device("test/device1/1")
+                proxy2 = context.get_device("test/device2/1")
+                assert proxy1.attr1 == 1.0
+                assert proxy2.attr2 == 2.0
 
     :param devices_info:
       a sequence of dicts with information about
@@ -435,8 +433,8 @@ class MultiDeviceTestContext(object):
         """Exit method for context support."""
         self.stop()
 
-# Single device test context
 
+# Single device test context
 class DeviceTestContext(MultiDeviceTestContext):
     """Context to run a single device without a database.
 

--- a/tango/test_context.py
+++ b/tango/test_context.py
@@ -486,7 +486,6 @@ class DeviceTestContext(MultiDeviceTestContext):
                  instance_name=None, device_name=None, properties=None,
                  db=None, host=None, port=0, debug=3,
                  process=False, daemon=False, timeout=None):
-        """Inititalize the context to run a given device."""
         # Argument
         if not server_name:
             server_name = device.__name__

--- a/tango/test_context.py
+++ b/tango/test_context.py
@@ -341,7 +341,6 @@ class MultiDeviceTestContext(object):
             f.write("/".join((server, instance, "DEVICE", tangoclass)))
             for device_name in device_names:
                 f.write(': "' + device_name + '"\n')
-            f.flush()
         # Create database
         db = Database(self.db)
         # Write properties

--- a/tango/test_context.py
+++ b/tango/test_context.py
@@ -184,6 +184,10 @@ class MultiDeviceTestContext(object):
                 device_list.append(device)
 
         # Target and arguments
+        if class_list and device_list:
+            os.unlink(self.db)
+            raise ValueError("mixing HLAPI and classical API in devices_info "
+                             "is not supported")
         if class_list:
             runserver = partial(run, class_list, cmd_args)
         elif len(device_list) == 1 and hasattr(device_list[0], "run_server"):

--- a/tango/test_context.py
+++ b/tango/test_context.py
@@ -374,7 +374,6 @@ class DeviceTestContext(MultiDeviceTestContext):
     def connect(self):
         super(DeviceTestContext, self).connect()
         # Get device proxy
-        print(self.get_device_access())
         self.device = DeviceProxy(self.get_device_access())
         self.device.ping()
 

--- a/tango/test_context.py
+++ b/tango/test_context.py
@@ -372,20 +372,25 @@ class DeviceTestContext(MultiDeviceTestContext):
                 )
             },
         )
-        super().__init__(devices_info, server_name=server_name,
-                         instance_name=instance_name, db=db, host=host,
-                         port=port, debug=debug, process=process,
-                         daemon=daemon, timeout=timeout)
+        super(DeviceTestContext, self).__init__(devices_info,
+                                                server_name=server_name,
+                                                instance_name=instance_name,
+                                                db=db, host=host,
+                                                port=port, debug=debug,
+                                                process=process,
+                                                daemon=daemon,
+                                                timeout=timeout)
 
         self.device_name = device_name
         self.device = self.server = None
 
     def get_device_access(self):
         """Return the full device name."""
-        return super().get_device_access(self.device_name)
+        return super(DeviceTestContext, self).get_device_access(
+            self.device_name)
 
     def connect(self):
-        super().connect()
+        super(DeviceTestContext, self).connect()
         # Get device proxy
         print(self.get_device_access())
         self.device = DeviceProxy(self.get_device_access())

--- a/tango/test_context.py
+++ b/tango/test_context.py
@@ -370,7 +370,7 @@ class MultiDeviceTestContext(object):
         Maintains previously accessed device proxies in a cache to not recreate
         then on every access.
         """
-        if not device_name in self._devices:
+        if device_name not in self._devices:
             device = DeviceProxy(self.get_device_access(device_name))
             self._devices[device_name] = device
         return self._devices[device_name]

--- a/tango/test_context.py
+++ b/tango/test_context.py
@@ -339,8 +339,9 @@ class MultiDeviceTestContext(object):
         # Open the file
         with open(self.db, "a") as f:
             f.write("/".join((server, instance, "DEVICE", tangoclass)))
-            for device_name in device_names:
-                f.write(': "' + device_name + '"\n')
+            f.write(": ")
+            f.write(", ".join(device_names))
+            f.write("\n")
         # Create database
         db = Database(self.db)
         # Write properties

--- a/tango/test_context.py
+++ b/tango/test_context.py
@@ -321,7 +321,7 @@ class MultiDeviceTestContext(object):
         """Exit method for context support."""
         self.stop()
 
-# Device test context
+# Single device test context
 
 class DeviceTestContext(MultiDeviceTestContext):
     """ Context to run a device without a database."""

--- a/tango/test_context.py
+++ b/tango/test_context.py
@@ -419,7 +419,14 @@ class MultiDeviceTestContext(object):
         self.thread.join(timeout)
 
     def __enter__(self):
-        """Enter method for context support."""
+        """Enter method for context support.
+
+        :return:
+          Instance of this test context.  Use `get_device` to get proxy
+          access to any of the devices started by this context.
+        :rtype:
+          :class:`~tango.test_context.MultiDeviceTestContext`
+        """
         if not self.thread.is_alive():
             self.start()
         return self

--- a/tango/test_context.py
+++ b/tango/test_context.py
@@ -160,6 +160,7 @@ class MultiDeviceTestContext(object):
 
         class_list = []
         device_list = []
+        tangoclass_list = []
         for device_info in devices_info:
             device_cls = None
             cls = device_info["class"]
@@ -169,6 +170,11 @@ class MultiDeviceTestContext(object):
             else:
                 device = cls
             tangoclass = device.__name__
+            if tangoclass in tangoclass_list:
+                os.unlink(self.db)
+                raise ValueError("multiple entries in devices_info pointing "
+                                 "to the same Tango class")
+            tangoclass_list.append(tangoclass)
             # File
             self.generate_db_file_tangoclass(server_name, instance_name,
                                              tangoclass)

--- a/tango/test_utils.py
+++ b/tango/test_utils.py
@@ -11,7 +11,7 @@ except ImportError:
 # Local imports
 from . import DevState, GreenMode
 from .server import Device
-from .test_context import DeviceTestContext
+from .test_context import MultiDeviceTestContext, DeviceTestContext
 
 # Conditional imports
 try:
@@ -24,7 +24,7 @@ try:
 except ImportError:
     numpy = None
 
-__all__ = ('DeviceTestContext', 'SimpleDevice')
+__all__ = ('MultiDeviceTestContext', 'DeviceTestContext', 'SimpleDevice')
 
 PY3 = sys.version_info >= (3,)
 

--- a/tests/test_test_context.py
+++ b/tests/test_test_context.py
@@ -1,0 +1,202 @@
+# -*- coding: utf-8 -*-
+
+import pytest
+
+import tango
+
+from tango.server import Device
+from tango.server import command, attribute, device_property
+from tango.test_utils import DeviceTestContext, MultiDeviceTestContext
+
+
+class Device1(Device):
+    @attribute
+    def attr1(self):
+        return 100
+
+
+class Device2(Device):
+    @attribute
+    def attr2(self):
+        return 200
+
+
+class ClassicAPIDeviceImpl(tango.LatestDeviceImpl):
+    def __init__(self, cl, name):
+        tango.LatestDeviceImpl.__init__(self, cl, name)
+        ClassicAPIDeviceImpl.init_device(self)
+
+    def init_device(self):
+        self.get_device_properties(self.get_device_class())
+        self.attr_attr1_read = 100
+
+    def read_attr1(self, attr):
+        attr.set_value(self.attr_attr1_read)
+
+
+class ClassicAPIDeviceClass(tango.DeviceClass):
+    attr_list = {"attr1": [[tango.DevLong64, tango.SCALAR, tango.READ]]}
+
+
+def test_single_device(server_green_mode):
+    class TestDevice(Device1):
+        green_mode = server_green_mode
+
+    with DeviceTestContext(TestDevice) as proxy:
+        assert proxy.attr1 == 100
+
+
+def test_single_device_old_api():
+    with DeviceTestContext(ClassicAPIDeviceImpl, ClassicAPIDeviceClass) as proxy:
+        assert proxy.attr1 == 100
+
+
+def test_multi_with_single_device(server_green_mode):
+    class TestDevice(Device1):
+        green_mode = server_green_mode
+
+    devices_info = ({"class": TestDevice, "devices": [{"name": "test/device1/1"}]},)
+
+    with MultiDeviceTestContext(devices_info) as context:
+        proxy1 = context.get_device("test/device1/1")
+        assert proxy1.attr1 == 100
+
+
+def test_multi_with_single_device_old_api():
+    devices_info = (
+        {
+            "class": (ClassicAPIDeviceClass, ClassicAPIDeviceImpl),
+            "devices": [{"name": "test/device1/1"}],
+        },
+    )
+
+    with MultiDeviceTestContext(devices_info) as context:
+        proxy1 = context.get_device("test/device1/1")
+        assert proxy1.attr1 == 100
+
+
+def test_multi_with_two_devices(server_green_mode):
+    class TestDevice1(Device1):
+        green_mode = server_green_mode
+
+    class TestDevice2(Device2):
+        green_mode = server_green_mode
+
+    devices_info = (
+        {"class": TestDevice1, "devices": [{"name": "test/device1/1"}]},
+        {"class": TestDevice2, "devices": [{"name": "test/device2/1"}]},
+    )
+
+    with MultiDeviceTestContext(devices_info) as context:
+        proxy1 = context.get_device("test/device1/1")
+        proxy2 = context.get_device("test/device2/1")
+        assert proxy1.attr1 == 100
+        assert proxy2.attr2 == 200
+
+
+def test_multi_device_access():
+    devices_info = (
+        {"class": Device1, "devices": [{"name": "test/device1/1"}]},
+        {"class": Device2, "devices": [{"name": "test/device2/2"}]},
+    )
+
+    with MultiDeviceTestContext(devices_info) as context:
+        device_access1 = context.get_device_access("test/device1/1")
+        device_access2 = context.get_device_access("test/device2/2")
+        server_access = context.get_server_access()
+        assert "test/device1/1" in device_access1
+        assert "test/device2/2" in device_access2
+        assert context.server_name in server_access
+        proxy1 = tango.DeviceProxy(device_access1)
+        proxy2 = tango.DeviceProxy(device_access2)
+        proxy_server = tango.DeviceProxy(server_access)
+        assert proxy1.attr1 == 100
+        assert proxy2.attr2 == 200
+        assert proxy_server.State() == tango.DevState.ON
+
+
+def test_multi_device_proxy_cached():
+    devices_info = ({"class": Device1, "devices": [{"name": "test/device1/1"}]},)
+
+    with MultiDeviceTestContext(devices_info) as context:
+        device1_first = context.get_device("test/device1/1")
+        device1_second = context.get_device("test/device1/1")
+        assert device1_first is device1_second
+
+
+def test_multi_with_two_devices_with_properties(server_green_mode):
+    class TestDevice1(Device):
+        green_mode = server_green_mode
+
+        prop1 = device_property(dtype=str)
+
+        @command(dtype_out=str)
+        def get_prop1(self):
+            return self.prop1
+
+    class TestDevice2(Device):
+        green_mode = server_green_mode
+
+        prop2 = device_property(dtype=int)
+
+        @command(dtype_out=int)
+        def get_prop2(self):
+            return self.prop2
+
+    devices_info = (
+        {
+            "class": TestDevice1,
+            "devices": [{"name": "test/device1/1", "properties": {"prop1": "abcd"}}],
+        },
+        {
+            "class": TestDevice2,
+            "devices": [{"name": "test/device2/2", "properties": {"prop2": 5555}}],
+        },
+    )
+
+    with MultiDeviceTestContext(devices_info) as context:
+        proxy1 = context.get_device("test/device1/1")
+        proxy2 = context.get_device("test/device2/2")
+        assert proxy1.get_prop1() == "abcd"
+        assert proxy2.get_prop2() == 5555
+
+
+@pytest.fixture(
+    # Per test we have the input config tuple, and then the expected exception type
+    params=[
+        # empty config
+        [tuple(), IndexError],
+        # missing/invalid keys
+        [({"not-class": Device1, "devices": [{"name": "test/device1/1"}]},), KeyError],
+        [({"class": Device1, "not-devices": [{"name": "test/device1/1"}]},), KeyError],
+        [({"class": Device1, "devices": [{"not-name": "test/device1/1"}]},), KeyError],
+        # duplicate class
+        [
+            (
+                {"class": Device1, "devices": [{"name": "test/device1/1"}]},
+                {"class": Device1, "devices": [{"name": "test/device1/2"}]},
+            ),
+            ValueError,
+        ],
+        # mixing old "classic" API and new high level API
+        [
+            (
+                {"class": Device1, "devices": [{"name": "test/device1/1"}]},
+                {
+                    "class": (ClassicAPIDeviceClass, ClassicAPIDeviceImpl),
+                    "devices": [{"name": "test/device1/2"}],
+                },
+            ),
+            ValueError,
+        ],
+    ]
+)
+def bad_multi_device_config(request):
+    return request.param
+
+
+def test_multi_bad_config_fails(bad_multi_device_config):
+    bad_config, expected_error = bad_multi_device_config
+    with pytest.raises(expected_error):
+        with MultiDeviceTestContext(bad_config):
+            pass


### PR DESCRIPTION
First of all thanks to @ajoubertza and @tiagocoutinho for your suggestions to the interface.  Also, if you find that the proposed interface could be improved just let me know and I will change it.

DeviceTestContext runs just one Device hence is only useful for unit testing of one Device. Integration tests involving multiple Devices within the same server are not possible. Add MultiDeviceTestContext for that purpose. This context thanks to a little bit more complicated interface allows to run multiple Devices (each of them even exporting multiple devices) all within one server.

At the same time refactor the DeviceTestContext to use the MultipleDeviceTestContext as its base class. This way, the DeviceTestContext is just a simplified interface to its base class.
