### PR TITLE
Reduce six requirement from 1.12 to 1.10

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -435,11 +435,11 @@ def setup_args():
     requires = [
         'boost_python (>=1.33)',
         'numpy (>=1.1)',
-        'six (>=1.12)',
+        'six (>=1.10)',
     ]
 
     install_requires = [
-        'six (>=1.12)',
+        'six (>=1.10)',
     ]
     if PYTHON_VERSION < (3, 4):
         install_requires.append('enum34')

--- a/tango/db.py
+++ b/tango/db.py
@@ -29,7 +29,7 @@ from ._tango import StdStringVector, Database, DbDatum, DbData, \
 
 from .utils import is_pure_str, is_non_str_seq, seq_2_StdStringVector, \
     seq_2_DbDevInfos, seq_2_DbDevExportInfos, seq_2_DbData, DbData_2_dict, \
-    obj_2_property
+    obj_2_property, ensure_binary
 from .utils import document_method as __document_method
 
 
@@ -202,7 +202,7 @@ def __Database__generic_get_property(self, obj_name, value, f):
             if isinstance(e, DbDatum):
                 new_value.append(e)
             else:
-                e = six.ensure_binary(e, 'latin-1')
+                e = ensure_binary(e, 'latin-1')
                 new_value.append(DbDatum(e))
     elif isinstance(value, collections_abc.Mapping):
         new_value = DbData()
@@ -238,7 +238,7 @@ def __Database__generic_delete_property(self, obj_name, value, f):
         new_value.append(value)
     elif is_pure_str(value):
         new_value = DbData()
-        value = six.ensure_binary(value, 'latin-1')
+        value = ensure_binary(value, 'latin-1')
         new_value.append(DbDatum(value))
     elif isinstance(value, collections_abc.Sequence):
         new_value = DbData()
@@ -246,7 +246,7 @@ def __Database__generic_delete_property(self, obj_name, value, f):
             if isinstance(e, DbDatum):
                 new_value.append(e)
             else:
-                e = six.ensure_binary(e, 'latin-1')
+                e = ensure_binary(e, 'latin-1')
                 new_value.append(DbDatum(e))
     elif isinstance(value, collections_abc.Mapping):
         new_value = DbData()

--- a/tango/device_proxy.py
+++ b/tango/device_proxy.py
@@ -34,6 +34,7 @@ from .utils import seq_2_StdStringVector, StdStringVector_2_seq
 from .utils import DbData_2_dict, obj_2_property
 from .utils import document_method as __document_method
 from .utils import dir2
+from .utils import ensure_binary
 
 from .green import green, green_callback
 from .green import get_green_mode
@@ -685,7 +686,7 @@ def __DeviceProxy__delete_property(self, value):
             if isinstance(e, DbDatum):
                 new_value.append(e)
             else:
-                e = six.ensure_binary(e, 'latin-1')
+                e = ensure_binary(e, 'latin-1')
                 new_value.append(DbDatum(e))
     elif isinstance(value, collections_abc.Mapping):
         new_value = DbData()

--- a/tango/utils.py
+++ b/tango/utils.py
@@ -47,7 +47,7 @@ __all__ = (
     "CaselessList", "CaselessDict", "EventCallBack", "get_home",
     "from_version_str_to_hex_str", "from_version_str_to_int",
     "seq_2_StdStringVector", "StdStringVector_2_seq",
-    "dir2", "TO_TANGO_TYPE")
+    "dir2", "TO_TANGO_TYPE", "ensure_binary")
 
 __docformat__ = "restructuredtext"
 
@@ -1070,7 +1070,7 @@ def obj_2_property(value):
             else:
                 if not is_pure_str(v):
                     v = str(v)
-                v = six.ensure_binary(v, encoding='latin-1')
+                v = ensure_binary(v, encoding='latin-1')
                 db_datum.value_string.append(v)
             new_value.append(db_datum)
         value = new_value
@@ -1737,3 +1737,28 @@ def dir2(obj):
         attrs.update(dir2(cls))
     attrs.update(get_attrs(obj))
     return list(attrs)
+
+
+if hasattr(six, "ensure_binary"):
+    ensure_binary = six.ensure_binary
+else:
+    # For older versions of six (<1.12), fallback to local
+    # implementation
+
+    def ensure_binary(s, encoding='utf-8', errors='strict'):
+        """Coerce **s** to six.binary_type.
+        For Python 2:
+          - `unicode` -> encoded to `str`
+          - `str` -> `str`
+        For Python 3:
+          - `str` -> encoded to `bytes`
+          - `bytes` -> `bytes`
+
+        Code taken from https://github.com/benjaminp/six/blob/1.12.0/six.py#L853
+        """
+        if isinstance(s, six.text_type):
+            return s.encode(encoding, errors)
+        elif isinstance(s, six.binary_type):
+            return s
+        else:
+            raise TypeError("not expecting type '%s'" % type(s))


### PR DESCRIPTION
This is to help with Linux packaging - many do not have `python-six` 1.12, so building the package fails.  E.g., on Ubuntu 18.04, version 1.11 is available.

The limit is reduced to 1.10, because that is the version in which the next newest function we require, `create_unbound_method`, was added. 1.10 was released in October 2015.  It is available with Ubuntu 16.04 and Debian 9.

More details in issue: #296