### PR TITLE
Add get_device_attribute_list and missing pipe methods to Database interface

### DIFF
--- a/ext/database.cpp
+++ b/ext/database.cpp
@@ -436,6 +436,9 @@ void export_database()
         .def("get_device_attribute_list",
             (void (Tango::Database::*) (const std::string &, StdStringVector &))
             &Tango::Database::get_device_attribute_list)
+        .def("get_device_pipe_list",
+            (void (Tango::Database::*) (const std::string &, StdStringVector &))
+            &Tango::Database::get_device_pipe_list)
         .def("_get_class_property",
             (void (Tango::Database::*) (std::string, Tango::DbData &))
             &Tango::Database::get_class_property)
@@ -464,6 +467,7 @@ void export_database()
         .def("get_class_attribute_list",
             (Tango::DbDatum (Tango::Database::*) (const std::string &, const std::string &))
             get_class_attribute_list_)
+        .def("get_class_pipe_list", &Tango::Database::get_class_pipe_list)
 
         //
         // Attribute methods

--- a/ext/database.cpp
+++ b/ext/database.cpp
@@ -433,6 +433,9 @@ void export_database()
         .def("get_device_attribute_property_history",
             (Tango::DbHistoryList (Tango::Database::*) (const std::string &, const std::string &, const std::string &))
             get_device_attribute_property_history_)
+        .def("get_device_attribute_list",
+            (void (Tango::Database::*) (const std::string &, StdStringVector &))
+            &Tango::Database::get_device_attribute_list)
         .def("_get_class_property",
             (void (Tango::Database::*) (std::string, Tango::DbData &))
             &Tango::Database::get_class_property)

--- a/ext/database.cpp
+++ b/ext/database.cpp
@@ -35,7 +35,7 @@ struct PyDatabase
                 return bopy::make_tuple();
         }
     };
-    
+
     static inline boost::shared_ptr<Tango::Database>
     makeDatabase_host_port1(const std::string &host, int port)
     {
@@ -120,7 +120,7 @@ struct PyDatabase
         self.get_device_from_alias(input, output);
         return boost::python::str(output);
     }
-    
+
     static inline boost::python::str
     get_alias_from_device(Tango::Database& self, const std::string &input)
     {
@@ -128,7 +128,7 @@ struct PyDatabase
         self.get_alias_from_device(input, output);
         return boost::python::str(output);
     }
-    
+
     static inline boost::python::str
     get_attribute_from_alias(Tango::Database& self, const std::string &input)
     {
@@ -136,7 +136,7 @@ struct PyDatabase
         self.get_attribute_from_alias(input, output);
         return boost::python::str(output);
     }
-    
+
     static inline boost::python::str
     get_alias_from_attribute(Tango::Database& self, const std::string &input)
     {
@@ -231,14 +231,14 @@ void export_database()
         &Tango::Database::import_device;
     Tango::DbDevFullInfo (Tango::Database::*get_device_info_)(std::string &) =
         &Tango::Database::get_device_info;
-    
+
     Tango::DbDatum (Tango::Database::*get_attribute_alias_list_)(std::string &) =
         &Tango::Database::get_attribute_alias_list;
     void (Tango::Database::*put_attribute_alias_)(std::string &, std::string &) =
         &Tango::Database::put_attribute_alias;
     void (Tango::Database::*delete_attribute_alias_)(std::string &) =
         &Tango::Database::delete_attribute_alias;
-    
+
     bopy::class_<Tango::Database, bopy::bases<Tango::Connection> > Database("Database", bopy::init<>())
     ;
 
@@ -252,7 +252,7 @@ void export_database()
         // Pickle
         //
         .def_pickle(PyDatabase::PickleSuite())
-        
+
         //
         // general methods
         //
@@ -272,7 +272,7 @@ void export_database()
         .def("is_multi_tango_host", &Tango::Database::is_multi_tango_host)
         .def("get_file_name", &Tango::Database::get_file_name,
             bopy::return_value_policy<bopy::copy_const_reference>())
-            
+
         //
         // General methods
         //
@@ -303,12 +303,12 @@ void export_database()
 
         .def("add_device", &Tango::Database::add_device)
         .def("delete_device", &Tango::Database::delete_device)
-        .def("import_device", 
+        .def("import_device",
             (Tango::DbDevImportInfo (Tango::Database::*) (const std::string &))
             import_device_)
         .def("export_device", &Tango::Database::export_device)
         .def("unexport_device", &Tango::Database::unexport_device)
-        .def("get_device_info", 
+        .def("get_device_info",
             (Tango::DbDevFullInfo (Tango::Database::*) (const std::string &))
             get_device_info_)
         .def("get_device_name",
@@ -346,7 +346,7 @@ void export_database()
         .def("delete_device_alias",
             (void (Tango::Database::*) (const std::string &))
             delete_device_alias_)
-        
+
         //
         // server methods
         //
@@ -391,7 +391,7 @@ void export_database()
             (Tango::DbDatum (Tango::Database::*) (const std::string &))
             get_device_class_list_)
         .def("get_server_release", &Tango::Database::get_server_release)
-        
+
         //
         // property methods
         //
@@ -486,7 +486,9 @@ void export_database()
             (void (Tango::Database::*) (const std::string &))
             &Tango::Database::unexport_event)
 
-// alias methods
+        //
+        // alias methods
+        //
 
         .def("get_device_from_alias", &PyDatabase::get_device_from_alias)
         .def("get_alias_from_device", &PyDatabase::get_alias_from_device)
@@ -495,4 +497,3 @@ void export_database()
 
         ;
 }
-

--- a/ext/database.cpp
+++ b/ext/database.cpp
@@ -216,6 +216,8 @@ void export_database()
         &Tango::Database::get_device_property_list;
     Tango::DbHistoryList (Tango::Database::*get_device_attribute_property_history_)(std::string &, std::string &, std::string &) =
         &Tango::Database::get_device_attribute_property_history;
+    Tango::DbHistoryList (Tango::Database::*get_device_pipe_property_history_)(std::string &, std::string &, std::string &) =
+        &Tango::Database::get_device_pipe_property_history;
     Tango::DbHistoryList (Tango::Database::*get_class_property_history_)(std::string &, std::string &) =
         &Tango::Database::get_class_property_history;
     Tango::DbDatum (Tango::Database::*get_class_list_)(std::string &) =
@@ -224,6 +226,8 @@ void export_database()
         &Tango::Database::get_class_property_list;
     Tango::DbHistoryList (Tango::Database::*get_class_attribute_property_history_)(std::string &, std::string &, std::string &) =
         &Tango::Database::get_class_attribute_property_history;
+    Tango::DbHistoryList (Tango::Database::*get_class_pipe_property_history_)(std::string &, std::string &, std::string &) =
+        &Tango::Database::get_class_pipe_property_history;
     Tango::DbDatum (Tango::Database::*get_class_attribute_list_)(std::string &, std::string &) =
         &Tango::Database::get_class_attribute_list;
 
@@ -426,13 +430,23 @@ void export_database()
         .def("_get_device_attribute_property",
             (void (Tango::Database::*) (std::string, Tango::DbData &))
             &Tango::Database::get_device_attribute_property)
+        .def("_get_device_pipe_property",
+            (void (Tango::Database::*) (std::string, Tango::DbData &))
+            &Tango::Database::get_device_pipe_property)
         .def("_put_device_attribute_property",
             &Tango::Database::put_device_attribute_property)
+        .def("_put_device_pipe_property",
+            &Tango::Database::put_device_pipe_property)
         .def("_delete_device_attribute_property",
             &Tango::Database::delete_device_attribute_property)
+        .def("_delete_device_pipe_property",
+            &Tango::Database::delete_device_pipe_property)
         .def("get_device_attribute_property_history",
             (Tango::DbHistoryList (Tango::Database::*) (const std::string &, const std::string &, const std::string &))
             get_device_attribute_property_history_)
+        .def("get_device_pipe_property_history",
+            (Tango::DbHistoryList (Tango::Database::*) (const std::string &, const std::string &, const std::string &))
+            get_device_pipe_property_history_)
         .def("get_device_attribute_list",
             (void (Tango::Database::*) (const std::string &, StdStringVector &))
             &Tango::Database::get_device_attribute_list)
@@ -456,13 +470,23 @@ void export_database()
         .def("_get_class_attribute_property",
             (void (Tango::Database::*) (std::string, Tango::DbData &))
             &Tango::Database::get_class_attribute_property)
+        .def("_get_class_pipe_property",
+            (void (Tango::Database::*) (std::string, Tango::DbData &))
+            &Tango::Database::get_class_pipe_property)
         .def("_put_class_attribute_property",
             &Tango::Database::put_class_attribute_property)
+        .def("_put_class_pipe_property",
+            &Tango::Database::put_class_pipe_property)
         .def("_delete_class_attribute_property",
             &Tango::Database::delete_class_attribute_property)
+        .def("_delete_class_pipe_property",
+            &Tango::Database::delete_class_pipe_property)
         .def("get_class_attribute_property_history",
             (Tango::DbHistoryList (Tango::Database::*) (const std::string &, const std::string &, const std::string &))
             get_class_attribute_property_history_)
+        .def("get_class_pipe_property_history",
+            (Tango::DbHistoryList (Tango::Database::*) (const std::string &, const std::string &, const std::string &))
+            get_class_pipe_property_history_)
 
         .def("get_class_attribute_list",
             (Tango::DbDatum (Tango::Database::*) (const std::string &, const std::string &))

--- a/tango/db.py
+++ b/tango/db.py
@@ -802,7 +802,7 @@ def __Database__put_class_attribute_property(self, class_name, value):
             Throws     : ConnectionFailed, CommunicationFailed, DevFailed from device (DB_SQLError)"""
 
     if isinstance(value, DbData):
-        pass
+        new_value = value
     elif is_non_str_seq(value):
         new_value = seq_2_DbData(value)
     elif isinstance(value, collections_abc.Mapping):
@@ -821,12 +821,11 @@ def __Database__put_class_attribute_property(self, class_name, value):
                 else:
                     db_datum.value_string.append(str(v2))
                 new_value.append(db_datum)
-        value = new_value
     else:
         raise TypeError(
             'Value must be a tango.DbData, '
             'a sequence<DbDatum> or a dictionary')
-    return self._put_class_attribute_property(class_name, value)
+    return self._put_class_attribute_property(class_name, new_value)
 
 
 def __Database__delete_class_attribute_property(self, class_name, value):

--- a/tango/db.py
+++ b/tango/db.py
@@ -1857,6 +1857,24 @@ def __doc_Database():
         New in PyTango 7.0.0
     """)
 
+    document_method("get_device_attribute_list", """
+    get_device_attribute_list(self, dev_name, att_list) -> None
+
+            Get the list of attribute(s) with some data defined in database
+            for a specified device. Note that this is not the list of all
+            device attributes because not all attribute(s) have some data
+            in database
+            This corresponds to the pure C++ API call.
+
+        Parameters :
+            - dev_name : (str) device name
+            - att_list [out] : (StdStringVector) array that will contain the
+                               attribute name list
+        Return     : None
+
+        Throws     : ConnectionFailed, CommunicationFailed, DevFailed from device (DB_SQLError)
+    """)
+
     document_method("_get_class_property", """
     _get_class_property(self, class_name, props) -> None
 

--- a/tango/db.py
+++ b/tango/db.py
@@ -1407,7 +1407,7 @@ def __doc_Database():
     document_method("_add_server", """
     _add_server(self, serv_name, dev_info) -> None
 
-            Add a a group of devices to the database.
+            Add a group of devices to the database.
             This corresponds to the pure C++ API call.
 
         Parameters :
@@ -1515,7 +1515,7 @@ def __doc_Database():
     document_method("get_server_class_list", """
     get_server_class_list(self, server) -> DbDatum
 
-            Query the database for a list of classes instancied by the
+            Query the database for a list of classes instantiated by the
             specified server. The DServer class exists in all TANGO servers
             and for this reason this class is removed from the returned list.
 
@@ -1562,7 +1562,7 @@ def __doc_Database():
     get_server_list(self, wildcard) -> DbDatum
 
             Return the list of all servers registered in the database.
-            If wildcard parameter is given, then the the list matching servers
+            If wildcard parameter is given, then the list of matching servers
             will be returned (ex: Serial/\*)
 
         Parameters :
@@ -1573,7 +1573,7 @@ def __doc_Database():
     document_method("get_host_server_list", """
     get_host_server_list(self, host_name) -> DbDatum
 
-            Query the database for a list of servers registred on the specified host.
+            Query the database for a list of servers registered on the specified host.
 
         Parameters :
             - host_name : (str) host name
@@ -1948,7 +1948,7 @@ def __doc_Database():
     _get_class_attribute_property(self, class_name, props) -> None
 
             Query the database for a list of class attribute properties for
-            the specified objec. The attribute names are returned with the
+            the specified object. The attribute names are returned with the
             number of properties specified as their value. The first DbDatum
             element of the returned DbData vector contains the first
             attribute name and the first attribute property number. The
@@ -1981,8 +1981,9 @@ def __doc_Database():
     document_method("get_class_attribute_property_history", """
     get_class_attribute_property_history(self, dev_name, attr_name, prop_name) -> DbHistoryList
 
-            Delete a list of properties for the specified class.
-            This corresponds to the pure C++ API call.
+            Get the list of the last 10 modifications of the specifed class attribute
+            property. Note that prop_name and attr_name can contain a wildcard character
+            (eg: 'prop*').
 
         Parameters :
             - dev_name : (str) device name
@@ -2075,8 +2076,8 @@ def __doc_Database():
     put_attribute_alias(self, attr_name, alias) -> None
 
             Set an alias for an attribute name. The attribute alias is
-            specified by aliasname and the attribute name is specifed by
-            attname. If the given alias already exists, a DevFailed exception
+            specified by alias and the attribute name is specifed by
+            attr_name. If the given alias already exists, a DevFailed exception
             is thrown.
 
         Parameters :
@@ -2174,8 +2175,8 @@ def __doc_DbDatum():
 
 def __doc_DbDevExportInfo():
     DbDevExportInfo.__doc__ = """
-    import info for a device (should be retrived from the database) with
-    the following members:
+    A structure containing export info for a device (should be
+    retrieved from the database) with the following members:
 
         - name : (str) device name
         - ior : (str) CORBA reference of the device
@@ -2186,8 +2187,8 @@ def __doc_DbDevExportInfo():
 
 def __doc_DbDevImportInfo():
     DbDevImportInfo.__doc__ = """
-    import info for a device (should be retrived from the database) with
-    the following members:
+    A structure containing import info for a device (should be
+    retrieved from the database) with the following members:
 
         - name : (str) device name
         - exported : 1 if device is running, 0 else

--- a/tango/db.py
+++ b/tango/db.py
@@ -589,6 +589,39 @@ def __Database__get_device_attribute_property(self, dev_name, value):
         self, dev_name, value, self._get_device_attribute_property)
 
 
+def __Database__get_device_pipe_property(self, dev_name, value):
+    """
+        get_device_pipe_property(self, dev_name, value) -> dict<str, dict<str, seq<str>>>
+
+                Query the database for a list of device pipe properties for the
+                specified device. The method returns all the properties for the specified
+                pipes.
+
+            Parameters :
+                - dev_name : (string) device name
+                - value : can be one of the following:
+
+                    1. str [in] - single pipe properties to be fetched
+                    2. DbDatum [in] - single pipe properties to be fetched
+                    3. DbData [in,out] - several pipe properties to be fetched
+                       In this case (direct C++ API) the DbData will be filled with
+                       the property values
+                    4. sequence<str> [in] - several pipe properties to be fetched
+                    5. sequence<DbDatum> [in] - several pipe properties to be fetched
+                    6. dict<str, obj> [in,out] - keys are pipe names
+                       In this case the given dict values will be changed to contain the
+                       several pipe property values
+
+            Return     :  a dictionary which keys are the pipe names the
+                                 value associated with each key being a another
+                                 dictionary where keys are property names and value is
+                                 a DbDatum containing the property value.
+
+            Throws     : ConnectionFailed, CommunicationFailed, DevFailed from device (DB_SQLError)"""
+    return __Database__generic_get_attr_pipe_property(
+        self, dev_name, value, self._get_device_pipe_property)
+
+
 def __Database__put_device_attribute_property(self, dev_name, value):
     """
         put_device_attribute_property( self, dev_name, value) -> None
@@ -615,6 +648,32 @@ def __Database__put_device_attribute_property(self, dev_name, value):
         self, dev_name, value, self._put_device_attribute_property)
 
 
+def __Database__put_device_pipe_property(self, dev_name, value):
+    """
+        put_device_pipe_property( self, dev_name, value) -> None
+
+                Insert or update a list of properties for the specified device.
+
+            Parameters :
+                - dev_name : (str) device name
+                - value : can be one of the following:
+
+                    1. DbData - several property data to be inserted
+                    2. sequence<DbDatum> - several property data to be inserted
+                    3. dict<str, dict<str, obj>> keys are pipe names and value being another
+                       dictionary which keys are the pipe property names and the value
+                       associated with each key being:
+
+                       3.1 seq<str>
+                       3.2 tango.DbDatum
+
+            Return     : None
+
+            Throws     : ConnectionFailed, CommunicationFailed, DevFailed from device (DB_SQLError)"""
+    return __Database__generic_put_attr_pipe_property(
+        self, dev_name, value, self._put_device_pipe_property)
+
+
 def __Database__delete_device_attribute_property(self, dev_name, value):
     """
         delete_device_attribute_property(self, dev_name, value) -> None
@@ -634,6 +693,27 @@ def __Database__delete_device_attribute_property(self, dev_name, value):
             Throws     : ConnectionFailed, CommunicationFailed, DevFailed from device (DB_SQLError)"""
     return __Database__generic_delete_attr_pipe_property(
         self, dev_name, value, self._delete_device_attribute_property)
+
+
+def __Database__delete_device_pipe_property(self, dev_name, value):
+    """
+        delete_device_pipe_property(self, dev_name, value) -> None
+
+                Delete a list of pipe properties for the specified device.
+
+            Parameters :
+                - devname : (string) device name
+                - propnames : can be one of the following:
+                    1. DbData [in] - several property data to be deleted
+                    2. sequence<str> [in]- several property data to be deleted
+                    3. sequence<DbDatum> [in] - several property data to be deleted
+                    3. dict<str, seq<str>> keys are pipe names and value being a list of pipe property names
+
+            Return     : None
+
+            Throws     : ConnectionFailed, CommunicationFailed, DevFailed from device (DB_SQLError)"""
+    return __Database__generic_delete_attr_pipe_property(
+        self, dev_name, value, self._delete_device_pipe_property)
 
 
 def __Database__get_class_property(self, class_name, value):
@@ -745,6 +825,39 @@ def __Database__get_class_attribute_property(self, class_name, value):
         self, class_name, value, self._get_class_attribute_property)
 
 
+def __Database__get_class_pipe_property(self, class_name, value):
+    """
+        get_class_pipe_property( self, class_name, value) -> dict<str, dict<str, seq<str>>
+
+                Query the database for a list of class pipe properties for the
+                specified class. The method returns all the properties for the specified
+                pipes.
+
+            Parameters :
+                - class_name : (str) class name
+                - propnames : can be one of the following:
+
+                    1. str [in] - single pipe properties to be fetched
+                    2. DbDatum [in] - single pipe properties to be fetched
+                    3. DbData [in,out] - several pipe properties to be fetched
+                       In this case (direct C++ API) the DbData will be filled with the property
+                       values
+                    4. sequence<str> [in] - several pipe properties to be fetched
+                    5. sequence<DbDatum> [in] - several pipe properties to be fetched
+                    6. dict<str, obj> [in,out] - keys are pipe names
+                       In this case the given dict values will be changed to contain the several
+                       pipe property values
+
+            Return     : a dictionary which keys are the pipe names the
+                         value associated with each key being a another
+                         dictionary where keys are property names and value is
+                         a sequence of strings being the property value.
+
+            Throws     : ConnectionFailed, CommunicationFailed, DevFailed from device (DB_SQLError)"""
+    return __Database__generic_get_attr_pipe_property(
+        self, class_name, value, self._get_class_pipe_property)
+
+
 def __Database__put_class_attribute_property(self, class_name, value):
     """
         put_class_attribute_property(self, class_name, value) -> None
@@ -771,6 +884,32 @@ def __Database__put_class_attribute_property(self, class_name, value):
         self, class_name, value, self._put_class_attribute_property)
 
 
+def __Database__put_class_pipe_property(self, class_name, value):
+    """
+        put_class_pipe_property(self, class_name, value) -> None
+
+                Insert or update a list of properties for the specified class.
+
+            Parameters :
+                - class_name : (str) class name
+                - propdata : can be one of the following:
+
+                    1. tango.DbData - several property data to be inserted
+                    2. sequence<DbDatum> - several property data to be inserted
+                    3. dict<str, dict<str, obj>> keys are pipe names and value
+                       being another dictionary which keys are the pipe property
+                       names and the value associated with each key being:
+
+                       3.1 seq<str>
+                       3.2 tango.DbDatum
+
+            Return     : None
+
+            Throws     : ConnectionFailed, CommunicationFailed, DevFailed from device (DB_SQLError)"""
+    return __Database__generic_put_attr_pipe_property(
+        self, class_name, value, self._put_class_pipe_property)
+
+
 def __Database__delete_class_attribute_property(self, class_name, value):
     """
         delete_class_attribute_property(self, class_name, value) -> None
@@ -793,6 +932,30 @@ def __Database__delete_class_attribute_property(self, class_name, value):
                          DevFailed from device (DB_SQLError)"""
     return __Database__generic_delete_attr_pipe_property(
         self, class_name, value, self._delete_class_attribute_property)
+
+
+def __Database__delete_class_pipe_property(self, class_name, value):
+    """
+        delete_class_pipe_property(self, class_name, value) -> None
+
+                Delete a list of pipe properties for the specified class.
+
+            Parameters :
+                - class_name : (str) class name
+                - propnames : can be one of the following:
+
+                    1. DbData [in] - several property data to be deleted
+                    2. sequence<str> [in]- several property data to be deleted
+                    3. sequence<DbDatum> [in] - several property data to be deleted
+                    4. dict<str, seq<str>> keys are pipe names and value being a
+                       list of pipe property names
+
+            Return     : None
+
+            Throws     : ConnectionFailed, CommunicationFailed
+                         DevFailed from device (DB_SQLError)"""
+    return __Database__generic_delete_attr_pipe_property(
+        self, class_name, value, self._delete_class_pipe_property)
 
 
 def __Database__get_service_list(self, filter='.*'):
@@ -823,14 +986,20 @@ def __init_Database():
     Database.delete_device_property = __Database__delete_device_property
     Database.get_device_property_list = __Database__get_device_property_list
     Database.get_device_attribute_property = __Database__get_device_attribute_property
+    Database.get_device_pipe_property = __Database__get_device_pipe_property
     Database.put_device_attribute_property = __Database__put_device_attribute_property
+    Database.put_device_pipe_property = __Database__put_device_pipe_property
     Database.delete_device_attribute_property = __Database__delete_device_attribute_property
+    Database.delete_device_pipe_property = __Database__delete_device_pipe_property
     Database.get_class_property = __Database__get_class_property
     Database.put_class_property = __Database__put_class_property
     Database.delete_class_property = __Database__delete_class_property
     Database.get_class_attribute_property = __Database__get_class_attribute_property
+    Database.get_class_pipe_property = __Database__get_class_pipe_property
     Database.put_class_attribute_property = __Database__put_class_attribute_property
+    Database.put_class_pipe_property = __Database__put_class_pipe_property
     Database.delete_class_attribute_property = __Database__delete_class_attribute_property
+    Database.delete_class_pipe_property = __Database__delete_class_pipe_property
     Database.get_service_list = __Database__get_service_list
     Database.__str__ = __Database__str
     Database.__repr__ = __Database__str
@@ -1727,10 +1896,41 @@ def __doc_Database():
         Throws     : ConnectionFailed, CommunicationFailed, DevFailed from device (DB_SQLError)
     """)
 
+    document_method("_get_device_pipe_property", """
+    _get_device_pipe_property(self, dev_name, props) -> None
+
+            Query the database for a list of device pipe properties for
+            the specified device. The pipe names are specified by the
+            DbData (seq<DbDatum>) structures. The method returns all the
+            properties for the specified pipes in the same DbDatum structures.
+            This corresponds to the pure C++ API call.
+
+        Parameters :
+            - dev_name : (str) device name
+            - props [in, out] : (DbData) pipe names
+        Return     : None
+
+        Throws     : ConnectionFailed, CommunicationFailed, DevFailed from device (DB_SQLError)
+    """)
+
     document_method("_put_device_attribute_property", """
     _put_device_attribute_property(self, dev_name, props) -> None
 
             Insert or update a list of attribute properties for the specified device.
+            This corresponds to the pure C++ API call.
+
+        Parameters :
+            - dev_name : (str) device name
+            - props : (DbData) property data
+        Return     : None
+
+        Throws     : ConnectionFailed, CommunicationFailed, DevFailed from device (DB_SQLError)
+    """)
+
+    document_method("_put_device_pipe_property", """
+    _put_device_pipe_property(self, dev_name, props) -> None
+
+            Insert or update a list of pipe properties for the specified device.
             This corresponds to the pure C++ API call.
 
         Parameters :
@@ -1764,8 +1964,25 @@ def __doc_Database():
         Throws     : ConnectionFailed, CommunicationFailed, DevFailed from device (DB_SQLError)
     """)
 
+    document_method("_delete_device_pipe_property", """
+    _delete_device_pipe_property(self, dev_name, props) -> None
+
+            Delete a list of pipe properties for the specified device.
+            The pipe names are specified by the vector of DbDatum structures. Here
+            See _delete_device_attribute_property for example usage.
+
+            This corresponds to the pure C++ API call.
+
+        Parameters :
+            - serv_name : (str) server name
+            - props : (DbData) pipe property data
+        Return     : None
+
+        Throws     : ConnectionFailed, CommunicationFailed, DevFailed from device (DB_SQLError)
+    """)
+
     document_method("get_device_attribute_property_history", """
-    get_device_attribute_property_history(self, dev_name, att_name, prop_name) -> DbHistoryList
+    get_device_attribute_property_history(self, dev_name, attr_name, prop_name) -> DbHistoryList
 
             Get the list of the last 10 modifications of the specified device
             attribute property. Note that propname and devname can contain a
@@ -1773,7 +1990,7 @@ def __doc_Database():
 
         Parameters :
             - dev_name : (str) device name
-            - attn_ame : (str) attribute name
+            - attr_name : (str) attribute name
             - prop_name : (str) property name
 
         Return     : DbHistoryList containing the list of modifications
@@ -1781,6 +1998,23 @@ def __doc_Database():
         Throws     : ConnectionFailed, CommunicationFailed, DevFailed from device (DB_SQLError)
 
         New in PyTango 7.0.0
+    """)
+
+    document_method("get_device_pipe_property_history", """
+    get_device_pipe_property_history(self, dev_name, pipe_name, prop_name) -> DbHistoryList
+
+            Get the list of the last 10 modifications of the specified device
+            pipe property. Note that propname and devname can contain a
+            wildcard character (eg: 'prop*').
+
+        Parameters :
+            - dev_name : (str) device name
+            - pipe_name : (str) pipe name
+            - prop_name : (str) property name
+
+        Return     : DbHistoryList containing the list of modifications
+
+        Throws     : ConnectionFailed, CommunicationFailed, DevFailed from device (DB_SQLError)
     """)
 
     document_method("get_device_attribute_list", """
@@ -1926,6 +2160,26 @@ def __doc_Database():
         Throws     : ConnectionFailed, CommunicationFailed, DevFailed from device (DB_SQLError)
     """)
 
+    document_method("_get_class_pipe_property", """
+    _get_class_pipe_property(self, class_name, props) -> None
+
+            Query the database for a list of class pipe properties for
+            the specified object. The pipe names are returned with the
+            number of properties specified as their value. The first DbDatum
+            element of the returned DbData vector contains the first
+            pipe name and the first pipe property number. The
+            following DbDatum element contains the first pipe property
+            name and property values.
+            This corresponds to the pure C++ API call.
+
+        Parameters :
+            - class_name : (str) class name
+            - props [in,out] : (DbData) property names
+        Return     : None
+
+        Throws     : ConnectionFailed, CommunicationFailed, DevFailed from device (DB_SQLError)
+    """)
+
     document_method("_put_class_attribute_property", """
     _put_class_attribute_property(self, class_name, props) -> None
 
@@ -1935,6 +2189,48 @@ def __doc_Database():
         Parameters :
             - class_name : (str) class name
             - props : (DbData) property data
+        Return     : None
+
+        Throws     : ConnectionFailed, CommunicationFailed, DevFailed from device (DB_SQLError)
+    """)
+
+    document_method("_put_class_pipe_property", """
+    _put_class_pipe_property(self, class_name, props) -> None
+
+            Insert or update a list of pipe properties for the specified class.
+            This corresponds to the pure C++ API call.
+
+        Parameters :
+            - class_name : (str) class name
+            - props : (DbData) property data
+        Return     : None
+
+        Throws     : ConnectionFailed, CommunicationFailed, DevFailed from device (DB_SQLError)
+    """)
+
+    document_method("_delete_class_attribute_property", """
+    _delete_class_attribute_property(self, class_name, props) -> None
+
+            Delete a list of attribute properties for the specified class.
+            This corresponds to the pure C++ API call.
+
+        Parameters :
+            - class_name : (str) server name
+            - props : (DbData) attribute property data
+        Return     : None
+
+        Throws     : ConnectionFailed, CommunicationFailed, DevFailed from device (DB_SQLError)
+    """)
+
+    document_method("_delete_class_pipe_property", """
+    _delete_class_pipe_property(self, class_name, props) -> None
+
+            Delete a list of pipe properties for the specified class.
+            This corresponds to the pure C++ API call.
+
+        Parameters :
+            - class_name : (str) server name
+            - props : (DbData) pipe property data
         Return     : None
 
         Throws     : ConnectionFailed, CommunicationFailed, DevFailed from device (DB_SQLError)
@@ -1956,6 +2252,22 @@ def __doc_Database():
         Throws     : ConnectionFailed, CommunicationFailed, DevFailed from device (DB_SQLError)
 
         New in PyTango 7.0.0
+    """)
+
+    document_method("get_class_pipe_property_history", """
+    get_class_pipe_property_history(self, dev_name, pipe_name, prop_name) -> DbHistoryList
+
+            Get the list of the last 10 modifications of the specifed class pipe
+            property. Note that prop_name and attr_name can contain a wildcard character
+            (eg: 'prop*').
+
+        Parameters :
+            - dev_name : (str) device name
+            - pipe_name : (str) pipe name
+            - prop_name : (str) property name
+        Return     : DbHistoryList containing the list of modifications
+
+        Throws     : ConnectionFailed, CommunicationFailed, DevFailed from device (DB_SQLError)
     """)
 
     document_method("get_class_attribute_list", """

--- a/tango/db.py
+++ b/tango/db.py
@@ -1874,6 +1874,24 @@ def __doc_Database():
         Throws     : ConnectionFailed, CommunicationFailed, DevFailed from device (DB_SQLError)
     """)
 
+    document_method("get_device_pipe_list", """
+    get_device_pipe_list(self, dev_name, pipe_list) -> None
+
+            Get the list of pipe(s) with some data defined in database
+            for a specified device. Note that this is not the list of all
+            device pipes because not all pipe(s) have some data
+            in database
+            This corresponds to the pure C++ API call.
+
+        Parameters :
+            - dev_name : (str) device name
+            - pipe_list [out] : (StdStringVector) array that will contain the
+                                pipe name list
+        Return     : None
+
+        Throws     : ConnectionFailed, CommunicationFailed, DevFailed from device (DB_SQLError)
+    """)
+
     document_method("_get_class_property", """
     _get_class_property(self, class_name, props) -> None
 
@@ -2027,6 +2045,21 @@ def __doc_Database():
         Throws     : ConnectionFailed, CommunicationFailed, DevFailed from device (DB_SQLError)
 
         New in PyTango 7.0.0
+    """)
+
+    document_method("get_class_pipe_list", """
+    get_class_pipe_list(self, class_name, wildcard) -> DbDatum
+
+            Query the database for a list of pipes defined for the specified
+            class which match the specified wildcard.
+            This corresponds to the pure C++ API call.
+
+        Parameters :
+            - class_name : (str) class name
+            - wildcard : (str) pipe name
+        Return     : DbDatum containing the list of matching pipes for the given class
+
+        Throws     : ConnectionFailed, CommunicationFailed, DevFailed from device (DB_SQLError)
     """)
 
     document_method("get_attribute_alias", """


### PR DESCRIPTION
The `Database` class from `db.py`, which is the interface to the TANGO database, is missing some methods compared to the C++ version.  This PR adds the following:
- `get_device_attribute_list`
- `get_device_pipe_list`
- `get_device_pipe_property `
- `put_device_pipe_property `
- `delete_device_pipe_property `
- `get_device_pipe_property_history`
- `get_class_pipe_property`
- `put_class_pipe_property`
- `delete_class_pipe_property`
- `get_class_pipe_property_history`

Some typos and incorrect docstrings were also fixed.

The PR will be easier to review if the individual commits are considered - especially 070ab3a should be viewed on its own (due to the refactoring in 98ea932).

Closes:  #313
