### PR TITLE
Add omni_thread::ensure_self to AutoPythonAllowThreads

### DIFF
--- a/ext/pyutils.h
+++ b/ext/pyutils.h
@@ -12,6 +12,7 @@
 #pragma once
 
 #include <boost/python.hpp>
+#include <omnithread.h>
 
 namespace bopy = boost::python;
 
@@ -208,6 +209,12 @@ public:
     {
         giveup();
     }
+private:
+  // The following variable ensures usage of this from a non-omnithread will
+  // still get a dummy omnithread ID - cppTango requires threads to
+  // be identifiable in this way.
+  // See https://github.com/tango-controls/pytango/issues/307
+  omni_thread::ensure_self auto_self;
 };
 
 /**


### PR DESCRIPTION
This is to fix issues with multi-threaded applications, when using "standard" threads, i.e. not [omnithreads](https://fossies.org/dox/omniORB-4.2.3/classomni__thread.html).  Typical failures occur when using `DeviceProxy` objects created in different threads that subscribe to events.

The cppTango layer assumes threads are omnithreads, and some of its checks rely on them having an omnithread ID.  This `ensure_self` object creates a dummy ID.

The `AutoPythonAllowThreads` class is a guard used to release the GIL and protects all (most?) network I/O via the cppTango layer.  An `ensure_self` object will now exist for the lifetime of each guard as well.

Closes issue #307
Closes issue #292

(Does not help with issue #315)