### PR TITLE
Add test to verify get_device_properties called on init

### DIFF
--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -322,6 +322,24 @@ def test_device_property_with_default_value(typed_values, server_green_mode):
         assert_close(proxy.get_prop(), expected(value))
 
 
+def test_device_get_device_properties_when_init_device(server_green_mode):
+
+    class TestDevice(Device):
+        green_mode = server_green_mode
+        _got_properties = False
+
+        def get_device_properties(self, *args, **kwargs):
+            super(TestDevice, self).get_device_properties(*args, **kwargs)
+            self._got_properties = True
+
+        @attribute(dtype=bool)
+        def got_properties(self):
+            return self._got_properties
+
+    with DeviceTestContext(TestDevice, process=True) as proxy:
+        assert proxy.got_properties
+
+
 # Test inheritance
 
 def test_inheritance(server_green_mode):


### PR DESCRIPTION
This is to test that `get_device_properties` is called automatically when a device starts up under all versions of Python.  There was a report that it doesn't work under 3.6.