### PR TITLE
Add enum34 to Python 2.7 docker images

### DIFF
--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -57,7 +57,7 @@ conda env export > /opt/current/environment-py${PYTHON_VERSION}-tango${TANGO_VER
 
 For Python 2.7, the requirements are slightly different, so replace the line with `pytest` with:
 ```shell script
-conda install --yes trollius futures 'pytest < 5' pytest-xdist 'gevent != 1.5a1' psutil
+conda install --yes trollius futures 'pytest < 5' pytest-xdist 'gevent != 1.5a1' psutil enum34
 ```
 
 Note:  the packages lists were taken from `.travis.yml` and `setup.py` - these will need

--- a/.devcontainer/environment-py2.7-tango9.2.5.yml
+++ b/.devcontainer/environment-py2.7-tango9.2.5.yml
@@ -13,11 +13,12 @@ dependencies:
   - blas=1.0=mkl
   - boost=1.67.0=py27_4
   - bzip2=1.0.8=h7b6447c_0
-  - ca-certificates=2019.11.27=0
+  - ca-certificates
   - certifi=2019.11.28=py27_0
   - cffi=1.13.2=py27h2e261b9_0
   - configparser=4.0.2=py27_0
   - contextlib2=0.6.0.post1=py_0
+  - enum34=1.1.6=py27_1
   - execnet=1.7.1=py_0
   - funcsigs=1.0.2=py27_0
   - futures=3.3.0=py27_0

--- a/.devcontainer/environment-py2.7-tango9.3.2.yml
+++ b/.devcontainer/environment-py2.7-tango9.3.2.yml
@@ -13,11 +13,12 @@ dependencies:
   - blas=1.0=mkl
   - boost=1.67.0=py27_4
   - bzip2=1.0.8=h7b6447c_0
-  - ca-certificates=2019.11.27=0
+  - ca-certificates
   - certifi=2019.11.28=py27_0
   - cffi=1.13.2=py27h2e261b9_0
   - configparser=4.0.2=py27_0
   - contextlib2=0.6.0.post1=py_0
+  - enum34=1.1.6=py27_1
   - execnet=1.7.1=py_0
   - funcsigs=1.0.2=py27_0
   - futures=3.3.0=py27_0

--- a/.devcontainer/environment-py3.7-tango9.2.5.yml
+++ b/.devcontainer/environment-py3.7-tango9.2.5.yml
@@ -11,7 +11,7 @@ dependencies:
   - blas=1.0=mkl
   - boost=1.67.0=py37_4
   - bzip2=1.0.8=h7b6447c_0
-  - ca-certificates=2019.11.27=0
+  - ca-certificates
   - certifi=2019.11.28=py37_0
   - cffi=1.13.2=py37h2e261b9_0
   - execnet=1.7.1=py_0

--- a/.devcontainer/environment-py3.7-tango9.3.2.yml
+++ b/.devcontainer/environment-py3.7-tango9.3.2.yml
@@ -11,7 +11,7 @@ dependencies:
   - blas=1.0=mkl
   - boost=1.67.0=py37_4
   - bzip2=1.0.8=h7b6447c_0
-  - ca-certificates=2019.11.27=0
+  - ca-certificates
   - certifi=2019.11.28=py37_0
   - cffi=1.13.2=py37h2e261b9_0
   - execnet=1.7.1=py_0


### PR DESCRIPTION
This backport package is required under Python 2.7.

Also removed the pin on `ca-certificates` because these are continuously updated.