### PR TITLE
Update green mode docs and asyncio example

### DIFF
--- a/doc/green_modes/green.rst
+++ b/doc/green_modes/green.rst
@@ -8,6 +8,9 @@ modes have been added: :obj:`~tango.GreenMode.Futures` and
 :obj:`~tango.GreenMode.Gevent`. In version 9.2.0 another one has been
 added: :obj:`~tango.GreenMode.Asyncio`.
 
+.. note:: The preferred mode to use for new projects is :obj:`~tango.GreenMode.Asyncio`.
+          Support for this mode will take priority over the others.
+
 The :obj:`~tango.GreenMode.Futures` uses the standard python module
 :mod:`concurrent.futures`.
 The :obj:`~tango.GreenMode.Gevent` mode uses the well known gevent_ library.

--- a/doc/green_modes/green_modes_server.rst
+++ b/doc/green_modes/green_modes_server.rst
@@ -1,10 +1,6 @@
 Server green modes
 ------------------
 
-.. warning::
-   Green modes for the server side are still very much experimental.
-   If you encounter any issues, please report them on the GitHub issues_ page.
-
 PyTango server API from version 9.2.0 supports two green modes:
 :obj:`~tango.GreenMode.Gevent` and :obj:`~tango.GreenMode.Asyncio`.
 Both can be used in writing new device servers in an asynchronous way.
@@ -26,11 +22,10 @@ as it is a lot harder to debug. You should use this green mode with care.
 change too much in your existing code (or you don't feel comfortable with
 writing syntax of asynchronous calls).
 
-Another thing to have in mind is that the Tango monitor lock is present - you
-can't have two read operations happening concurrently. Any subsequent ones
-will always have to wait for the first one to finish.
+Another thing to keep in mind is that when using :obj:`~tango.GreenMode.Gevent`
+green mode there is no Tango monitor lock!
 
-Greenlets (a task in a background, but handled within the event loop) can be
+Greenlets (a task in the background, but handled within the event loop) can be
 used.
 
 

--- a/doc/green_modes/green_modes_server.rst
+++ b/doc/green_modes/green_modes_server.rst
@@ -23,10 +23,10 @@ change too much in your existing code (or you don't feel comfortable with
 writing syntax of asynchronous calls).
 
 Another thing to keep in mind is that when using :obj:`~tango.GreenMode.Gevent`
-green mode there is no Tango monitor lock!
+green mode is that the Tango monitor lock is disabled, so the client requests can
+be processed concurrently.
 
-Greenlets (a task in the background, but handled within the event loop) can be
-used.
+Greenlets can also be used to spawn tasks in the background.
 
 
 asyncio mode

--- a/doc/how-to-contribute.rst
+++ b/doc/how-to-contribute.rst
@@ -29,6 +29,10 @@ Documentation is written in reStructuredText_ and built with Sphinx_ - it's easy
 It also uses autodoc_ importing docstrings from tango package.
 Theme is not important, a theme prepared for Tango Community can be also used.
 
+To test the docs locally requires Python >= 3.5:
+      - ``$ pip install sphinx sphinx_rtd_theme``
+      - ``$ python setup.py build_doc``
+
 Source code standard
 --------------------
 
@@ -187,7 +191,7 @@ Bump the version with "-dev" in the develop branch
     ``(9, 3, 3, 'dev', 0)``.
   * In ``appveyor.yml``, change ``version``, e.g. from ``9.3.2.{build}`` to
     ``9.3.3.dev0.{build}``.
-   * Create PR, merge to ``develop``.
+  * Create PR, merge to ``develop``.
 
 Create and fill in the release description on GitHub
   * Go to the Tags page: https://github.com/tango-controls/pytango/tags

--- a/examples/asyncio_green_mode/asyncio_device_example.py
+++ b/examples/asyncio_green_mode/asyncio_device_example.py
@@ -14,6 +14,12 @@ class AsyncioDevice(Device):
 
     @command
     async def long_running_command(self):
+        self.set_state(DevState.OPEN)
+        await asyncio.sleep(2)
+        self.set_state(DevState.CLOSE)
+
+    @command
+    async def background_task_command(self):
         loop = asyncio.get_event_loop()
         future = loop.create_task(self.coroutine_target())
 


### PR DESCRIPTION
These changes are based on comments in issue #333.

The fact that "asyncio is preferred" was agreed to at the Tango Kernel Developers meeting on [27/02/2020](https://github.com/tango-controls/tango-kernel-followup/blob/master/2020/2020-02-27/Minutes.md#pytango-news).  gevent and concurrent.futures are still supported, but we favour the asyncio approach going forward as it is the Python standard.