### PR TITLE
Generalise search for libboost_python on POSIX

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -88,7 +88,6 @@ To test the installation, import ``tango`` and check ``tango.utils.info()``::
         Python : 2.7.15
         Numpy  : 1.16.2
         Tango  : 9.3.3
-        Boost  : 0.0.0
 
     PyTango running on:
     ('Linux', 'hostname', '4.4.0-131-generic', '#157-Ubuntu SMP Sat Jul 27 06:00:36 UTC 2019', 'x86_64', 'x86_64')

--- a/README.rst
+++ b/README.rst
@@ -37,7 +37,7 @@ General dependencies:
 Python dependencies:
 
 -  numpy_ >= 1.1
--  six_
+-  six_ >= 1.10
 
 Build dependencies:
 
@@ -51,7 +51,9 @@ Optional dependencies:
 
 .. note:: As a general rule, libtango_ and pytango_ should share the same major
 	  and minor version (for a version ``X.Y.Z``, ``X`` and ``Y`` should
-	  match)
+	  match).
+      On some systems you may need to install ``libtango``, ``omniORB4`` and ``libzmq`` related
+      development packages.
 
 
 Install
@@ -70,9 +72,9 @@ In both cases, the installation takes a few minutes since the ``_tango`` boost
 extension has to compile.
 
 .. note::
-   
-   On some systems you may need to install ``libtango``, ``omniORB4`` and ``libzmq`` related 
-   developement packages.
+   For custom `Boost.Python`_ installation locations, environment variables can be used
+   to modify the default paths.  See the description of the ``BOOST_ROOT`` and related
+   variables in the ``setup.py`` file.
 
 Usage
 -----
@@ -148,7 +150,7 @@ All contributions,  `PR and bug reports`_ are welcome, please see: `How to Contr
 .. _PyPI: http://pypi.python.org/pypi/pytango
 
 .. _libtango: http://tango-controls.org/downloads
-.. _Boost.Python: http://boost.org/doc/libs/1_61_0/libs/python/doc/html
+.. _Boost.Python: https://www.boost.org/doc/libs/release/libs/python/doc/html/index.html
 .. _numpy: http://pypi.python.org/pypi/numpy
 .. _six: http://pypi.python.org/pypi/six
 .. _setuptools: http://pypi.python.org/pypi/setuptools

--- a/setup.py
+++ b/setup.py
@@ -176,11 +176,12 @@ def add_lib_boost(dirs):
         BOOST_ROOT=/opt/my_boost
 
     Alternatively, the header and library folders can be specified
-    individually (do not set BOOST_ROOT):
+    individually (do not set BOOST_ROOT).  For example, if the
+    python.hpp file is in /usr/local/include/boost123/boost/:
 
         BOOST_HEADERS=/usr/local/include/boost123
 
-    and/or:
+    If the libboost_python.so file is in /usr/local/lib/boost123:
 
         BOOST_LIBRARIES=/usr/local/lib/boost123
 

--- a/setup.py
+++ b/setup.py
@@ -159,13 +159,46 @@ def add_lib(name, dirs, sys_libs,
 
 
 def add_lib_boost(dirs):
-    # special boost-python configuration
+    """Add boost-python configuration details.
+
+    There are optional environment variables that can be used for
+    non-standard boost installations.
+
+    The BOOST_ROOT can be used for a custom boost installation in
+    a separate directory, like:
+
+        /opt/my_boost
+            |- include
+            |- lib
+
+    In this case, use:
+
+        BOOST_ROOT=/opt/my_boost
+
+    Alternatively, the header and library folders can be specified
+    individually (do not set BOOST_ROOT):
+
+        BOOST_HEADERS=/usr/local/include/boost123
+
+    and/or:
+
+        BOOST_LIBRARIES=/usr/local/lib/boost123
+
+    Lastly, the boost-python library name can be specified, if the
+    automatic detection is not working.  For example, if the
+    library is libboost_python_custom.so, then use:
+
+        BOOST_PYTHON_LIB=boost_python_custom
+
+    """
 
     BOOST_ROOT = os.environ.get('BOOST_ROOT')
-    BOOST_LIB = os.environ.get('BOOST_LIB')
-    boost_library_name = BOOST_LIB if BOOST_LIB else 'boost_python'
+    BOOST_HEADERS = os.environ.get('BOOST_HEADERS')
+    BOOST_LIBRARIES = os.environ.get('BOOST_LIBRARIES')
+    BOOST_PYTHON_LIB = os.environ.get('BOOST_PYTHON_LIB')
+    boost_library_name = BOOST_PYTHON_LIB if BOOST_PYTHON_LIB else 'boost_python'
     if BOOST_ROOT is None:
-        if POSIX and not BOOST_LIB:
+        if POSIX and not BOOST_PYTHON_LIB:
             # library name differs widely across distributions, so if it
             # wasn't specified as an environment var, then try the
             # various options, being as Python version specific as possible
@@ -182,6 +215,10 @@ def add_lib_boost(dirs):
                 if find_library(candidate):
                     boost_library_name = candidate
                     break
+        if BOOST_HEADERS:
+            dirs['include_dirs'].append(BOOST_HEADERS)
+        if BOOST_LIBRARIES:
+            dirs['library_dirs'].append(BOOST_LIBRARIES)
     else:
         inc_dir = os.path.join(BOOST_ROOT, 'include')
         lib_dirs = [os.path.join(BOOST_ROOT, 'lib')]

--- a/setup.py
+++ b/setup.py
@@ -17,6 +17,8 @@ import runpy
 import struct
 import subprocess
 
+from ctypes.util import find_library
+
 from setuptools import setup, Extension
 from setuptools import Command
 from setuptools.command.build_ext import build_ext as dftbuild_ext
@@ -25,12 +27,6 @@ from setuptools.command.install import install as dftinstall
 from distutils.command.build import build as dftbuild
 from distutils.unixccompiler import UnixCCompiler
 from distutils.version import LooseVersion as V
-
-# Distro import
-try:
-    from pip._vendor import distro
-except ImportError:
-    import platform as distro
 
 # Sphinx imports
 try:
@@ -54,14 +50,6 @@ IS64 = 8 * struct.calcsize("P") == 64
 PYTHON_VERSION = sys.version_info
 PYTHON2 = (2,) <= PYTHON_VERSION < (3,)
 PYTHON3 = (3,) <= PYTHON_VERSION < (4,)
-
-# Linux distribution
-distribution = distro.linux_distribution()[0].lower() if POSIX else ""
-distribution_match = lambda names: any(x in distribution for x in names)
-DEBIAN = distribution_match(['debian', 'ubuntu', 'mint'])
-REDHAT = distribution_match(['redhat', 'fedora', 'centos', 'opensuse'])
-GENTOO = distribution_match(['gentoo'])
-CONDA = 'CONDA_PREFIX' in os.environ
 
 # Arguments
 TESTING = any(x in sys.argv for x in ['test', 'pytest'])
@@ -168,6 +156,44 @@ def add_lib(name, dirs, sys_libs,
         if lib_name.startswith('lib'):
             lib_name = lib_name[3:]
         dirs['libraries'].append(lib_name)
+
+
+def add_lib_boost(dirs):
+    # special boost-python configuration
+
+    BOOST_ROOT = os.environ.get('BOOST_ROOT')
+    BOOST_LIB = os.environ.get('BOOST_LIB')
+    boost_library_name = BOOST_LIB if BOOST_LIB else 'boost_python'
+    if BOOST_ROOT is None:
+        if POSIX and not BOOST_LIB:
+            # library name differs widely across distributions, so if it
+            # wasn't specified as an environment var, then try the
+            # various options, being as Python version specific as possible
+            suffixes = [
+                "{v[0]}{v[1]}".format(v=PYTHON_VERSION),
+                "-{v[0]}{v[1]}".format(v=PYTHON_VERSION),
+                "-py{v[0]}{v[1]}".format(v=PYTHON_VERSION),
+                "{v[0]}-py{v[0]}{v[1]}".format(v=PYTHON_VERSION),
+                "{v[0]}".format(v=PYTHON_VERSION),
+                ""
+            ]
+            for suffix in suffixes:
+                candidate = boost_library_name + suffix
+                if find_library(candidate):
+                    boost_library_name = candidate
+                    break
+    else:
+        inc_dir = os.path.join(BOOST_ROOT, 'include')
+        lib_dirs = [os.path.join(BOOST_ROOT, 'lib')]
+        if IS64:
+            lib64_dir = os.path.join(BOOST_ROOT, 'lib64')
+            if os.path.isdir(lib64_dir):
+                lib_dirs.insert(0, lib64_dir)
+
+        dirs['include_dirs'].append(inc_dir)
+        dirs['library_dirs'].extend(lib_dirs)
+
+    dirs['libraries'].append(boost_library_name)
 
 
 class build(dftbuild):
@@ -366,35 +392,7 @@ def setup_args():
     add_lib('omni', directories, sys_libs, lib_name='omniORB4')
     add_lib('zmq', directories, sys_libs, lib_name='libzmq')
     add_lib('tango', directories, sys_libs, inc_suffix='tango')
-
-    # special boost-python configuration
-
-    BOOST_ROOT = os.environ.get('BOOST_ROOT')
-    boost_library_name = 'boost_python'
-    if BOOST_ROOT is None:
-        if CONDA:
-            suffix = ''
-        elif DEBIAN:
-            suffix = "-py{v[0]}{v[1]}".format(v=PYTHON_VERSION)
-            boost_library_name += suffix
-        elif REDHAT:
-            if PYTHON3:
-                boost_library_name += '3'
-        elif GENTOO:
-            suffix = "-{v[0]}.{v[1]}".format(v=PYTHON_VERSION)
-            boost_library_name += suffix
-    else:
-        inc_dir = os.path.join(BOOST_ROOT, 'include')
-        lib_dirs = [os.path.join(BOOST_ROOT, 'lib')]
-        if IS64:
-            lib64_dir = os.path.join(BOOST_ROOT, 'lib64')
-            if os.path.isdir(lib64_dir):
-                lib_dirs.insert(0, lib64_dir)
-
-        directories['include_dirs'].append(inc_dir)
-        directories['library_dirs'].extend(lib_dirs)
-
-    directories['libraries'].append(boost_library_name)
+    add_lib_boost(directories)
 
     # special numpy configuration
 

--- a/tango/pytango_init.py
+++ b/tango/pytango_init.py
@@ -75,7 +75,6 @@ def init_constants():
     class Runtime(object):
         PY_VERSION = ".".join(map(str, sys.version_info[:3]))
         TANGO_VERSION = tg_rt_ver
-        BOOST_VERSION = '0.0.0'
         if constants.NUMPY_SUPPORT:
             import numpy
             NUMPY_VERSION = numpy.__version__

--- a/tango/utils.py
+++ b/tango/utils.py
@@ -1693,7 +1693,6 @@ PyTango runtime is:
     Python : {2.PY_VERSION}
     Numpy  : {2.NUMPY_VERSION}
     Tango  : {2.TANGO_VERSION}
-    Boost  : {2.BOOST_VERSION}
 
 PyTango running on:
 {2.UNAME}


### PR DESCRIPTION
The naming of the boost library has changed around version 1.67, so the current approach in `setup.py` was failing on newer Linux distributions.  Instead of hardcoding the suffix for different
distributions, use the `ctypes.utils.find_library` function and try the various permutations.  The `find_library` function uses `ldconfig` and a few other tools under the hood, so it should be reliable.

A new environment variable option was added for the case where the search fails.  The library name can be specified directly by setting `BOOST_LIB`.

Fixes:  #300 and #310

Also remove the reporting of boost version from runtime info since we don't get the boost version at runtime - displaying "0.0.0" leads to confusion. 

For interest, here's a review of the current Python boost library names:

Path:  `/usr/lib/x86_64-linux-gnu/`, except for CentOS in `/usr/lib64/`

Distribution | Release  | Boost version | Files
-------------|----------|---------------|-------
Ubuntu | 14.04 (Trusty) | 1.54 & 1.55   | libboost_python-py27.a
| | | | libboost_python-py27.so
| | | | libboost_python-py33.so
| | | | libboost_python-py34.so
| | | | libboost_python.so
Ubuntu | 16.04 (Xenial) | 1.58 | libboost_python-py27.so
| | | | libboost_python-py35.so
| | | | libboost_python.so
Ubuntu | 18.04 (Bionic) | 1.65 | libboost_python-py27.so
| | | | libboost_python-py36.so
| | | | libboost_python.so
| | | | libboost_python3-py36.so
| | | | libboost_python3.so
Ubuntu | 19.04 (Disco) | 1.67 | libboost_python.so
| | | | libboost_python27.so
| | | | libboost_python3-py37.so
| | | | libboost_python3.so
| | | | libboost_python37.so
Ubuntu | 20.04 (Focal) | 1.71 ? | libboost_python37.so
| | | | libboost_python38.so
Debian | 8 (Jessie) | 1.55 | libboost_python-py27.so
| | | | libboost_python-py34.so
| | | | libboost_python.so
Debian | 9 (Stretch) | 1.62 | libboost_python-py27.so
| | | | libboost_python-py35.so
| | | | libboost_python.so
Debian | 10 (Buster) | 1.67 | libboost_python.so
| | | | libboost_python27.so
| | | | libboost_python3-py37.so
| | | | libboost_python3.so
| | | | libboost_python37.so
Debian | 11 (Bullseye) | 1.67 ? | libboost_python.so
| | | | libboost_python27.so
| | | | libboost_python3-py37.so
| | | | libboost_python3.so
| | | | libboost_python37.so
| | | | libboost_python38.so
Debian | Experimental (Sid) | 1.71 ? | libboost_python37.so
| | | | libboost_python38.so
CentOS | 6  | 1.41 | libboost_python-mt.so
| | | | libboost_python.so
CentOS | 7  | 1.53 | libboost_python3-mt.so
| | | | libboost_python3.so
| | | | libboost_python3-mt.so
| | | | libboost_python3.so
CentOS | 8  | 1.66 | libboost_python3.so
Gentoo | 2.6  | 1.72 | libboost_python27.so
| | | | libboost_python36.so
