### PR TITLE
Fix read/write/is_allowed not called for dynamic attribute in async mode server

### DIFF
--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -549,7 +549,10 @@ def test_exeption_propagation(server_green_mode):
 # Test server dynamic attributes async mode
 
 def test_dyn_attr_async_read(typed_values, server_green_mode):
-    dtype, values, expected = typed_values
+    py_dtype, values, expected = typed_values
+
+    import tango.device_proxy.__get_tango_type as get_tango_type
+    dtype = get_tango_type(py_dtype)
 
     class TestDevice(Device):
         green_mode = server_green_mode

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -556,12 +556,13 @@ def test_dyn_attr_async_read(typed_values, server_green_mode):
 
     class TestDevice(Device):
         green_mode = server_green_mode
+        _is_testattr_allowed = True
 
         def __init__(self, *args, **kwargs):
             super(TestDevice, self).__init__(*args, **kwargs)
 
             attr = Attr("TestAttr", dtype, AttrWriteType.READ_WRITE)
-            self.add_attribute(attr, self.read_attr, self.write_attr)
+            self.add_attribute(attr, self.read_attr, self.write_attr, self.is_attr_allowed)
 
         def read_attr(self, attr):
             attr.set_value(self.attr_value)
@@ -569,7 +570,16 @@ def test_dyn_attr_async_read(typed_values, server_green_mode):
         def write_attr(self, attr):
             self.attr_value = attr.get_write_value()
 
+        def is_attr_allowed(self, req_type):
+            return self._is_testattr_allowed
+
     with DeviceTestContext(TestDevice) as proxy:
+        proxy._is_testattr_allowed = True
         for value in values:
             proxy.TestAttr = value
             assert_close(proxy.attr, expected(value))
+
+        proxy._is_testattr_allowed = False
+        for value in values:
+            with pytest.raises(DevFailed) as record:
+                proxy.TestAttr = value

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -581,5 +581,5 @@ def test_dyn_attr_async_read(typed_values, server_green_mode):
 
         proxy._is_testattr_allowed = False
         for value in values:
-            with pytest.raises(DevFailed) as record:
+            with pytest.raises(DevFailed):
                 proxy.TestAttr = value

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -573,7 +573,7 @@ def test_dyn_attr_async_read(typed_values, server_green_mode):
         def is_attr_allowed(self, req_type):
             return self._is_testattr_allowed
 
-        @command
+        @command(dtype_in=bool)
         def make_allowed(self, yesno):
             self._is_testattr_allowed = yesno
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -560,7 +560,7 @@ def test_dyn_attr_async_read(typed_values, server_green_mode):
         def __init__(self, *args, **kwargs):
             super(TestDevice, self).__init__(*args, **kwargs)
 
-            attr = Attr("Attribute", dtype, AttrWriteType.READ_WRITE)
+            attr = Attr("TestAttr", dtype, AttrWriteType.READ_WRITE)
             self.add_attribute(attr, self.read_attr, self.write_attr)
 
         def read_attr(self, attr):
@@ -571,5 +571,5 @@ def test_dyn_attr_async_read(typed_values, server_green_mode):
 
     with DeviceTestContext(TestDevice) as proxy:
         for value in values:
-            proxy.Attribute = value
+            proxy.TestAttr = value
             assert_close(proxy.attr, expected(value))

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -551,8 +551,8 @@ def test_exeption_propagation(server_green_mode):
 def test_dyn_attr_async_read(typed_values, server_green_mode):
     py_dtype, values, expected = typed_values
 
-    import tango.device_proxy.__get_tango_type as get_tango_type
-    dtype = get_tango_type(py_dtype)
+    from tango.device_proxy import __get_tango_type
+    dtype = __get_tango_type(py_dtype)
 
     class TestDevice(Device):
         green_mode = server_green_mode

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -578,7 +578,7 @@ def test_dyn_attr_async_read(typed_values, server_green_mode):
             self._is_testattr_allowed = yesno
 
     with DeviceTestContext(TestDevice) as proxy:
-        proxy._is_testattr_allowed = True
+        proxy.make_allowed(True)
         for value in values:
             proxy.TestAttr = value
             assert_close(proxy.TestAttr, expected(value))

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -577,7 +577,7 @@ def test_dyn_attr_async_read(typed_values, server_green_mode):
         proxy._is_testattr_allowed = True
         for value in values:
             proxy.TestAttr = value
-            assert_close(proxy.attr, expected(value))
+            assert_close(proxy.TestAttr, expected(value))
 
         proxy._is_testattr_allowed = False
         for value in values:


### PR DESCRIPTION
Hi,
this is PR with fix for #173.

Now it is a draft with (failing) tests only