### PR TITLE
Fix #340: build DevFailed origin from format_exception instead of for…

### DIFF
--- a/ext/exception.cpp
+++ b/ext/exception.cpp
@@ -177,9 +177,9 @@ Tango::DevFailed to_dev_failed(PyObject *type, PyObject *value,
 
             PyObject *tbList_ptr = PyObject_CallMethod(
                     tracebackModule,
-                    (char *)"format_tb",
-                    (char *)"O",
-                    traceback == NULL ? Py_None : traceback);
+                    (char *)"format_exception",
+                    (char *)"OOO",
+                    type, value, traceback);
             
             boost::python::object tbList = object(handle<>(tbList_ptr));
             boost::python::str origin = str("").join(tbList);


### PR DESCRIPTION
The DevFailed.origin text is being build from the inspect.format_tb() function
With this PR I propose to build it from inspect.format_exception(). This way the full exception information is seen as requested by #340 

This introduces an incompatibility if someone is parsing the DevFailed.origin error to do fancy stuff.
I don't think anyone is crazy enough to do it but just in case here is the warning. 