### PR TITLE
Extend the info on dependencies in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -31,7 +31,7 @@ PyTango_ is compatible with python 2 and python 3.
 
 General dependencies:
 
--  libtango_ >= 9.2, and its dependencies: omniORB4 and libzmq
+-  libtango_ >= 9.3, and its dependencies: omniORB4 and libzmq
 -  `Boost.Python`_ >= 1.33
 
 Python dependencies:

--- a/README.rst
+++ b/README.rst
@@ -31,7 +31,7 @@ PyTango_ is compatible with python 2 and python 3.
 
 General dependencies:
 
--  libtango_ >= 9.2
+-  libtango_ >= 9.2, and its dependencies: omniORB4 and libzmq
 -  `Boost.Python`_ >= 1.33
 
 Python dependencies:
@@ -69,6 +69,10 @@ Alternatively, PyTango_ can be built and installed from the
 In both cases, the installation takes a few minutes since the ``_tango`` boost
 extension has to compile.
 
+.. note::
+   
+   On some systems you may need to install ``libtango``, ``omniORB4`` and ``libzmq`` related 
+   developement packages.
 
 Usage
 -----

--- a/setup.py
+++ b/setup.py
@@ -456,7 +456,7 @@ def setup_args():
     ]
 
     if PYTHON2:
-        tests_require += ['trollius', 'futures', 'pytest < 5', 'zipp < 2']
+        tests_require += ['trollius', 'futures', 'pytest < 5', 'zipp >= 0.5, < 2']
     else:
         tests_require += ['pytest']
 

--- a/setup.py
+++ b/setup.py
@@ -456,7 +456,7 @@ def setup_args():
     ]
 
     if PYTHON2:
-        tests_require += ['trollius', 'futures', 'pytest < 5']
+        tests_require += ['trollius', 'futures', 'pytest < 5', 'zipp < 2']
     else:
         tests_require += ['pytest']
 


### PR DESCRIPTION
Hi, following @andygotz ask related to [this converation](https://github.com/tango-controls/pytango/issues/339#issuecomment-593986697), I am sending a proposition to update the README with a short extension of the info on dependencies. 