### PR TITLE
Add testing and builds for Python 3.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ env:
     - PYTHON_VERSION=3.5
     - PYTHON_VERSION=3.6
     - PYTHON_VERSION=3.7
+    - PYTHON_VERSION=3.8
 
 cache:
   timeout: 300

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -70,6 +70,27 @@ environment:
       CMAKE_GENERATOR: "Visual Studio 14 2015 Win64"
       boost_version: 1.73.0
 
+    - platform: win32
+      configuration: Release
+      ARCH: win32-msvc14
+      ARCH_PY: win32-msvc14-py38
+      VC_VER: 14.0
+      MSVCVERSION: v140
+      PYTHON_VER: 38
+      PYTHON_ROOT: c:\Python38\
+      CMAKE_GENERATOR: "Visual Studio 14 2015"
+      boost_version: 1.73.0
+    - platform: x64
+      configuration: Release
+      ARCH: x64-msvc14
+      ARCH_PY: x64-msvc14-py38
+      VC_VER: 14.0
+      MSVCVERSION: v140
+      PYTHON_VER: 38
+      PYTHON_ROOT: c:\Python38-x64\
+      CMAKE_GENERATOR: "Visual Studio 14 2015 Win64"
+      boost_version: 1.73.0
+
 init:
   # Tango
   - cmd: cd "C:\projects\"

--- a/setup.py
+++ b/setup.py
@@ -468,6 +468,8 @@ def setup_args():
         'PyTango',  # Backward compatibilty
     ]
 
+    python_requires = '>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*'
+
     requires = [
         'boost_python (>=1.33)',
         'numpy (>=1.1)',
@@ -525,6 +527,7 @@ def setup_args():
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
         'Topic :: Scientific/Engineering',
         'Topic :: Software Development :: Libraries',
     ]
@@ -607,6 +610,7 @@ def setup_args():
         data_files=data_files,
         provides=provides,
         keywords=Release.keywords,
+        python_requires=python_requires,
         requires=requires,
         install_requires=install_requires,
         setup_requires=setup_requires,


### PR DESCRIPTION
Python 3.8 has been out for almost a year now, so give it 1st class support.

Also added `python_requires` field to match the classifiers.  No upper bound, as that is unnecessarily limiting.