### PR TITLE
Fix memory leak for DevEncoded attributes

### DIFF
--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -57,7 +57,7 @@ conda env export > /opt/current/environment-py${PYTHON_VERSION}-tango${TANGO_VER
 
 For Python 2.7, the requirements are slightly different, so replace the line with `pytest` with:
 ```shell script
-conda install --yes trollius futures 'pytest < 5' pytest-xdist 'gevent != 1.5a1' psutil enum34
+conda install --yes trollius futures 'pyparsing < 3' 'pytest < 5' pytest-xdist 'gevent != 1.5a1' psutil enum34
 ```
 
 Note:  the packages lists were taken from `.travis.yml` and `setup.py` - these will need

--- a/ext/server/attribute.cpp
+++ b/ext/server/attribute.cpp
@@ -236,7 +236,6 @@ namespace PyAttribute
 
         PYTG_NEW_TIME_FROM_DOUBLE(t, tv);
 	Tango::DevString val_str_real = val_str;
-        att.set_value(&val_str_real, (Tango::DevUChar*)view.buf, (long)view.len);	
         att.set_value_date_quality(&val_str_real, (Tango::DevUChar*)view.buf,
                                    (long)view.len, tv, quality);
 	PyBuffer_Release(&view);

--- a/setup.py
+++ b/setup.py
@@ -492,7 +492,8 @@ def setup_args():
     ]
 
     if PYTHON2:
-        tests_require += ['trollius', 'futures', 'pytest < 5', 'zipp >= 0.5, < 2']
+        tests_require += [
+            'trollius', 'futures', 'pyparsing < 3', 'pytest < 5', 'zipp >= 0.5, < 2']
     else:
         tests_require += ['pytest']
 


### PR DESCRIPTION
The extra call to `set_value` is not necessary, and is resulting in a memory leak, as some data it allocates is not released.  This is noticeable when pushing a high number of change events for a DevEncoded attribute.

See: https://github.com/tango-controls/TangoTickets/issues/30