### PR TITLE
Fix dynamic enum attributes created without labels #56

### DIFF
--- a/ext/server/attr.cpp
+++ b/ext/server/attr.cpp
@@ -164,6 +164,18 @@ void PyAttr::set_user_prop(vector<Tango::AttrProperty> &user_prop,
             def_prop.set_archive_event_rel_change(prop_value);
         else if (prop_name == "archive_period")
             def_prop.set_archive_event_period(prop_value);
+        else if (prop_name == "enum_labels") {
+            // Convert string back to vector
+            vector<string> labels;
+            string label_str = prop.get_value();
+            size_t offset = 0, pos = 0;
+            while( (pos = label_str.find(",", offset)) != string::npos) {
+                labels.push_back(label_str.substr(offset, pos-offset));
+                offset = pos + 1;
+            }
+            labels.push_back(label_str.substr(offset));
+            def_prop.set_enum_labels(labels);
+        }
     }
 }
 


### PR DESCRIPTION
As stated in issue #56, when creating a dynamic attribute of type DevEnum, the attribute is created without any label.
The problem lies in the function PyAttr::set_user_prop() called by the constructor of PyScaAttr, when a user_prop argument is passed. The properties are parsed and reassembled into a UserAttrProb object by the set_user_prop() function, that lacks support for the "enum_labels" property. That's why the attribute is created without labels.
