### PR TITLE
Bump version after 9.3.2 release

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -83,7 +83,7 @@ To test the installation, import ``tango`` and check ``tango.utils.info()``::
 
     >>> import tango
     >>> print(tango.utils.info())
-    PyTango 9.3.2 (9, 3, 2)
+    PyTango 9.3.3 (9, 3, 3)
     PyTango compiled with:
         Python : 2.7.15
         Numpy  : 1.16.2

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
-version: 9.3.2.{build}
+version: 9.3.3.dev0.{build}
 
 image: Visual Studio 2015
 

--- a/doc/how-to-contribute.rst
+++ b/doc/how-to-contribute.rst
@@ -86,9 +86,9 @@ Pick a version number
     number should correspond the current development number since each
     release process finishes with a version bump.
   * Patch release example:
-      - ``9.3.2.devN`` or ``9.3.2aN`` or ``9.3.2bN`` (current development branch)
-      - changes to ``9.3.2`` (the actual release)
-      - changes to ``9.3.3.dev0`` (bump the patch version at the end of the release process)
+      - ``9.3.3.devN`` or ``9.3.3aN`` or ``9.3.3bN`` (current development branch)
+      - changes to ``9.3.3`` (the actual release)
+      - changes to ``9.3.4.dev0`` (bump the patch version at the end of the release process)
 
 Create an issue in Github
   * This is to inform the community that a release is planned.
@@ -113,11 +113,11 @@ Create an issue in Github
   * A check list in this form on github can be ticked off as the work progresses.
 
 Make a branch from ``develop`` to prepare the release
-  * Example branch name: ``prepare-v9.3.2``.
+  * Example branch name: ``prepare-v9.3.3``.
   * Edit the changelog (in ``docs/revision.rst``).  Include *all* pull requests
     since the previous release.
   * Bump the versions (``tango/release.py`` and ``appveyor.yml``).
-    E.g. ``version_info = (9, 3, 2)``, and ``version: 9.3.2.{build}``
+    E.g. ``version_info = (9, 3, 3)``, and ``version: 9.3.3.{build}``
   * Create a pull request to get these changes reviewed before proceeding.
 
 Merge ``stable`` into ``develop``
@@ -145,7 +145,7 @@ Make sure the documentation is updated
   * Readthedocs *should* automatically build the docs for each:
       - push to develop (latest docs)
       - push to stable (stable docs)
-      - new tags (e.g v9.3.2)
+      - new tags (e.g v9.3.3)
   * *But*, the webhooks are somehow broken, so it probably won't work automatically!
       - Trigger the builds manually here:  https://readthedocs.org/projects/pytango/builds/
       - Set the new version to "active" here:
@@ -156,8 +156,8 @@ Create an annotated tag for the release
   * Create tag:
       - ``$ git checkout stable``
       - ``$ git pull``
-      - ``$ git tag -a -m "tag v9.3.2" v9.3.2``
-      - ``$ git push -v origin refs/tags/v9.3.2``
+      - ``$ git tag -a -m "tag v9.3.3" v9.3.3``
+      - ``$ git push -v origin refs/tags/v9.3.3``
 
 Upload the new version to PyPI
   * Log in to https://pypi.org.
@@ -166,31 +166,31 @@ Upload the new version to PyPI
   * Build release from the tagged commit:
       - ``$ git clean -xfd  # Warning - remove all non-versioned files and directories``
       - ``$ git fetch``
-      - ``$ git checkout v9.3.2``
+      - ``$ git checkout v9.3.3``
       - ``$ python setup.py sdist``
   * Optional:  Upload to https://test.pypi.org, and make sure all is well:
-      - ``$ twine upload -r testpypi dist/pytango-9.3.2.tar.gz``
+      - ``$ twine upload -r testpypi dist/pytango-9.3.3.tar.gz``
   * Optional:  Test installation (in a virtualenv):
       - ``$ pip install -i https://test.pypi.org/simple/ pytango``
   * Upload the source tarball to the real PyPI:
-      - ``$ twine upload dist/pytango-9.3.2.tar.gz``
+      - ``$ twine upload dist/pytango-9.3.3.tar.gz``
   * Run build for the tag on AppVeyor, download artifacts, and upload wheels:
-      - ``$ twine upload dist/pytango-9.3.2-cp27-cp27m-win32.whl``
-      - ``$ twine upload dist/pytango-9.3.2-cp27-cp27m-win_amd64.whl``
-      - ``$ twine upload dist/pytango-9.3.2-cp36-cp36m-win32.whl``
-      - ``$ twine upload dist/pytango-9.3.2-cp36-cp36m-win_amd64.whl``
-      - ``$ twine upload dist/pytango-9.3.2-cp37-cp37m-win32.whl``
-      - ``$ twine upload dist/pytango-9.3.2-cp37-cp37m-win_amd64.whl``
+      - ``$ twine upload dist/pytango-9.3.3-cp27-cp27m-win32.whl``
+      - ``$ twine upload dist/pytango-9.3.3-cp27-cp27m-win_amd64.whl``
+      - ``$ twine upload dist/pytango-9.3.3-cp36-cp36m-win32.whl``
+      - ``$ twine upload dist/pytango-9.3.3-cp36-cp36m-win_amd64.whl``
+      - ``$ twine upload dist/pytango-9.3.3-cp37-cp37m-win32.whl``
+      - ``$ twine upload dist/pytango-9.3.3-cp37-cp37m-win_amd64.whl``
 
 Bump the version with "-dev" in the develop branch
-  * Make branch like ``bump-v9.3.2.dev.0`` from head of ``develop``.
-  * Change all references to next version.  E.g. if releasing
-    v9.3.2, then update references to v9.3.3.
-  * This includes files like ``README.rst``, ``doc/howto.rst``, ``doc/start.rst``.
-  * In ``tango/release.py``, change ``version_info``, e.g. from ``(9, 3, 2)`` to
-    ``(9, 3, 3, 'dev', 0)``.
-  * In ``appveyor.yml``, change ``version``, e.g. from ``9.3.2.{build}`` to
-    ``9.3.3.dev0.{build}``.
+  * Make branch like ``bump-dev-version`` from head of ``develop``.
+  * Change all references to next version and next + 1.  E.g. if releasing
+    v9.3.3, then update v9.3.4 to v9.3.5 and v9.3.3 to v9.3.4.
+  * This includes files like ``README.rst``, ``doc/howto.rst``, ``doc/start.rst``, ``doc/how-to-contribute.rst``.
+  * In ``tango/release.py``, change ``version_info``, e.g. from ``(9, 3, 3)`` to
+    ``(9, 3, 4, 'dev', 0)``.
+  * In ``appveyor.yml``, change ``version``, e.g. from ``9.3.3.{build}`` to
+    ``9.3.4.dev0.{build}``.
   * Create PR, merge to ``develop``.
 
 Create and fill in the release description on GitHub

--- a/doc/howto.rst
+++ b/doc/howto.rst
@@ -44,9 +44,9 @@ The PyTango version::
 
     >>> import tango
     >>> tango.__version__
-    '9.3.2'
+    '9.3.3'
     >>> tango.__version_info__
-    (9, 3, 2)
+    (9, 3, 3)
 
 and the Tango C++ library version that PyTango was compiled with::
 

--- a/doc/start.rst
+++ b/doc/start.rst
@@ -115,6 +115,6 @@ To test the installation, import ``tango`` and check ``tango.Release.version``:
 .. sourcecode:: console
 
     $ python -c "import tango; print(tango.Release.version)"
-    9.3.2
+    9.3.3
 
 Next steps: Check out the :ref:`pytango-quick-tour`.

--- a/tango/release.py
+++ b/tango/release.py
@@ -45,7 +45,7 @@ class Release:
         - license: (str) the license
     """
     name = 'pytango'
-    version_info = (9, 3, 2)
+    version_info = (9, 3, 3, 'dev', 0)
     version = '.'.join(map(str, version_info[:3]))
     release = ''.join(map(str, version_info[3:]))
     separator = '.' if 'dev' in release or 'post' in release else ''


### PR DESCRIPTION
(This is tedious to do manually - would be nice to move to something like https://github.com/peritus/bumpversion)