### PR TITLE
Fix sphinx v3 warning

### DIFF
--- a/tango/device_server.py
+++ b/tango/device_server.py
@@ -1396,6 +1396,7 @@ def __doc_extra_DeviceImpl(cls):
         Parameters :
             attr_list : (sequence<int>) list of indices in the device object attribute vector
                         of an attribute to be read.
+
         Return     : None
 
         Throws     : DevFailed This method does not throw exception but a redefined method can.


### PR DESCRIPTION
When building docs for a Device class written with low level API
(which must define `read_attr_hardware()`) the following warning is raised:
"docstring of sardana.tango.macroserver.MacroServer.MacroServer.read_attr_hardware:9:
WARNING: Definition list ends without a blank line; unexpected unindent.".
Introduce a missing blank line.

Note that I was not able to reproduce the warning when building the PyTango docs.
It only happens when building my device docs (in Sardana) even if we simply define an empy method without docstring:

```python
    def read_attr_hardware(self, data):
        pass
```
Maybe it has to do with the way the docsting is injected with the `__doc_extra_DeviceImpl.document_method()`.
