### PR TITLE
Linked to static Pthread_win. Solves #355

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -198,7 +198,7 @@ target_link_libraries(${PROJECT_NAME} PUBLIC $ENV{TANGO_ROOT}/lib/libtango.lib
                                              $ENV{TANGO_ROOT}/lib/omnithread.lib
                                              $ENV{TANGO_ROOT}/lib/msvcstub.lib)
 target_link_libraries(${PROJECT_NAME} PUBLIC ws2_32 mswsock advapi32 comctl32 odbc32)
-target_link_libraries(${PROJECT_NAME} PUBLIC $ENV{TANGO_ROOT}/lib/pthreadVC2.lib)
+target_link_libraries(${PROJECT_NAME} PUBLIC $ENV{TANGO_ROOT}/lib/pthreadVC2-s.lib)
 target_link_libraries(${PROJECT_NAME} PUBLIC $ENV{TANGO_ROOT}/lib/libzmq-v${VCSTR}-mt-s-${ZMQ_VERSION_}.lib)
 target_link_libraries(${PROJECT_NAME} PUBLIC $ENV{BOOST_ROOT}/lib/libboost_python$ENV{PYTHON_VER}-vc${VCSTR}-mt-s-x${PY_TARGET}-${BOOST_VERSION_}.lib)
 target_link_libraries(${PROJECT_NAME} PUBLIC $ENV{PYTHON_ROOT}/libs/python$ENV{PYTHON_VER}.lib)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,7 +17,7 @@ add_definitions(-DNPY_NO_DEPRECATED_API)
 add_definitions(-DBOOST_PYTHON_STATIC_LIB)
 add_definitions(-DBOOST_ALL_NO_LIB)
 add_definitions(-DZMQ_STATIC)
-add_definitions(-D__POSIX_NT__)
+# add_definitions(-D__POSIX_NT__) #not present in cppTango build, try to make args identical
 
 if(CMAKE_SIZEOF_VOID_P EQUAL 8)
   set(PY_TARGET "64")


### PR DESCRIPTION
To avoid DLL dependency in python package, and since all other libs are statically linked, too. Solves #355 

(Untested since I would have to set up a build env, hope the CI test will do. If not, sorry, this is my first PR, I can manually compile it locally if necessary)

Things to consider:
* You often read never to mix static and dynamic linking. Here, all the other libs are static, too, so this should be fine, correct?
* If not, keeping the dynamic link is also fine, the DLL could be added to `setup.py` in `package_data` (and maybe to `appveyor.yml` to copy the right architecture/version).
* To test the linking, it might be necessary to call the exact functions introduced in 9.3.2 which use Pthreads to be sure there are no segfaults/memory errors (not an expert here)