### PR TITLE
MultiDeviceTestContext example

### DIFF
--- a/examples/multidevicetestcontext/conftest.py
+++ b/examples/multidevicetestcontext/conftest.py
@@ -1,0 +1,65 @@
+"""
+A module defining pytest fixtures for testing ska.mccs.
+
+Requires pytest and pytest-mock
+"""
+from collections import defaultdict
+import pytest
+import socket
+import tango
+from tango.test_context import MultiDeviceTestContext, get_host_ip
+from ska.mccs import MccsMaster, MccsSubarray
+
+devices_info = [
+    {
+        "class": MccsMaster,
+        "devices": (
+            {
+                "name": "low/elt/master",
+                "properties": {
+                    "MccsSubarrays": ["low/elt/subarray_1"],
+                }
+            },
+        )
+    },
+    {
+        "class": MccsSubarray,
+        "devices": [
+            {
+                "name": "low/elt/subarray_1",
+                "properties": {
+                }
+            },
+        ]
+    },
+]
+
+@pytest.fixture(scope="function")
+def tango_context(mocker):
+    """
+    Creates and returns a TANGO MultiDeviceTestContext object, with
+    tango.DeviceProxy patched to work around a name-resolving issue.
+    """
+    def _get_open_port():
+        s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        s.bind(("", 0))
+        s.listen(1)
+        port = s.getsockname()[1]
+        s.close()
+        return port
+
+    HOST = get_host_ip()
+    PORT = _get_open_port()
+
+    _DeviceProxy = tango.DeviceProxy
+    mocker.patch(
+        'tango.DeviceProxy',
+        wraps=lambda fqdn, *args, **kwargs: _DeviceProxy(
+            "tango://{0}:{1}/{2}#dbase=no".format(HOST, PORT, fqdn),
+            *args,
+            **kwargs
+        )
+    )
+
+    with MultiDeviceTestContext(devices_info, host=HOST, port=PORT) as context:
+        yield context

--- a/examples/multidevicetestcontext/conftest.py
+++ b/examples/multidevicetestcontext/conftest.py
@@ -1,15 +1,27 @@
+"""
+A module defining pytest fixtures for testing with MultiDeviceTestContext
+Requires pytest and pytest-mock
+"""
+
 from collections import defaultdict
 import pytest
 import socket
 import tango
 from tango.test_context import MultiDeviceTestContext, get_host_ip
 
+
 @pytest.fixture(scope="module")
 def devices_info(request):
     yield getattr(request.module, "devices_info")
 
+    
 @pytest.fixture(scope="function")
 def tango_context(mocker, devices_info):
+    """
+    Creates and returns a TANGO MultiDeviceTestContext object, with
+    tango.DeviceProxy patched to work around a name-resolving issue.
+    """
+    
     def _get_open_port():
         s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         s.bind(("", 0))
@@ -31,5 +43,5 @@ def tango_context(mocker, devices_info):
         )
     )
 
-    with MultiDeviceTestContext(devices_info, host=HOST, port=PORT) as context:
+    with MultiDeviceTestContext(devices_info, host=HOST, port=PORT, process=True) as context:
         yield context

--- a/examples/multidevicetestcontext/conftest.py
+++ b/examples/multidevicetestcontext/conftest.py
@@ -1,45 +1,15 @@
-"""
-A module defining pytest fixtures for testing ska.mccs.
-
-Requires pytest and pytest-mock
-"""
 from collections import defaultdict
 import pytest
 import socket
 import tango
 from tango.test_context import MultiDeviceTestContext, get_host_ip
-from ska.mccs import MccsMaster, MccsSubarray
 
-devices_info = [
-    {
-        "class": MccsMaster,
-        "devices": (
-            {
-                "name": "low/elt/master",
-                "properties": {
-                    "MccsSubarrays": ["low/elt/subarray_1"],
-                }
-            },
-        )
-    },
-    {
-        "class": MccsSubarray,
-        "devices": [
-            {
-                "name": "low/elt/subarray_1",
-                "properties": {
-                }
-            },
-        ]
-    },
-]
+@pytest.fixture(scope="module")
+def devices_info(request):
+    yield getattr(request.module, "devices_info")
 
 @pytest.fixture(scope="function")
-def tango_context(mocker):
-    """
-    Creates and returns a TANGO MultiDeviceTestContext object, with
-    tango.DeviceProxy patched to work around a name-resolving issue.
-    """
+def tango_context(mocker, devices_info):
     def _get_open_port():
         s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         s.bind(("", 0))

--- a/examples/multidevicetestcontext/test_integration.py
+++ b/examples/multidevicetestcontext/test_integration.py
@@ -1,39 +1,106 @@
 import pytest
-
-from tango import DevFailed, DevSource, DevState
-
-from ska.base.control_model import AdminMode
+import tango
+from tango.server import Device, attribute, command, device_property
 
 
-class TestMccsIntegration:
-    """
-    Integration test cases for the Mccs device classes
-    """
+class Master(Device):
+    WorkerFQDNs = device_property(dtype="DevVarStringArray")
 
-    def test_master_can_enable_subarray(self, tango_context):
-        """
-        Test that a MccsMaster device can enable an MccsSubarray device.
+    @command(dtype_in="DevLong")
+    def Turn_Worker_On(self, worker_id):
+        worker_fqdn = self.WorkerFQDNs[worker_id - 1]
+        worker_device = tango.DeviceProxy(worker_fqdn)
+        worker_device.is_on = True
 
-        Uses the `tango_context` pytest fixture.
-        """
-        master = tango_context.get_device("low/elt/master")
-        subarray = tango_context.get_device("low/elt/subarray_1")
+    @command(dtype_in="DevLong")
+    def Turn_Worker_Off(self, worker_id):
+        worker_fqdn = self.WorkerFQDNs[worker_id - 1]
+        worker_device = tango.DeviceProxy(worker_fqdn)
+        worker_device.is_on = False
 
-        # check subarray is disabled
-        assert subarray_1.adminMode == AdminMode.OFFLINE
-        assert subarray_1.State() == DevState.DISABLE
 
-        # enable subarray
-        master.EnableSubarray(1)
+class Worker(Device):
+    def init_device(self):
+        self._is_on = False
 
-        # check subarray 1 is enabled.
-        assert subarray_1.adminMode == AdminMode.ONLINE
-        assert subarray_1.State() == DevState.OFF
+    is_on = attribute(
+        dtype=tango.DevBoolean,
+        access=tango.AttrWriteType.READ_WRITE,
+    )
 
-        # try to enable subarray 1 again -- this should fail
-        with pytest.raises(DevFailed):
-            master.EnableSubarray(1)
+    def read_is_on(self):
+        return self._is_on
 
-        # check failure has no side-effect
-        assert subarray_1.adminMode == AdminMode.ONLINE
-        assert subarray_1.State() == DevState.OFF
+    def write_is_on(self, value):
+        self._is_on = value
+
+
+devices_info = [
+    {
+        "class": Master,
+        "devices": (
+            {
+                "name": "device/master/1",
+                "properties": {
+                    "WorkerFQDNs": [
+                        "device/worker/1",
+                        "device/worker/2"
+                    ],
+                }
+            },
+        )
+    },
+    {
+        "class": Worker,
+        "devices": [
+            {
+                "name": "device/worker/1",
+                "properties": {
+                }
+            },
+            {
+                "name": "device/worker/2",
+                "properties": {
+                }
+            },
+        ]
+    },
+]
+
+
+class TestMasterWorkerIntegration:
+    def test_master_turn_worker_on(self, tango_context):
+        master = tango_context.get_device("device/master/1")
+        worker_1 = tango_context.get_device("device/worker/1")
+        worker_2 = tango_context.get_device("device/worker/2")
+
+        # check initial state: both workers are off
+        assert worker_1.is_on == False
+        assert worker_2.is_on == False
+
+        # tell master to enable worker_1
+        master.turn_worker_on(1)
+
+        # check worker_1 is now on, and worker_2 is still off
+        assert worker_1.is_on == True
+        assert worker_2.is_on == False
+
+    def test_master_turn_worker_off(self, tango_context):
+        master = tango_context.get_device("device/master/1")
+        worker_1 = tango_context.get_device("device/worker/1")
+        worker_2 = tango_context.get_device("device/worker/2")
+
+        # tell master to enable both workers
+        master.turn_worker_on(1)
+        master.turn_worker_on(2)
+
+        # check initial state: both workers are on
+        assert worker_1.is_on == True
+        assert worker_2.is_on == True
+
+        # tell master to disable worker_1
+        master.turn_worker_off(1)
+
+        # check worker_1 is now off, and worker_2 is still on
+        assert worker_1.is_on == False
+        assert worker_2.is_on == True

--- a/examples/multidevicetestcontext/test_integration.py
+++ b/examples/multidevicetestcontext/test_integration.py
@@ -1,0 +1,39 @@
+import pytest
+
+from tango import DevFailed, DevSource, DevState
+
+from ska.base.control_model import AdminMode
+
+
+class TestMccsIntegration:
+    """
+    Integration test cases for the Mccs device classes
+    """
+
+    def test_master_can_enable_subarray(self, tango_context):
+        """
+        Test that a MccsMaster device can enable an MccsSubarray device.
+
+        Uses the `tango_context` pytest fixture.
+        """
+        master = tango_context.get_device("low/elt/master")
+        subarray = tango_context.get_device("low/elt/subarray_1")
+
+        # check subarray is disabled
+        assert subarray_1.adminMode == AdminMode.OFFLINE
+        assert subarray_1.State() == DevState.DISABLE
+
+        # enable subarray
+        master.EnableSubarray(1)
+
+        # check subarray 1 is enabled.
+        assert subarray_1.adminMode == AdminMode.ONLINE
+        assert subarray_1.State() == DevState.OFF
+
+        # try to enable subarray 1 again -- this should fail
+        with pytest.raises(DevFailed):
+            master.EnableSubarray(1)
+
+        # check failure has no side-effect
+        assert subarray_1.adminMode == AdminMode.ONLINE
+        assert subarray_1.State() == DevState.OFF

--- a/examples/multidevicetestcontext/test_integration.py
+++ b/examples/multidevicetestcontext/test_integration.py
@@ -21,6 +21,7 @@ class Master(Device):
 
 class Worker(Device):
     def init_device(self):
+        super(Worker, self).init_device()
         self._is_on = False
 
     is_on = attribute(


### PR DESCRIPTION
This pull request provides an example of using MultiDeviceTestContext. It provides a pytest fixture with a workaround for the name resolution issue decribed in #357. 