### PR TITLE
Fix convert2array for Unicode to DevVarStringArray (Py3)

### DIFF
--- a/ext/from_py.cpp
+++ b/ext/from_py.cpp
@@ -96,6 +96,7 @@ void convert2array(const object &py_value, Tango::DevVarStringArray & result)
     else if(PyUnicode_Check(py_value_ptr))
     {
         PyObject* py_bytes_value_ptr = PyUnicode_AsLatin1String(py_value_ptr);
+        result.length(1);
         result[0] = CORBA::string_dup(PyBytes_AS_STRING(py_bytes_value_ptr));
         Py_DECREF(py_bytes_value_ptr);
     }

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -439,6 +439,24 @@ def test_device_get_device_properties_when_init_device(server_green_mode):
         assert proxy.got_properties
 
 
+def test_device_get_attr_config(server_green_mode):
+
+    class TestDevice(Device):
+        green_mode = server_green_mode
+
+        @attribute(dtype=bool)
+        def attr_config_ok(self):
+            # testing that call to get_attribute_config for all types of
+            # input arguments gives same result and doesn't raise an exception
+            ac1 = self.get_attribute_config(b"attr_config_ok")
+            ac2 = self.get_attribute_config(u"attr_config_ok")
+            ac3 = self.get_attribute_config(["attr_config_ok"])
+            return repr(ac1) == repr(ac2) == repr(ac3)
+
+    with DeviceTestContext(TestDevice, process=True) as proxy:
+        assert proxy.attr_config_ok
+
+
 # Test inheritance
 
 def test_inheritance(server_green_mode):


### PR DESCRIPTION
Looking at the implementation for the PyBytes case, the PyUnicode case also needs to allocate a space in the result array before accessing. 

This was causing `RuntimeError: unidentifiable C++ exception` when calling the `Device.get_attribute_config` method with a Unicode string.  That will be most likely to occur in Python 3, where the native string type is Unicode.

Closes #361 