### PR TITLE
Update Windows CI and dev containers to boost 1.73.0

### DIFF
--- a/.devcontainer/environment-py2.7-tango9.3.4.yml
+++ b/.devcontainer/environment-py2.7-tango9.3.4.yml
@@ -1,21 +1,22 @@
 name: env-py2.7-tango9.3.4
 channels:
-  - conda-forge
   - tango-controls
+  - conda-forge
   - main
   - defaults
 dependencies:
   - _libgcc_mutex=0.1=main
   - apipkg=1.5=py27_0
   - atomicwrites=1.4.0=py_0
-  - attrs=19.3.0=py_0
+  - attrs=20.1.0=py_0
   - backports=1.0=py_2
   - binutils_impl_linux-64=2.33.1=he6710b0_7
   - binutils_linux-64=2.33.1=h9595d00_15
   - blas=1.0=mkl
-  - boost=1.67.0=py27_4
+  - boost=1.70.0=py27h9de70de_1
+  - boost-cpp=1.70.0=ha2d47e9_1
   - bzip2=1.0.8=h7b6447c_0
-  - ca-certificates=2020.6.24=0
+  - ca-certificates=2020.7.22=0
   - certifi=2019.11.28=py27_0
   - cffi=1.14.0=py27he30daa8_1
   - configparser=4.0.2=py27_0
@@ -34,16 +35,15 @@ dependencies:
   - gxx_linux-64=7.3.0=h553295d_15
   - icu=58.2=he6710b0_3
   - importlib_metadata=1.3.0=py27_0
-  - intel-openmp=2020.1=217
+  - intel-openmp=2020.2=254
   - ld_impl_linux-64=2.33.1=h53a641e_7
-  - libboost=1.67.0=h46d08c1_4
-  - libedit=3.1.20191231=h7b6447c_0
+  - libedit=3.1.20191231=h14c3975_1
   - libffi=3.3=he6710b0_2
   - libgcc-ng=9.1.0=hdf63c60_0
   - libgfortran-ng=7.3.0=hdf63c60_0
   - libsodium=1.0.18=h7b6447c_0
   - libstdcxx-ng=9.1.0=hdf63c60_0
-  - mkl=2020.1=217
+  - mkl=2020.2=256
   - mkl-service=2.3.0=py27he904b0f_0
   - mkl_fft=1.0.15=py27ha843d7b_0
   - mkl_random=1.1.0=py27hd6b4f25_0
@@ -58,23 +58,22 @@ dependencies:
   - pluggy=0.13.1=py27_0
   - psutil=5.6.7=py27h7b6447c_0
   - py=1.9.0=py_0
-  - py-boost=1.67.0=py27h04863e7_4
-  - pycparser=2.20=py_0
+  - pycparser=2.20=py_2
   - pyparsing=2.4.7=py_0
   - pytest=4.6.2=py27_0
-  - pytest-forked=1.1.3=py_0
-  - pytest-xdist=1.32.0=py_0
+  - pytest-forked=1.3.0=py_0
+  - pytest-xdist=1.34.0=py_0
   - python=2.7.18=h15b4118_1
   - readline=8.0=h7b6447c_0
   - scandir=1.10.0=py27h7b6447c_0
   - setuptools=44.0.0=py27_0
   - six=1.15.0=py_0
-  - sqlite=3.32.3=h62c20be_0
+  - sqlite=3.33.0=h62c20be_0
   - tango-test=3.0=h6bb024c_2
   - tk=8.6.10=hbc83047_0
   - trollius=2.2=py27h14c3975_0
   - wcwidth=0.2.5=py_0
-  - wheel=0.33.6=py27_0
+  - wheel=0.35.1=py_0
   - xz=5.2.5=h7b6447c_0
   - zeromq=4.3.2=he6710b0_2
   - zipp=0.6.0=py_0

--- a/.devcontainer/environment-py3.7-tango9.3.4.yml
+++ b/.devcontainer/environment-py3.7-tango9.3.4.yml
@@ -1,21 +1,22 @@
 name: env-py3.7-tango9.3.4
 channels:
-  - conda-forge
   - tango-controls
+  - conda-forge
   - main
   - defaults
 dependencies:
   - _libgcc_mutex=0.1=main
   - apipkg=1.5=py37_0
-  - attrs=19.3.0=py_0
+  - attrs=20.1.0=py_0
   - binutils_impl_linux-64=2.33.1=he6710b0_7
   - binutils_linux-64=2.33.1=h9595d00_15
   - blas=1.0=mkl
-  - boost=1.67.0=py37_4
+  - boost=1.73.0=py37h429e714_1
+  - boost-cpp=1.73.0=h9359b55_3
   - bzip2=1.0.8=h7b6447c_0
-  - ca-certificates=2020.6.24=0
+  - ca-certificates=2020.7.22=0
   - certifi=2020.6.20=py37_0
-  - cffi=1.14.0=py37he30daa8_1
+  - cffi=1.14.2=py37he30daa8_0
   - cpptango=9.3.4rc6=h6bb024c_0
   - cppzmq=4.6.0=hc9558a2_0
   - execnet=1.7.1=py_0
@@ -25,49 +26,48 @@ dependencies:
   - greenlet=0.4.16=py37h7b6447c_0
   - gxx_impl_linux-64=7.3.0=hdf63c60_1
   - gxx_linux-64=7.3.0=h553295d_15
-  - icu=58.2=he6710b0_3
+  - icu=67.1=he1b5a44_0
   - importlib-metadata=1.7.0=py37_0
   - importlib_metadata=1.7.0=0
-  - intel-openmp=2020.1=217
+  - iniconfig=1.0.1=py_0
+  - intel-openmp=2020.2=254
   - ld_impl_linux-64=2.33.1=h53a641e_7
-  - libboost=1.67.0=h46d08c1_4
-  - libedit=3.1.20191231=h7b6447c_0
+  - libedit=3.1.20191231=h14c3975_1
   - libffi=3.3=he6710b0_2
   - libgcc-ng=9.1.0=hdf63c60_0
-  - libgfortran-ng=7.3.0=hdf63c60_0
   - libsodium=1.0.18=h7b6447c_0
   - libstdcxx-ng=9.1.0=hdf63c60_0
-  - mkl=2020.1=217
+  - lz4-c=1.9.2=he6710b0_1
+  - mkl=2020.2=256
   - mkl-service=2.3.0=py37he904b0f_0
   - mkl_fft=1.1.0=py37h23d657b_0
   - mkl_random=1.1.1=py37h0573a6f_0
   - more-itertools=8.4.0=py_0
   - ncurses=6.2=he6710b0_1
-  - numpy=1.18.5=py37ha1c710e_0
-  - numpy-base=1.18.5=py37hde5b4d6_0
+  - numpy=1.19.1=py37hbc911f0_0
+  - numpy-base=1.19.1=py37hfa32c7d_0
   - omniorb=4.2.4=py37hb0870dc_0
   - openssl=1.1.1g=h7b6447c_0
   - packaging=20.4=py_0
-  - pip=20.1.1=py37_1
+  - pip=20.2.2=py37_0
   - pluggy=0.13.1=py37_0
-  - psutil=5.7.0=py37h7b6447c_0
+  - psutil=5.7.2=py37h7b6447c_0
   - py=1.9.0=py_0
-  - py-boost=1.67.0=py37h04863e7_4
-  - pycparser=2.20=py_0
+  - pycparser=2.20=py_2
   - pyparsing=2.4.7=py_0
-  - pytest=5.4.3=py37_0
-  - pytest-forked=1.1.3=py_0
-  - pytest-xdist=1.32.0=py_0
+  - pytest=6.0.1=py37_0
+  - pytest-forked=1.3.0=py_0
+  - pytest-xdist=2.1.0=py_0
   - python=3.7.7=hcff3b4d_5
   - python_abi=3.7=1_cp37m
   - readline=8.0=h7b6447c_0
-  - setuptools=47.3.1=py37_0
+  - setuptools=49.6.0=py37_0
   - six=1.15.0=py_0
-  - sqlite=3.32.3=h62c20be_0
+  - sqlite=3.33.0=h62c20be_0
   - tango-test=3.0=h6bb024c_2
   - tk=8.6.10=hbc83047_0
-  - wcwidth=0.2.5=py_0
-  - wheel=0.34.2=py37_0
+  - toml=0.10.1=py_0
+  - wheel=0.35.1=py_0
   - xz=5.2.5=h7b6447c_0
   - zeromq=4.3.2=he6710b0_2
   - zipp=3.1.0=py_0
@@ -75,5 +75,6 @@ dependencies:
   - zope=1.0=py37_1
   - zope.event=4.4=py37_0
   - zope.interface=4.7.1=py37h7b6447c_0
+  - zstd=1.4.5=h9ceee32_0
 prefix: /opt/conda/envs/env-py3.7-tango9.3.4
 

--- a/.devcontainer/environment-py3.8-tango9.3.4.yml
+++ b/.devcontainer/environment-py3.8-tango9.3.4.yml
@@ -1,21 +1,22 @@
 name: env-py3.8-tango9.3.4
 channels:
-  - conda-forge
   - tango-controls
+  - conda-forge
   - main
   - defaults
 dependencies:
   - _libgcc_mutex=0.1=main
   - apipkg=1.5=py38_0
-  - attrs=19.3.0=py_0
+  - attrs=20.1.0=py_0
   - binutils_impl_linux-64=2.33.1=he6710b0_7
   - binutils_linux-64=2.33.1=h9595d00_15
   - blas=1.0=mkl
-  - boost=1.71.0=py38_0
+  - boost=1.73.0=py38hd103949_1
+  - boost-cpp=1.73.0=h9359b55_3
   - bzip2=1.0.8=h7b6447c_0
-  - ca-certificates=2020.6.24=0
+  - ca-certificates=2020.7.22=0
   - certifi=2020.6.20=py38_0
-  - cffi=1.14.0=py38he30daa8_1
+  - cffi=1.14.2=py38he30daa8_0
   - cpptango=9.3.4rc6=h6bb024c_0
   - cppzmq=4.6.0=hc9558a2_0
   - execnet=1.7.1=py_0
@@ -25,53 +26,52 @@ dependencies:
   - greenlet=0.4.16=py38h7b6447c_0
   - gxx_impl_linux-64=7.3.0=hdf63c60_1
   - gxx_linux-64=7.3.0=h553295d_15
-  - icu=58.2=he6710b0_3
-  - intel-openmp=2020.1=217
+  - icu=67.1=he1b5a44_0
+  - iniconfig=1.0.1=py_0
+  - intel-openmp=2020.2=254
   - ld_impl_linux-64=2.33.1=h53a641e_7
-  - libboost=1.71.0=h97c9712_0
-  - libedit=3.1.20191231=h7b6447c_0
+  - libedit=3.1.20191231=h14c3975_1
   - libffi=3.3=he6710b0_2
   - libgcc-ng=9.1.0=hdf63c60_0
-  - libgfortran-ng=7.3.0=hdf63c60_0
   - libsodium=1.0.18=h7b6447c_0
   - libstdcxx-ng=9.1.0=hdf63c60_0
-  - mkl=2020.1=217
+  - lz4-c=1.9.2=he6710b0_1
+  - mkl=2020.2=256
   - mkl-service=2.3.0=py38he904b0f_0
   - mkl_fft=1.1.0=py38h23d657b_0
   - mkl_random=1.1.1=py38h0573a6f_0
   - more-itertools=8.4.0=py_0
   - ncurses=6.2=he6710b0_1
-  - numpy=1.18.5=py38ha1c710e_0
-  - numpy-base=1.18.5=py38hde5b4d6_0
+  - numpy=1.19.1=py38hbc911f0_0
+  - numpy-base=1.19.1=py38hfa32c7d_0
   - omniorb=4.2.4=py38h2c89da0_0
   - openssl=1.1.1g=h7b6447c_0
   - packaging=20.4=py_0
-  - pip=20.1.1=py38_1
+  - pip=20.2.2=py38_0
   - pluggy=0.13.1=py38_0
-  - psutil=5.7.0=py38h7b6447c_0
+  - psutil=5.7.2=py38h7b6447c_0
   - py=1.9.0=py_0
-  - py-boost=1.71.0=py38h962f231_0
-  - pycparser=2.20=py_0
+  - pycparser=2.20=py_2
   - pyparsing=2.4.7=py_0
-  - pytest=5.4.3=py38_0
-  - pytest-forked=1.1.3=py_0
-  - pytest-xdist=1.32.0=py_0
-  - python=3.8.3=hcff3b4d_2
+  - pytest=6.0.1=py38_0
+  - pytest-forked=1.3.0=py_0
+  - pytest-xdist=2.1.0=py_0
+  - python=3.8.5=hcff3b4d_0
   - python_abi=3.8=1_cp38
   - readline=8.0=h7b6447c_0
-  - setuptools=47.3.1=py38_0
+  - setuptools=49.6.0=py38_0
   - six=1.15.0=py_0
-  - sqlite=3.32.3=h62c20be_0
+  - sqlite=3.33.0=h62c20be_0
   - tango-test=3.0=h6bb024c_2
   - tk=8.6.10=hbc83047_0
-  - wcwidth=0.2.5=py_0
-  - wheel=0.34.2=py38_0
+  - toml=0.10.1=py_0
+  - wheel=0.35.1=py_0
   - xz=5.2.5=h7b6447c_0
   - zeromq=4.3.2=he6710b0_2
   - zlib=1.2.11=h7b6447c_3
   - zope=1.0=py38_1
   - zope.event=4.4=py38_0
-  - zope.interface=4.7.1=py38h7b6447c_0
-  - zstd=1.3.7=h0b5b093_0
+  - zope.interface=5.1.0=py38h7b6447c_0
+  - zstd=1.4.5=h9ceee32_0
 prefix: /opt/conda/envs/env-py3.8-tango9.3.4
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -135,11 +135,14 @@ set(HEADERS
 set(${PROJECT_NAME} INCLUDE_DIRS "$ENV{TANGO_ROOT}/include")
 
 if(MSVC90)
+  # v9 used for Python 2
   set(VCSTR "90")
+  set(BOOST_VERSION_ "1_70")
 elseif(MSVC14)
+  # v14 used for Python 3
   set(VCSTR "140")
+  set(BOOST_VERSION_ "1_73")
 endif()
-set(BOOST_VERSION_ "1_70")
 set(ZMQ_VERSION_ "4_0_5")
 
 set(RELEASE "Release_$ENV{PYTHON_VER}_${PY_TARGET}")

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,7 +6,6 @@ environment:
   cpptango_download_base: https://github.com/tango-controls/cppTango/releases/download/
   cpptango_version: 9.3.3
   boost_download_base: https://github.com/tango-controls/boost-ci/releases/download/
-  boost_version: 1.70.0
   matrix:
     - platform: win32
       configuration: Release
@@ -17,6 +16,7 @@ environment:
       PYTHON_VER: 27
       PYTHON_ROOT: c:\Python27\
       CMAKE_GENERATOR: "Visual Studio 9 2008"
+      boost_version: 1.70.0  # last boost-ci release with Py2 support
     - platform: x64
       configuration: Release
       ARCH: x64-msvc9
@@ -26,6 +26,7 @@ environment:
       PYTHON_VER: 27
       PYTHON_ROOT: c:\Python27-x64\
       CMAKE_GENERATOR: "Visual Studio 9 2008 Win64"
+      boost_version: 1.70.0  # last boost-ci release with Py2 support
 
     - platform: win32
       configuration: Release
@@ -36,6 +37,7 @@ environment:
       PYTHON_VER: 36
       PYTHON_ROOT: c:\Python36\
       CMAKE_GENERATOR: "Visual Studio 14 2015"
+      boost_version: 1.73.0
     - platform: x64
       configuration: Release
       ARCH: x64-msvc14
@@ -45,6 +47,7 @@ environment:
       PYTHON_VER: 36
       PYTHON_ROOT: c:\Python36-x64\
       CMAKE_GENERATOR: "Visual Studio 14 2015 Win64"
+      boost_version: 1.73.0
 
     - platform: win32
       configuration: Release
@@ -55,6 +58,7 @@ environment:
       PYTHON_VER: 37
       PYTHON_ROOT: c:\Python37\
       CMAKE_GENERATOR: "Visual Studio 14 2015"
+      boost_version: 1.73.0
     - platform: x64
       configuration: Release
       ARCH: x64-msvc14
@@ -64,13 +68,9 @@ environment:
       PYTHON_VER: 37
       PYTHON_ROOT: c:\Python37-x64\
       CMAKE_GENERATOR: "Visual Studio 14 2015 Win64"
+      boost_version: 1.73.0
 
 init:
-  # go to hell Xamarin (see http://help.appveyor.com/discussions/problems/4569)
-  - del "C:\Program Files (x86)\MSBuild\4.0\Microsoft.Common.Targets\ImportAfter\Xamarin.Common.targets"
-  - del "C:\Program Files (x86)\MSBuild\14.0\Microsoft.Common.targets\ImportAfter\Xamarin.Common.targets"
-  - del "C:\Program Files (x86)\MSBuild\12.0\Microsoft.Common.targets\ImportAfter\Xamarin.Common.targets"
-
   # Tango
   - cmd: cd "C:\projects\"
   - cmd: md libtango
@@ -144,7 +144,7 @@ after_build:
 
 on_failure:
   #RDP for failure
-  - ps: $blockRdp = $true; iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))
+  #- ps: $blockRdp = $true; iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))
 
 on_finish:
   #RDP for finish

--- a/ext/precompiled_header.hpp
+++ b/ext/precompiled_header.hpp
@@ -15,6 +15,7 @@
 // use this precompiled header.
 
 //#define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION
+#define BOOST_BIND_GLOBAL_PLACEHOLDERS
 
 #include <boost/python.hpp>
 #include <boost/version.hpp>


### PR DESCRIPTION
Update Windows builds (AppVeyor) to new [boost-ci](https://github.com/tango-controls/boost-ci/releases/tag/1.73.0) (Windows library) release.  Note Python 2 support was dropped in the boost-ci builds, so we still use the older version, 1.70.0, for Python 2.7 on Windows.  Also updated the dev container Conda environment files.

Windows builds are still broken (see #355), but this update should allow the Python 3.8 CI to at least compile without errors.