### PR TITLE
VScode remote development container support

### DIFF
--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -9,7 +9,7 @@ Using some command line overrides, images for various versions of Python and Tan
 
 ## Building the Docker image
 
-Run commands like the following:
+From within this folder, run commands like the following:
 
 ```shell script
 export PYTHON_VERSION=3.7
@@ -23,11 +23,13 @@ https://anaconda.org/tango-controls/cpptango/files
 ## Build, install and test PyTango in a container
 
 Run an instance of the container, volume mounting an external PyTango repo into the container.  For example:
+
 ```shell script
 docker run -it --rm -v ~/tango-src/pytango:/opt/pytango pytango-dev:py3.7-tango9.3.2 /bin/bash
 ```
 
 Inside the container:
+
 ```shell script
 cd /opt/pytango
 python setup.py build
@@ -38,12 +40,14 @@ python setup.py test
 
 The `environment-*.yml` files are created and can be updated using the commands below.
 It is convenient to do this in a container:
+
  ```shell script
 $ docker run -it --rm -v $PWD:/opt/current continuumio/miniconda3 /bin/bash
 ```
 
 Then run the commands inside that container - here's an example for a specific version of Python and Tango.
 Due to the volume mount above, the last line will output the environment file to your host's current folder.
+
 ```shell script
 export PYTHON_VERSION=3.7
 export TANGO_VERSION=9.3.4
@@ -56,6 +60,7 @@ conda env export > /opt/current/environment-py${PYTHON_VERSION}-tango${TANGO_VER
 ```
 
 For Python 2.7, the requirements are slightly different, so replace the line with `pytest` with:
+
 ```shell script
 conda install --yes trollius futures 'pyparsing < 3' 'pytest < 5' 'pytest-xdist < 2' 'gevent != 1.5a1' psutil enum34
 ```
@@ -70,23 +75,32 @@ Once the image has been built, it can be used with IDEs like
 (Professional version only), and
 [Visual Studio Code](https://code.visualstudio.com/docs/remote/containers)
 
-### PyCharm:
+### PyCharm
+
 Add a new interpreter:
+
 - Open the _Add Interpreter..._ dialog
 - Select _Docker_
 - Pick the image to use, e.g., `pytango-dev:py3.7-tango9.3.2`
 - Change the Python interpreter path to `/usr/local/bin/run-conda-python.sh`
 
 Running tests:
+
 - If you want to run all the tests, it will work out the box.
 - If you only want to run a subset, the `setup.cfg` file needs to be change temporarily:
   - In the `[tool:pytest]` section, remove the `tests` path from the additional options, to give:
      `addopts = -v --boxed`
   - If the change isn't made you may get errors like:
+
     ```
     collecting ... collected 0 items
     ERROR: file not found: tests
     ```
 
 ### Visual Studio Code
-TODO - probably need to add a `devcontainer.json` file...
+
+Developing in a container from within VScode requires installation of the "Remote Containers" extension.
+
+When opening the pytango folder in VScode, the Remote Containers extension will detect the presence of a `devcontainer.json` container configuration file, and will offer to reopen the folder in the container. The first time this is done, it will take a long time because the docker image must be built; after that first time, the image is cached.
+
+Once in the container, your `pytango` folder will be mounted at `/workspaces/pytango`.

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -4,5 +4,5 @@
     "dockerFile": "Dockerfile",
     "settings": {
         "terminal.integrated.shell.linux": "/bin/bash",
-    },
+    }
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,6 +3,6 @@
     "context": ".",
     "dockerFile": "Dockerfile",
     "settings": {
-        "terminal.integrated.shell.linux": "/bin/bash",
+        "terminal.integrated.shell.linux": "/bin/bash"
     }
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,8 @@
+{
+    "name": "Pytango",
+    "context": ".",
+    "dockerFile": "Dockerfile",
+    "settings": {
+        "terminal.integrated.shell.linux": "/bin/bash",
+    },
+}


### PR DESCRIPTION
This pull request adds VScode remote container support.

There's not much to it: just a basic `devcontainer.json` configuration file, and a couple of paragraphs of documentation.

I also markdownlinted the `README.md` while I was editing it, I hope that's okay.

It would have been nice if `python setup.py build` could have been added to the container config as a `postCreateCommand`, but unfortunately that has proven problematic (when run as a `postCreateCommand`, it gets stuck in the `build-ext` stage at `subprocess.Popen`.)
