### PR TITLE
Add string support for MultiDeviceTestContext devices_info class field

### DIFF
--- a/tango/test_utils.py
+++ b/tango/test_utils.py
@@ -12,6 +12,7 @@ except ImportError:
 from . import DevState, GreenMode
 from .server import Device
 from .test_context import MultiDeviceTestContext, DeviceTestContext
+from . import DeviceClass, LatestDeviceImpl, DevLong64, SCALAR, READ
 
 # Conditional imports
 try:
@@ -24,7 +25,13 @@ try:
 except ImportError:
     numpy = None
 
-__all__ = ('MultiDeviceTestContext', 'DeviceTestContext', 'SimpleDevice')
+__all__ = (
+    'MultiDeviceTestContext',
+    'DeviceTestContext',
+    'SimpleDevice',
+    'ClassicAPISimpleDeviceImpl',
+    'ClassicAPISimpleDeviceClass'
+)
 
 PY3 = sys.version_info >= (3,)
 
@@ -38,6 +45,23 @@ str_devstring = bytes_devstring.decode('latin-1')
 class SimpleDevice(Device):
     def init_device(self):
         self.set_state(DevState.ON)
+
+
+class ClassicAPISimpleDeviceImpl(LatestDeviceImpl):
+    def __init__(self, cls, name):
+        LatestDeviceImpl.__init__(self, cls, name)
+        ClassicAPISimpleDeviceImpl.init_device(self)
+
+    def init_device(self):
+        self.get_device_properties(self.get_device_class())
+        self.attr_attr1_read = 100
+
+    def read_attr1(self, attr):
+        attr.set_value(self.attr_attr1_read)
+
+
+class ClassicAPISimpleDeviceClass(DeviceClass):
+    attr_list = {"attr1": [[DevLong64, SCALAR, READ]]}
 
 
 # Test enums

--- a/tests/test_test_context.py
+++ b/tests/test_test_context.py
@@ -41,34 +41,30 @@ def test_single_device_old_api():
 
 
 @pytest.mark.parametrize(
-    "spec, device_cls, device",
+    "class_field, device",
     [
-        (SimpleDevice, None, SimpleDevice),
-        ("tango.test_utils.SimpleDevice", None, SimpleDevice),
+        (SimpleDevice, SimpleDevice),
+        ("tango.test_utils.SimpleDevice", SimpleDevice),
         (
             ("tango.test_utils.ClassicAPISimpleDeviceClass", "tango.test_utils.ClassicAPISimpleDeviceImpl"),
-            ClassicAPISimpleDeviceClass,
-            ClassicAPISimpleDeviceImpl,
+            ClassicAPISimpleDeviceImpl
         ),
         (
             ("tango.test_utils.ClassicAPISimpleDeviceClass", ClassicAPISimpleDeviceImpl),
-            ClassicAPISimpleDeviceClass,
             ClassicAPISimpleDeviceImpl
         ),
         (
             (ClassicAPISimpleDeviceClass, "tango.test_utils.ClassicAPISimpleDeviceImpl"),
-            ClassicAPISimpleDeviceClass,
-            ClassicAPISimpleDeviceImpl,
+            ClassicAPISimpleDeviceImpl
         ),
         (
-            (ClassicAPISimpleDeviceClass, ClassicAPISimpleDeviceImpl),
-            ClassicAPISimpleDeviceClass,
-            ClassicAPISimpleDeviceImpl,
+            (ClassicAPISimpleDeviceClass, ClassicAPISimpleDeviceImpl), 
+            ClassicAPISimpleDeviceImpl
         ),
     ]
 )
-def test_multi_devices_info(spec, device_cls, device):
-    devices_info = ({"class": spec, "devices": [{"name": "test/device1/1"}]},)
+def test_multi_devices_info(class_field, device):
+    devices_info = ({"class": class_field, "devices": [{"name": "test/device1/1"}]},)
 
     dev_class = device if isinstance(device, str) else device.__name__
 

--- a/tests/test_test_context.py
+++ b/tests/test_test_context.py
@@ -6,7 +6,13 @@ import tango
 
 from tango.server import Device
 from tango.server import command, attribute, device_property
-from tango.test_utils import DeviceTestContext, MultiDeviceTestContext
+from tango.test_utils import (
+    DeviceTestContext,
+    MultiDeviceTestContext,
+    SimpleDevice,
+    ClassicAPISimpleDeviceImpl,
+    ClassicAPISimpleDeviceClass
+)
 
 
 class Device1(Device):
@@ -21,23 +27,6 @@ class Device2(Device):
         return 200
 
 
-class ClassicAPIDeviceImpl(tango.LatestDeviceImpl):
-    def __init__(self, cl, name):
-        tango.LatestDeviceImpl.__init__(self, cl, name)
-        ClassicAPIDeviceImpl.init_device(self)
-
-    def init_device(self):
-        self.get_device_properties(self.get_device_class())
-        self.attr_attr1_read = 100
-
-    def read_attr1(self, attr):
-        attr.set_value(self.attr_attr1_read)
-
-
-class ClassicAPIDeviceClass(tango.DeviceClass):
-    attr_list = {"attr1": [[tango.DevLong64, tango.SCALAR, tango.READ]]}
-
-
 def test_single_device(server_green_mode):
     class TestDevice(Device1):
         green_mode = server_green_mode
@@ -47,8 +36,45 @@ def test_single_device(server_green_mode):
 
 
 def test_single_device_old_api():
-    with DeviceTestContext(ClassicAPIDeviceImpl, ClassicAPIDeviceClass) as proxy:
+    with DeviceTestContext(ClassicAPISimpleDeviceImpl, ClassicAPISimpleDeviceClass) as proxy:
         assert proxy.attr1 == 100
+
+
+@pytest.mark.parametrize(
+    "spec, device_cls, device",
+    [
+        (SimpleDevice, None, SimpleDevice),
+        ("tango.test_utils.SimpleDevice", None, SimpleDevice),
+        (
+            ("tango.test_utils.ClassicAPISimpleDeviceClass", "tango.test_utils.ClassicAPISimpleDeviceImpl"),
+            ClassicAPISimpleDeviceClass,
+            ClassicAPISimpleDeviceImpl,
+        ),
+        (
+            ("tango.test_utils.ClassicAPISimpleDeviceClass", ClassicAPISimpleDeviceImpl),
+            ClassicAPISimpleDeviceClass,
+            ClassicAPISimpleDeviceImpl
+        ),
+        (
+            (ClassicAPISimpleDeviceClass, "tango.test_utils.ClassicAPISimpleDeviceImpl"),
+            ClassicAPISimpleDeviceClass,
+            ClassicAPISimpleDeviceImpl,
+        ),
+        (
+            (ClassicAPISimpleDeviceClass, ClassicAPISimpleDeviceImpl),
+            ClassicAPISimpleDeviceClass,
+            ClassicAPISimpleDeviceImpl,
+        ),
+    ]
+)
+def test_multi_devices_info(spec, device_cls, device):
+    devices_info = ({"class": spec, "devices": [{"name": "test/device1/1"}]},)
+
+    dev_class = device if isinstance(device, str) else device.__name__
+
+    with MultiDeviceTestContext(devices_info) as context:
+        proxy1 = context.get_device("test/device1/1")
+        assert proxy1.info().dev_class == dev_class
 
 
 def test_multi_with_single_device(server_green_mode):
@@ -65,7 +91,7 @@ def test_multi_with_single_device(server_green_mode):
 def test_multi_with_single_device_old_api():
     devices_info = (
         {
-            "class": (ClassicAPIDeviceClass, ClassicAPIDeviceImpl),
+            "class": (ClassicAPISimpleDeviceClass, ClassicAPISimpleDeviceImpl),
             "devices": [{"name": "test/device1/1"}],
         },
     )
@@ -183,7 +209,7 @@ def test_multi_with_two_devices_with_properties(server_green_mode):
             (
                 {"class": Device1, "devices": [{"name": "test/device1/1"}]},
                 {
-                    "class": (ClassicAPIDeviceClass, ClassicAPIDeviceImpl),
+                    "class": (ClassicAPISimpleDeviceClass, ClassicAPISimpleDeviceImpl),
                     "devices": [{"name": "test/device1/2"}],
                 },
             ),


### PR DESCRIPTION
This pull request allows for `tango.test_context.MultiDeviceTestContext` to be invoked with a `devices_info` dictionary in which the device class entries are class _names_ rather than class _objects_. That is, instead of
```
from tango.test_utils import SimpleDevice
devices_info = (
    {
        "class": SimpleDevice,
        "devices": [
            {
                "name": "test/device1/1"
            }
        ]
    },
)
```
we can write
```
devices_info = (
    {
        "class": "tango.test_utils.SimpleDevice",
        "devices": [
            {
                "name": "test/device1/1"
            }
        ]
    },
)
```
This is useful because it renders the `devices_info` dict serialisable. When integration testing in a complex device ecosystem with many devices and device properties, the `devices_info` dict might become very large, and we might even want to test several different arrangements of devices or sets of device properties. Without serialisation, such tests could end up containing an awful lot of declarative code. But with serialisation, we can easily store the `devices_info` dicts in JSON files, and load them by name as required. Our tests will be much cleaner.

The elements of the implementation and testing are:
* a slight refactor to move some duplicated code into a `_device_class_from_field` helper function, which is then enhanced to support class names. The actual loading of a class given its name was already implemented in the `device` function, so we just make use of that.
* To test, we need some test devices that are specified in another module, so that they can be imported by name. Tango already provided a `SimpleDevice` in the `tango.test_utils` module, so we use it. To allow for testing against devices that use the classic API, the `ClassicAPIDeviceImpl` and `ClassicAPIDeviceClass` classes are moved from the local test module into the tango.test_utils module.
* The new functionality is tested in a new `test_multi_devices_info` test.
