### PR TITLE
Fix DeviceProxy repr/str memory leak 

### DIFF
--- a/tango/device_proxy.py
+++ b/tango/device_proxy.py
@@ -112,15 +112,15 @@ class __TangoInfo(object):
         dev_class,
         dev_type,
         doc_url,
-        server_id,
         server_host,
+        server_id,
         server_version,
     ):
         self.dev_class = str(dev_class)
         self.dev_type = str(dev_type)
         self.doc_url = str(doc_url)
-        self.server_id = str(server_id)
         self.server_host = str(server_host)
+        self.server_id = str(server_id)
         self.server_version = int(server_version)
 
     @classmethod
@@ -140,8 +140,8 @@ class __TangoInfo(object):
             dev_class=info.dev_class,
             dev_type=info.dev_type,
             doc_url=info.doc_url,
-            server_host=info.server_id,
-            server_id=info.server_host,
+            server_host=info.server_host,
+            server_id=info.server_id,
             server_version=info.server_version,
         )
 

--- a/tango/device_proxy.py
+++ b/tango/device_proxy.py
@@ -105,14 +105,45 @@ def get_device_proxy(*args, **kwargs):
 
 
 class __TangoInfo(object):
-    """Helper class for when DeviceProxy.info() is not available"""
+    """Helper class for copying DeviceInfo, or when DeviceProxy.info() fails."""
 
-    def __init__(self):
-        self.dev_class = self.dev_type = 'Device'
-        self.doc_url = 'http://www.esrf.fr/computing/cs/tango/tango_doc/ds_doc/'
-        self.server_host = 'Unknown'
-        self.server_id = 'Unknown'
-        self.server_version = 1
+    def __init__(
+        self,
+        dev_class,
+        dev_type,
+        doc_url,
+        server_id,
+        server_host,
+        server_version,
+    ):
+        self.dev_class = str(dev_class)
+        self.dev_type = str(dev_type)
+        self.doc_url = str(doc_url)
+        self.server_id = str(server_id)
+        self.server_host = str(server_host)
+        self.server_version = int(server_version)
+
+    @classmethod
+    def from_defaults(cls):
+        return cls(
+            dev_class='Device',
+            dev_type='Device',
+            doc_url='Doc URL = https://www.tango-controls.org/developers/dsc',
+            server_host='Unknown',
+            server_id='Unknown',
+            server_version=1,
+        )
+
+    @classmethod
+    def from_copy(cls, info):
+        return cls(
+            dev_class=info.dev_class,
+            dev_type=info.dev_type,
+            doc_url=info.doc_url,
+            server_host=info.server_id,
+            server_id=info.server_host,
+            server_version=info.server_version,
+        )
 
 
 # -------------------------------------------------------------------------------
@@ -1398,9 +1429,11 @@ def __DeviceProxy___get_info_(self):
     """Protected method that gets device info once and stores it in cache"""
     if not hasattr(self, '_dev_info'):
         try:
-            self.__dict__["_dev_info"] = self.info()
+            info = self.info()
+            info_without_cyclic_reference = __TangoInfo.from_copy(info)
+            self.__dict__["_dev_info"] = info_without_cyclic_reference
         except:
-            return __TangoInfo()
+            return __TangoInfo.from_defaults()
     return self._dev_info
 
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -512,17 +512,3 @@ def test_no_memory_leak_for_str(green_mode_device_proxy, simple_device_fqdn):
     del proxy
     gc.collect()
     assert weak_ref() is None
-
-
-def test_no_memory_leak_when_overriding_methods(
-        green_mode_device_proxy, simple_device_fqdn):
-    proxy = green_mode_device_proxy(simple_device_fqdn)
-    ping_device(proxy)
-    weak_ref = weakref.ref(proxy)
-
-    proxy.write_attribute = proxy.write_attribute
-
-    # clear strong reference and check if object can be garbage collected
-    del proxy
-    gc.collect()
-    assert weak_ref() is None

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -171,7 +171,8 @@ def ping_device(proxy):
 
 @pytest.fixture(params=[GreenMode.Synchronous,
                         GreenMode.Asyncio,
-                        GreenMode.Gevent],
+                        GreenMode.Gevent,
+                        GreenMode.Futures],
                 scope="module")
 def tango_test(request):
     green_mode = request.param
@@ -215,7 +216,8 @@ def writable_spectrum_attribute(request):
 
 @pytest.fixture(params=[GreenMode.Synchronous,
                         GreenMode.Asyncio,
-                        GreenMode.Gevent])
+                        GreenMode.Gevent,
+                        GreenMode.Futures])
 def green_mode_device_proxy(request):
     green_mode = request.param
     return device_proxy_map[green_mode]


### PR DESCRIPTION
Fixes #298 

As @birkenfeld reported:
> The problem is caused by the result of dev.info() being assigned to dev._dev_info, and a reference cycle is created. This is normally handled by the GC, but only if every object in the reference cycle is GC aware.

The boost layer is using the CallPolicy [`return_internal_reference<1>`](https://wiki.python.org/moin/boost.python/CallPolicy#return_internal_reference).  This CallPolicy means that the `info()` return object cannot be released until the `DeviceProxy` instance is released.  However, the `DeviceProxy` instance cannot be released until the `info()` return object is released.  Python's garbage collector cannot break this the cyclic reference.

The solution is to make a new object that copies the fields from the original `info()` call, and store that instead.  The existing `__TangoInfo` was extended for this purpose.

It may be that changing the boost CallPolicy is another way to fix it, but I don't know enough about that to ensure no new problems are introduced.

Also added `GreenMode.Futures` to the client tests - not sure why it was excluded, but now all modes are tested.