### PR TITLE
Update CI and dev Docker to cpptango 9.3.4

### DIFF
--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -54,7 +54,7 @@ export TANGO_VERSION=9.3.4
 conda create --yes --name env-py${PYTHON_VERSION}-tango${TANGO_VERSION} python=${PYTHON_VERSION}
 conda activate env-py${PYTHON_VERSION}-tango${TANGO_VERSION}
 conda install --yes -c main -c conda-forge boost gxx_linux-64 cppzmq numpy
-conda install --yes -c main -c conda-forge -c tango-controls cpptango=${TANGO_VERSION} tango-test
+conda install --yes -c main -c conda-forge -c tango-controls cpptango==${TANGO_VERSION} tango-test
 conda install --yes pytest pytest-xdist 'gevent != 1.5a1' psutil
 conda env export > /opt/current/environment-py${PYTHON_VERSION}-tango${TANGO_VERSION}.yml
 ```

--- a/.devcontainer/build_all.sh
+++ b/.devcontainer/build_all.sh
@@ -12,6 +12,11 @@ TANGO_VERSION=9.3.2
 echo py${PYTHON_VERSION}-tango${TANGO_VERSION}
 docker build . -t pytango-dev:py${PYTHON_VERSION}-tango${TANGO_VERSION} --build-arg PYTHON_VERSION --build-arg TANGO_VERSION --no-cache
 
+PYTHON_VERSION=2.7
+TANGO_VERSION=9.3.4
+echo py${PYTHON_VERSION}-tango${TANGO_VERSION}
+docker build . -t pytango-dev:py${PYTHON_VERSION}-tango${TANGO_VERSION} --build-arg PYTHON_VERSION --build-arg TANGO_VERSION --no-cache
+
 PYTHON_VERSION=3.7
 TANGO_VERSION=9.2.5
 echo py${PYTHON_VERSION}-tango${TANGO_VERSION}
@@ -19,5 +24,15 @@ docker build . -t pytango-dev:py${PYTHON_VERSION}-tango${TANGO_VERSION} --build-
 
 PYTHON_VERSION=3.7
 TANGO_VERSION=9.3.2
+echo py${PYTHON_VERSION}-tango${TANGO_VERSION}
+docker build . -t pytango-dev:py${PYTHON_VERSION}-tango${TANGO_VERSION} --build-arg PYTHON_VERSION --build-arg TANGO_VERSION --no-cache
+
+PYTHON_VERSION=3.7
+TANGO_VERSION=9.3.4
+echo py${PYTHON_VERSION}-tango${TANGO_VERSION}
+docker build . -t pytango-dev:py${PYTHON_VERSION}-tango${TANGO_VERSION} --build-arg PYTHON_VERSION --build-arg TANGO_VERSION --no-cache
+
+PYTHON_VERSION=3.8
+TANGO_VERSION=9.3.4
 echo py${PYTHON_VERSION}-tango${TANGO_VERSION}
 docker build . -t pytango-dev:py${PYTHON_VERSION}-tango${TANGO_VERSION} --build-arg PYTHON_VERSION --build-arg TANGO_VERSION --no-cache

--- a/.devcontainer/environment-py2.7-tango9.3.4.yml
+++ b/.devcontainer/environment-py2.7-tango9.3.4.yml
@@ -1,28 +1,28 @@
 name: env-py2.7-tango9.3.4
 channels:
   - tango-controls
-  - conda-forge
   - main
+  - conda-forge
   - defaults
 dependencies:
-  - _libgcc_mutex=0.1=main
+  - _libgcc_mutex=0.1=conda_forge
+  - _openmp_mutex=4.5=1_gnu
   - apipkg=1.5=py27_0
   - atomicwrites=1.4.0=py_0
-  - attrs=20.1.0=py_0
-  - backports=1.0=py_2
+  - attrs=20.3.0=pyhd3eb1b0_0
+  - backports=1.0=pyhd3eb1b0_2
   - binutils_impl_linux-64=2.33.1=he6710b0_7
   - binutils_linux-64=2.33.1=h9595d00_15
   - blas=1.0=mkl
-  - boost=1.70.0=py27h9de70de_1
-  - boost-cpp=1.70.0=ha2d47e9_1
+  - boost=1.67.0=py27_4
   - bzip2=1.0.8=h7b6447c_0
-  - ca-certificates=2020.7.22=0
-  - certifi=2019.11.28=py27_0
+  - ca-certificates=2020.10.14=0
+  - certifi=2020.6.20=pyhd3eb1b0_3
   - cffi=1.14.0=py27he30daa8_1
   - configparser=4.0.2=py27_0
   - contextlib2=0.6.0.post1=py_0
-  - cpptango=9.3.4rc6=h6bb024c_0
-  - cppzmq=4.6.0=hc9558a2_0
+  - cpptango=9.3.4=h2bc3f7f_0
+  - cppzmq=4.7.1=h667716f_0
   - enum34=1.1.6=py27_1
   - execnet=1.7.1=py_0
   - funcsigs=1.0.2=py27_0
@@ -37,12 +37,14 @@ dependencies:
   - importlib_metadata=1.3.0=py27_0
   - intel-openmp=2020.2=254
   - ld_impl_linux-64=2.33.1=h53a641e_7
+  - libboost=1.67.0=h46d08c1_4
   - libedit=3.1.20191231=h14c3975_1
   - libffi=3.3=he6710b0_2
-  - libgcc-ng=9.1.0=hdf63c60_0
+  - libgcc-ng=9.3.0=h5dbcf3e_17
   - libgfortran-ng=7.3.0=hdf63c60_0
+  - libgomp=9.3.0=h5dbcf3e_17
   - libsodium=1.0.18=h7b6447c_0
-  - libstdcxx-ng=9.1.0=hdf63c60_0
+  - libstdcxx-ng=9.3.0=h2ae2ef3_17
   - mkl=2020.2=256
   - mkl-service=2.3.0=py27he904b0f_0
   - mkl_fft=1.0.15=py27ha843d7b_0
@@ -58,6 +60,7 @@ dependencies:
   - pluggy=0.13.1=py27_0
   - psutil=5.6.7=py27h7b6447c_0
   - py=1.9.0=py_0
+  - py-boost=1.67.0=py27h04863e7_4
   - pycparser=2.20=py_2
   - pyparsing=2.4.7=py_0
   - pytest=4.6.2=py27_0
@@ -73,9 +76,9 @@ dependencies:
   - tk=8.6.10=hbc83047_0
   - trollius=2.2=py27h14c3975_0
   - wcwidth=0.2.5=py_0
-  - wheel=0.35.1=py_0
+  - wheel=0.35.1=pyhd3eb1b0_0
   - xz=5.2.5=h7b6447c_0
-  - zeromq=4.3.2=he6710b0_2
+  - zeromq=4.3.3=he6710b0_3
   - zipp=0.6.0=py_0
   - zlib=1.2.11=h7b6447c_3
 prefix: /opt/conda/envs/env-py2.7-tango9.3.4

--- a/.devcontainer/environment-py3.7-tango9.3.4.yml
+++ b/.devcontainer/environment-py3.7-tango9.3.4.yml
@@ -1,80 +1,83 @@
 name: env-py3.7-tango9.3.4
 channels:
   - tango-controls
-  - conda-forge
   - main
+  - conda-forge
   - defaults
 dependencies:
-  - _libgcc_mutex=0.1=main
+  - _libgcc_mutex=0.1=conda_forge
+  - _openmp_mutex=4.5=1_gnu
   - apipkg=1.5=py37_0
-  - attrs=20.1.0=py_0
+  - attrs=20.3.0=pyhd3eb1b0_0
   - binutils_impl_linux-64=2.33.1=he6710b0_7
   - binutils_linux-64=2.33.1=h9595d00_15
   - blas=1.0=mkl
-  - boost=1.73.0=py37h429e714_1
-  - boost-cpp=1.73.0=h9359b55_3
+  - boost=1.73.0=py37_11
   - bzip2=1.0.8=h7b6447c_0
-  - ca-certificates=2020.7.22=0
-  - certifi=2020.6.20=py37_0
-  - cffi=1.14.2=py37he30daa8_0
-  - cpptango=9.3.4rc6=h6bb024c_0
-  - cppzmq=4.6.0=hc9558a2_0
+  - ca-certificates=2020.10.14=0
+  - certifi=2020.6.20=pyhd3eb1b0_3
+  - cffi=1.14.3=py37he30daa8_0
+  - cpptango=9.3.4=h2bc3f7f_0
+  - cppzmq=4.7.1=h667716f_0
   - execnet=1.7.1=py_0
   - gcc_impl_linux-64=7.3.0=habb00fd_1
   - gcc_linux-64=7.3.0=h553295d_15
-  - gevent=20.6.2=py37h7b6447c_0
-  - greenlet=0.4.16=py37h7b6447c_0
+  - gevent=20.9.0=py37h7b6447c_0
+  - greenlet=0.4.17=py37h7b6447c_0
   - gxx_impl_linux-64=7.3.0=hdf63c60_1
   - gxx_linux-64=7.3.0=h553295d_15
-  - icu=67.1=he1b5a44_0
-  - importlib-metadata=1.7.0=py37_0
-  - importlib_metadata=1.7.0=0
-  - iniconfig=1.0.1=py_0
+  - icu=58.2=he6710b0_3
+  - importlib-metadata=2.0.0=py_1
+  - importlib_metadata=2.0.0=1
+  - iniconfig=1.1.1=py_0
   - intel-openmp=2020.2=254
   - ld_impl_linux-64=2.33.1=h53a641e_7
+  - libboost=1.73.0=h37e3b65_11
   - libedit=3.1.20191231=h14c3975_1
   - libffi=3.3=he6710b0_2
-  - libgcc-ng=9.1.0=hdf63c60_0
+  - libgcc-ng=9.3.0=h5dbcf3e_17
+  - libgomp=9.3.0=h5dbcf3e_17
   - libsodium=1.0.18=h7b6447c_0
-  - libstdcxx-ng=9.1.0=hdf63c60_0
-  - lz4-c=1.9.2=he6710b0_1
+  - libstdcxx-ng=9.3.0=h2ae2ef3_17
+  - lz4-c=1.9.2=heb0550a_3
   - mkl=2020.2=256
   - mkl-service=2.3.0=py37he904b0f_0
-  - mkl_fft=1.1.0=py37h23d657b_0
+  - mkl_fft=1.2.0=py37h23d657b_0
   - mkl_random=1.1.1=py37h0573a6f_0
-  - more-itertools=8.4.0=py_0
+  - more-itertools=8.6.0=pyhd3eb1b0_0
   - ncurses=6.2=he6710b0_1
-  - numpy=1.19.1=py37hbc911f0_0
-  - numpy-base=1.19.1=py37hfa32c7d_0
-  - omniorb=4.2.4=py37hb0870dc_0
-  - openssl=1.1.1g=h7b6447c_0
+  - numpy=1.19.2=py37h54aff64_0
+  - numpy-base=1.19.2=py37hfa32c7d_0
+  - omniorb=4.2.4=py37hb0870dc_1
+  - openssl=1.1.1h=h7b6447c_0
   - packaging=20.4=py_0
-  - pip=20.2.2=py37_0
+  - pip=20.2.4=py37h06a4308_0
   - pluggy=0.13.1=py37_0
   - psutil=5.7.2=py37h7b6447c_0
   - py=1.9.0=py_0
+  - py-boost=1.73.0=py37h962f231_11
   - pycparser=2.20=py_2
   - pyparsing=2.4.7=py_0
-  - pytest=6.0.1=py37_0
+  - pytest=6.1.1=py37_0
   - pytest-forked=1.3.0=py_0
   - pytest-xdist=2.1.0=py_0
-  - python=3.7.7=hcff3b4d_5
+  - python=3.7.9=h7579374_0
   - python_abi=3.7=1_cp37m
   - readline=8.0=h7b6447c_0
-  - setuptools=49.6.0=py37_0
-  - six=1.15.0=py_0
+  - setuptools=50.3.1=py37h06a4308_1
+  - six=1.15.0=py37h06a4308_0
   - sqlite=3.33.0=h62c20be_0
   - tango-test=3.0=h6bb024c_2
   - tk=8.6.10=hbc83047_0
   - toml=0.10.1=py_0
-  - wheel=0.35.1=py_0
+  - wheel=0.35.1=pyhd3eb1b0_0
   - xz=5.2.5=h7b6447c_0
-  - zeromq=4.3.2=he6710b0_2
-  - zipp=3.1.0=py_0
+  - zeromq=4.3.3=he6710b0_3
+  - zipp=3.4.0=pyhd3eb1b0_0
   - zlib=1.2.11=h7b6447c_3
   - zope=1.0=py37_1
-  - zope.event=4.4=py37_0
-  - zope.interface=4.7.1=py37h7b6447c_0
+  - zope.event=4.5.0=py37_0
+  - zope.interface=5.1.2=py37h7b6447c_0
   - zstd=1.4.5=h9ceee32_0
 prefix: /opt/conda/envs/env-py3.7-tango9.3.4
 

--- a/.devcontainer/environment-py3.8-tango9.3.4.yml
+++ b/.devcontainer/environment-py3.8-tango9.3.4.yml
@@ -1,77 +1,80 @@
 name: env-py3.8-tango9.3.4
 channels:
   - tango-controls
-  - conda-forge
   - main
+  - conda-forge
   - defaults
 dependencies:
-  - _libgcc_mutex=0.1=main
+  - _libgcc_mutex=0.1=conda_forge
+  - _openmp_mutex=4.5=1_gnu
   - apipkg=1.5=py38_0
-  - attrs=20.1.0=py_0
+  - attrs=20.3.0=pyhd3eb1b0_0
   - binutils_impl_linux-64=2.33.1=he6710b0_7
   - binutils_linux-64=2.33.1=h9595d00_15
   - blas=1.0=mkl
-  - boost=1.73.0=py38hd103949_1
-  - boost-cpp=1.73.0=h9359b55_3
+  - boost=1.73.0=py38_11
   - bzip2=1.0.8=h7b6447c_0
-  - ca-certificates=2020.7.22=0
-  - certifi=2020.6.20=py38_0
-  - cffi=1.14.2=py38he30daa8_0
-  - cpptango=9.3.4rc6=h6bb024c_0
-  - cppzmq=4.6.0=hc9558a2_0
+  - ca-certificates=2020.10.14=0
+  - certifi=2020.6.20=pyhd3eb1b0_3
+  - cffi=1.14.3=py38he30daa8_0
+  - cpptango=9.3.4=h2bc3f7f_0
+  - cppzmq=4.7.1=h667716f_0
   - execnet=1.7.1=py_0
   - gcc_impl_linux-64=7.3.0=habb00fd_1
   - gcc_linux-64=7.3.0=h553295d_15
-  - gevent=20.6.2=py38h7b6447c_0
-  - greenlet=0.4.16=py38h7b6447c_0
+  - gevent=20.9.0=py38h7b6447c_0
+  - greenlet=0.4.17=py38h7b6447c_0
   - gxx_impl_linux-64=7.3.0=hdf63c60_1
   - gxx_linux-64=7.3.0=h553295d_15
-  - icu=67.1=he1b5a44_0
-  - iniconfig=1.0.1=py_0
+  - icu=58.2=he6710b0_3
+  - iniconfig=1.1.1=py_0
   - intel-openmp=2020.2=254
   - ld_impl_linux-64=2.33.1=h53a641e_7
+  - libboost=1.73.0=h37e3b65_11
   - libedit=3.1.20191231=h14c3975_1
   - libffi=3.3=he6710b0_2
-  - libgcc-ng=9.1.0=hdf63c60_0
+  - libgcc-ng=9.3.0=h5dbcf3e_17
+  - libgomp=9.3.0=h5dbcf3e_17
   - libsodium=1.0.18=h7b6447c_0
-  - libstdcxx-ng=9.1.0=hdf63c60_0
-  - lz4-c=1.9.2=he6710b0_1
+  - libstdcxx-ng=9.3.0=h2ae2ef3_17
+  - lz4-c=1.9.2=heb0550a_3
   - mkl=2020.2=256
   - mkl-service=2.3.0=py38he904b0f_0
-  - mkl_fft=1.1.0=py38h23d657b_0
+  - mkl_fft=1.2.0=py38h23d657b_0
   - mkl_random=1.1.1=py38h0573a6f_0
-  - more-itertools=8.4.0=py_0
+  - more-itertools=8.6.0=pyhd3eb1b0_0
   - ncurses=6.2=he6710b0_1
-  - numpy=1.19.1=py38hbc911f0_0
-  - numpy-base=1.19.1=py38hfa32c7d_0
-  - omniorb=4.2.4=py38h2c89da0_0
-  - openssl=1.1.1g=h7b6447c_0
+  - numpy=1.19.2=py38h54aff64_0
+  - numpy-base=1.19.2=py38hfa32c7d_0
+  - omniorb=4.2.4=py38h2c89da0_1
+  - openssl=1.1.1h=h7b6447c_0
   - packaging=20.4=py_0
-  - pip=20.2.2=py38_0
+  - pip=20.2.4=py38h06a4308_0
   - pluggy=0.13.1=py38_0
   - psutil=5.7.2=py38h7b6447c_0
   - py=1.9.0=py_0
+  - py-boost=1.73.0=py38h962f231_11
   - pycparser=2.20=py_2
   - pyparsing=2.4.7=py_0
-  - pytest=6.0.1=py38_0
+  - pytest=6.1.1=py38_0
   - pytest-forked=1.3.0=py_0
   - pytest-xdist=2.1.0=py_0
-  - python=3.8.5=hcff3b4d_0
+  - python=3.8.5=h7579374_1
   - python_abi=3.8=1_cp38
   - readline=8.0=h7b6447c_0
-  - setuptools=49.6.0=py38_0
-  - six=1.15.0=py_0
+  - setuptools=50.3.1=py38h06a4308_1
+  - six=1.15.0=py38h06a4308_0
   - sqlite=3.33.0=h62c20be_0
   - tango-test=3.0=h6bb024c_2
   - tk=8.6.10=hbc83047_0
   - toml=0.10.1=py_0
-  - wheel=0.35.1=py_0
+  - wheel=0.35.1=pyhd3eb1b0_0
   - xz=5.2.5=h7b6447c_0
-  - zeromq=4.3.2=he6710b0_2
+  - zeromq=4.3.3=he6710b0_3
   - zlib=1.2.11=h7b6447c_3
   - zope=1.0=py38_1
-  - zope.event=4.4=py38_0
-  - zope.interface=5.1.0=py38h7b6447c_0
+  - zope.event=4.5.0=py38_0
+  - zope.interface=5.1.2=py38h7b6447c_0
   - zstd=1.4.5=h9ceee32_0
 prefix: /opt/conda/envs/env-py3.8-tango9.3.4
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ branches:
 
 env:
   global:
-    - TANGO_DEPENDENCIES='cpptango==9.3.4rc6 tango-test'
+    - TANGO_DEPENDENCIES='cpptango==9.3.4 tango-test'
   matrix:
     - PYTHON_VERSION=2.7
     - PYTHON_VERSION=3.5

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,7 +4,7 @@ image: Visual Studio 2015
 
 environment:
   cpptango_download_base: https://github.com/tango-controls/cppTango/releases/download/
-  cpptango_version: 9.3.3
+  cpptango_version: 9.3.4
   boost_download_base: https://github.com/tango-controls/boost-ci/releases/download/
   matrix:
     - platform: win32


### PR DESCRIPTION
Official release of cppTango 9.3.4 is available on Conda, so use it.