### PR TITLE
Add std namespace prefix in C++ code

### DIFF
--- a/examples/interfacechangeEvents/IfchangeServer.cpp
+++ b/examples/interfacechangeEvents/IfchangeServer.cpp
@@ -118,7 +118,7 @@ IfchangeServer::IfchangeServer(Tango::DeviceClass *cl, const char *s, const char
 //--------------------------------------------------------
 void IfchangeServer::delete_device()
 {
-	DEBUG_STREAM << "IfchangeServer::delete_device() " << device_name << endl;
+	DEBUG_STREAM << "IfchangeServer::delete_device() " << device_name << std::endl;
 	/*----- PROTECTED REGION ID(IfchangeServer::delete_device) ENABLED START -----*/
 	
 	//	Delete device allocated objects
@@ -135,7 +135,7 @@ void IfchangeServer::delete_device()
 //--------------------------------------------------------
 void IfchangeServer::init_device()
 {
-	DEBUG_STREAM << "IfchangeServer::init_device() create device " << device_name << endl;
+	DEBUG_STREAM << "IfchangeServer::init_device() create device " << device_name << std::endl;
 	/*----- PROTECTED REGION ID(IfchangeServer::init_device_before) ENABLED START -----*/
 	
 	//	Initialization before get_device_property() call
@@ -163,7 +163,7 @@ void IfchangeServer::init_device()
 //--------------------------------------------------------
 void IfchangeServer::always_executed_hook()
 {
-	DEBUG_STREAM << "IfchangeServer::always_executed_hook()  " << device_name << endl;
+	DEBUG_STREAM << "IfchangeServer::always_executed_hook()  " << device_name << std::endl;
 	/*----- PROTECTED REGION ID(IfchangeServer::always_executed_hook) ENABLED START -----*/
 	
 	//	code always executed before all requests
@@ -179,7 +179,7 @@ void IfchangeServer::always_executed_hook()
 //--------------------------------------------------------
 void IfchangeServer::read_attr_hardware(TANGO_UNUSED(std::vector<long> &attr_list))
 {
-	DEBUG_STREAM << "IfchangeServer::read_attr_hardware(std::vector<long> &attr_list) entering... " << endl;
+	DEBUG_STREAM << "IfchangeServer::read_attr_hardware(std::vector<long> &attr_list) entering... " << std::endl;
 	/*----- PROTECTED REGION ID(IfchangeServer::read_attr_hardware) ENABLED START -----*/
 	
 	//	Add your own code
@@ -198,7 +198,7 @@ void IfchangeServer::read_attr_hardware(TANGO_UNUSED(std::vector<long> &attr_lis
 //--------------------------------------------------------
 void IfchangeServer::read_busy(Tango::Attribute &attr)
 {
-	DEBUG_STREAM << "IfchangeServer::read_busy(Tango::Attribute &attr) entering... " << endl;
+	DEBUG_STREAM << "IfchangeServer::read_busy(Tango::Attribute &attr) entering... " << std::endl;
 	/*----- PROTECTED REGION ID(IfchangeServer::read_busy) ENABLED START -----*/
 	//	Set the attribute value
 	*attr_busy_read = true;
@@ -218,7 +218,7 @@ void IfchangeServer::read_busy(Tango::Attribute &attr)
 //--------------------------------------------------------
 void IfchangeServer::read_ioattr(Tango::Attribute &attr)
 {
-	DEBUG_STREAM << "IfchangeServer::read_ioattr(Tango::Attribute &attr) entering... " << endl;
+	DEBUG_STREAM << "IfchangeServer::read_ioattr(Tango::Attribute &attr) entering... " << std::endl;
 	Tango::DevDouble	*att_value = get_ioattr_data_ptr(attr.get_name());
 	/*----- PROTECTED REGION ID(IfchangeServer::read_ioattr) ENABLED START -----*/
 	//	Set the attribute value
@@ -254,7 +254,7 @@ void IfchangeServer::add_dynamic_attributes()
 //--------------------------------------------------------
 void IfchangeServer::add_dynamic()
 {
-	DEBUG_STREAM << "IfchangeServer::Add_dynamic()  - " << device_name << endl;
+	DEBUG_STREAM << "IfchangeServer::Add_dynamic()  - " << device_name << std::endl;
 	/*----- PROTECTED REGION ID(IfchangeServer::add_dynamic) ENABLED START -----*/
 	
 	add_iocmd_dynamic_command("test_dynamic_Command", true);
@@ -272,7 +272,7 @@ void IfchangeServer::add_dynamic()
 //--------------------------------------------------------
 void IfchangeServer::delete__dynamic()
 {
-	DEBUG_STREAM << "IfchangeServer::Delete_Dynamic()  - " << device_name << endl;
+	DEBUG_STREAM << "IfchangeServer::Delete_Dynamic()  - " << device_name << std::endl;
 	/*----- PROTECTED REGION ID(IfchangeServer::delete__dynamic) ENABLED START -----*/
 	
 	remove_iocmd_dynamic_command("test_dynamic_Command");
@@ -290,7 +290,7 @@ void IfchangeServer::delete__dynamic()
 //--------------------------------------------------------
 void IfchangeServer::iocmd(Tango::Command &command)
 {
-	DEBUG_STREAM << "IfchangeServer::" << command.get_name() << "  - " << device_name << endl;
+	DEBUG_STREAM << "IfchangeServer::" << command.get_name() << "  - " << device_name << std::endl;
 	/*----- PROTECTED REGION ID(IfchangeServer::iocmd) ENABLED START -----*/
 	
 	//	Add your own code

--- a/examples/interfacechangeEvents/IfchangeServer.cpp
+++ b/examples/interfacechangeEvents/IfchangeServer.cpp
@@ -177,9 +177,9 @@ void IfchangeServer::always_executed_hook()
  *	Description : Hardware acquisition for attributes
  */
 //--------------------------------------------------------
-void IfchangeServer::read_attr_hardware(TANGO_UNUSED(vector<long> &attr_list))
+void IfchangeServer::read_attr_hardware(TANGO_UNUSED(std::vector<long> &attr_list))
 {
-	DEBUG_STREAM << "IfchangeServer::read_attr_hardware(vector<long> &attr_list) entering... " << endl;
+	DEBUG_STREAM << "IfchangeServer::read_attr_hardware(std::vector<long> &attr_list) entering... " << endl;
 	/*----- PROTECTED REGION ID(IfchangeServer::read_attr_hardware) ENABLED START -----*/
 	
 	//	Add your own code

--- a/examples/interfacechangeEvents/IfchangeServer.cpp
+++ b/examples/interfacechangeEvents/IfchangeServer.cpp
@@ -83,7 +83,7 @@ namespace IfchangeServer_ns
  *                implementing the classIfchangeServer
  */
 //--------------------------------------------------------
-IfchangeServer::IfchangeServer(Tango::DeviceClass *cl, string &s)
+IfchangeServer::IfchangeServer(Tango::DeviceClass *cl, std::string &s)
  : TANGO_BASE_CLASS(cl, s.c_str())
 {
 	/*----- PROTECTED REGION ID(IfchangeServer::constructor_1) ENABLED START -----*/

--- a/examples/interfacechangeEvents/IfchangeServer.h
+++ b/examples/interfacechangeEvents/IfchangeServer.h
@@ -124,7 +124,7 @@ public:
 	 *	Description : Hardware acquisition for attributes.
 	 */
 	//--------------------------------------------------------
-	virtual void read_attr_hardware(vector<long> &attr_list);
+	virtual void read_attr_hardware(std::vector<long> &attr_list);
 
 /**
  *	Attribute busy related methods

--- a/examples/interfacechangeEvents/IfchangeServer.h
+++ b/examples/interfacechangeEvents/IfchangeServer.h
@@ -78,7 +78,7 @@ public:
 	 *	@param cl	Class.
 	 *	@param s 	Device Name
 	 */
-	IfchangeServer(Tango::DeviceClass *cl,string &s);
+	IfchangeServer(Tango::DeviceClass *cl,std::string &s);
 	/**
 	 * Constructs a newly device object.
 	 *
@@ -148,10 +148,10 @@ public:
 	 */
 	virtual void read_ioattr(Tango::Attribute &attr);
 	virtual bool is_ioattr_allowed(Tango::AttReqType type);
-	void add_ioattr_dynamic_attribute(string attname);
-	void remove_ioattr_dynamic_attribute(string attname);
-	Tango::DevDouble *get_ioattr_data_ptr(string &name);
-	map<string,Tango::DevDouble>	   ioattr_data;
+	void add_ioattr_dynamic_attribute(std::string attname);
+	void remove_ioattr_dynamic_attribute(std::string attname);
+	Tango::DevDouble *get_ioattr_data_ptr(std::string &name);
+	map<std::string,Tango::DevDouble>	   ioattr_data;
 
 	//--------------------------------------------------------
 	/**
@@ -190,8 +190,8 @@ public:
 	 */
 	virtual void iocmd(Tango::Command &command);
 	virtual bool is_iocmd_allowed(const CORBA::Any &any);
-	void add_iocmd_dynamic_command(string cmdname, bool device);
-	void remove_iocmd_dynamic_command(string cmdname);
+	void add_iocmd_dynamic_command(std::string cmdname, bool device);
+	void remove_iocmd_dynamic_command(std::string cmdname);
 
 	//--------------------------------------------------------
 	/**

--- a/examples/interfacechangeEvents/IfchangeServerClass.cpp
+++ b/examples/interfacechangeEvents/IfchangeServerClass.cpp
@@ -83,7 +83,7 @@ IfchangeServerClass *IfchangeServerClass::_instance = NULL;
 //--------------------------------------------------------
 IfchangeServerClass::IfchangeServerClass(string &s):Tango::DeviceClass(s)
 {
-	cout2 << "Entering IfchangeServerClass constructor" << endl;
+	cout2 << "Entering IfchangeServerClass constructor" << std::endl;
 	set_default_property();
 	write_class_property();
 
@@ -91,7 +91,7 @@ IfchangeServerClass::IfchangeServerClass(string &s):Tango::DeviceClass(s)
 	
 	/*----- PROTECTED REGION END -----*/	//	IfchangeServerClass::constructor
 
-	cout2 << "Leaving IfchangeServerClass constructor" << endl;
+	cout2 << "Leaving IfchangeServerClass constructor" << std::endl;
 }
 
 //--------------------------------------------------------
@@ -147,7 +147,7 @@ IfchangeServerClass *IfchangeServerClass::instance()
 {
 	if (_instance == NULL)
 	{
-		cerr << "Class is not initialised !!" << endl;
+		cerr << "Class is not initialised !!" << std::endl;
 		exit(-1);
 	}
 	return _instance;
@@ -171,7 +171,7 @@ IfchangeServerClass *IfchangeServerClass::instance()
 //--------------------------------------------------------
 CORBA::Any *Add_dynamicClass::execute(Tango::DeviceImpl *device, TANGO_UNUSED(const CORBA::Any &in_any))
 {
-	cout2 << "Add_dynamicClass::execute(): arrived" << endl;
+	cout2 << "Add_dynamicClass::execute(): arrived" << std::endl;
 	((static_cast<IfchangeServer *>(device))->add_dynamic());
 	return new CORBA::Any();
 }
@@ -189,7 +189,7 @@ CORBA::Any *Add_dynamicClass::execute(Tango::DeviceImpl *device, TANGO_UNUSED(co
 //--------------------------------------------------------
 CORBA::Any *Delete_DynamicClass::execute(Tango::DeviceImpl *device, TANGO_UNUSED(const CORBA::Any &in_any))
 {
-	cout2 << "Delete_DynamicClass::execute(): arrived" << endl;
+	cout2 << "Delete_DynamicClass::execute(): arrived" << std::endl;
 	((static_cast<IfchangeServer *>(device))->delete__dynamic());
 	return new CORBA::Any();
 }
@@ -207,7 +207,7 @@ CORBA::Any *Delete_DynamicClass::execute(Tango::DeviceImpl *device, TANGO_UNUSED
 //--------------------------------------------------------
 CORBA::Any *iocmdClass::execute(Tango::DeviceImpl *device, TANGO_UNUSED(const CORBA::Any &in_any))
 {
-	cout2 << "iocmdClass::execute(): arrived" << endl;
+	cout2 << "iocmdClass::execute(): arrived" << std::endl;
 	((static_cast<IfchangeServer *>(device))->iocmd(*this));
 	return new CORBA::Any();
 }
@@ -444,7 +444,7 @@ void IfchangeServerClass::device_factory(const Tango::DevVarStringArray *devlist
 	//	Create devices and add it into the device list
 	for (unsigned long i=0 ; i<devlist_ptr->length() ; i++)
 	{
-		cout4 << "Device name : " << (*devlist_ptr)[i].in() << endl;
+		cout4 << "Device name : " << (*devlist_ptr)[i].in() << std::endl;
 		device_list.push_back(new IfchangeServer(this, (*devlist_ptr)[i]));
 	}
 
@@ -601,7 +601,7 @@ void IfchangeServerClass::create_static_attribute_list(std::vector<Tango::Attr *
 		defaultAttList.push_back(att_name);
 	}
 
-	cout2 << defaultAttList.size() << " attributes in default list" << endl;
+	cout2 << defaultAttList.size() << " attributes in default list" << std::endl;
 
 	/*----- PROTECTED REGION ID(IfchangeServerClass::create_static_att_list) ENABLED START -----*/
 	
@@ -637,7 +637,7 @@ void IfchangeServerClass::erase_dynamic_attributes(const Tango::DevVarStringArra
 			std::vector<string>::iterator ite_str = find(defaultAttList.begin(), defaultAttList.end(), att_name);
 			if (ite_str == defaultAttList.end())
 			{
-				cout2 << att_name << " is a UNWANTED dynamic attribute for device " << (*devlist_ptr)[i] << endl;
+				cout2 << att_name << " is a UNWANTED dynamic attribute for device " << (*devlist_ptr)[i] << std::endl;
 				Tango::Attribute &att = dev->get_device_attr()->get_attr_by_name(att_name.c_str());
 				dev->remove_attribute(att_list[att.get_attr_idx()], true, false);
 				--ite_att;

--- a/examples/interfacechangeEvents/IfchangeServerClass.cpp
+++ b/examples/interfacechangeEvents/IfchangeServerClass.cpp
@@ -128,7 +128,7 @@ IfchangeServerClass *IfchangeServerClass::init(const char *name)
 			string s(name);
 			_instance = new IfchangeServerClass(s);
 		}
-		catch (bad_alloc &)
+		catch (std::bad_alloc &)
 		{
 			throw;
 		}

--- a/examples/interfacechangeEvents/IfchangeServerClass.cpp
+++ b/examples/interfacechangeEvents/IfchangeServerClass.cpp
@@ -276,7 +276,7 @@ void IfchangeServerClass::set_default_property()
 	string	prop_name;
 	string	prop_desc;
 	string	prop_def;
-	vector<string>	vect_data;
+	std::vector<string>	vect_data;
 
 	//	Set Default Class Properties
 
@@ -308,7 +308,7 @@ void IfchangeServerClass::write_class_property()
 
 	//	Put Description
 	Tango::DbDatum	description("Description");
-	vector<string>	str_desc;
+	std::vector<string>	str_desc;
 	str_desc.push_back("");
 	description << str_desc;
 	data.push_back(description);
@@ -413,7 +413,7 @@ void IfchangeServerClass::write_class_property()
 
 	//  Put inheritance
 	Tango::DbDatum	inher_datum("InheritedFrom");
-	vector<string> inheritance;
+	std::vector<string> inheritance;
 	inheritance.push_back("TANGO_BASE_CLASS");
 	inher_datum << inheritance;
 	data.push_back(inher_datum);
@@ -479,7 +479,7 @@ void IfchangeServerClass::device_factory(const Tango::DevVarStringArray *devlist
  *                and store them in the attribute list
  */
 //--------------------------------------------------------
-void IfchangeServerClass::attribute_factory(vector<Tango::Attr *> &att_list)
+void IfchangeServerClass::attribute_factory(std::vector<Tango::Attr *> &att_list)
 {
 	/*----- PROTECTED REGION ID(IfchangeServerClass::attribute_factory_before) ENABLED START -----*/
 	
@@ -592,7 +592,7 @@ void IfchangeServerClass::command_factory()
  * @param	att_list	the ceated attribute list
  */
 //--------------------------------------------------------
-void IfchangeServerClass::create_static_attribute_list(vector<Tango::Attr *> &att_list)
+void IfchangeServerClass::create_static_attribute_list(std::vector<Tango::Attr *> &att_list)
 {
 	for (unsigned long i=0 ; i<att_list.size() ; i++)
 	{
@@ -618,7 +618,7 @@ void IfchangeServerClass::create_static_attribute_list(vector<Tango::Attr *> &at
  * @param	list of all attributes
  */
 //--------------------------------------------------------
-void IfchangeServerClass::erase_dynamic_attributes(const Tango::DevVarStringArray *devlist_ptr, vector<Tango::Attr *> &att_list)
+void IfchangeServerClass::erase_dynamic_attributes(const Tango::DevVarStringArray *devlist_ptr, std::vector<Tango::Attr *> &att_list)
 {
 	Tango::Util *tg = Tango::Util::instance();
 
@@ -627,14 +627,14 @@ void IfchangeServerClass::erase_dynamic_attributes(const Tango::DevVarStringArra
 		Tango::DeviceImpl *dev_impl = tg->get_device_by_name(((string)(*devlist_ptr)[i]).c_str());
 		IfchangeServer *dev = static_cast<IfchangeServer *> (dev_impl);
 
-		vector<Tango::Attribute *> &dev_att_list = dev->get_device_attr()->get_attribute_list();
-		vector<Tango::Attribute *>::iterator ite_att;
+		std::vector<Tango::Attribute *> &dev_att_list = dev->get_device_attr()->get_attribute_list();
+		std::vector<Tango::Attribute *>::iterator ite_att;
 		for (ite_att=dev_att_list.begin() ; ite_att != dev_att_list.end() ; ++ite_att)
 		{
 			string att_name((*ite_att)->get_name_lower());
 			if ((att_name == "state") || (att_name == "status"))
 				continue;
-			vector<string>::iterator ite_str = find(defaultAttList.begin(), defaultAttList.end(), att_name);
+			std::vector<string>::iterator ite_str = find(defaultAttList.begin(), defaultAttList.end(), att_name);
 			if (ite_str == defaultAttList.end())
 			{
 				cout2 << att_name << " is a UNWANTED dynamic attribute for device " << (*devlist_ptr)[i] << endl;
@@ -655,9 +655,9 @@ void IfchangeServerClass::erase_dynamic_attributes(const Tango::DevVarStringArra
  *	Description : returns Tango::Attr * object found by name
  */
 //--------------------------------------------------------
-Tango::Attr *IfchangeServerClass::get_attr_object_by_name(vector<Tango::Attr *> &att_list, string attname)
+Tango::Attr *IfchangeServerClass::get_attr_object_by_name(std::vector<Tango::Attr *> &att_list, string attname)
 {
-	vector<Tango::Attr *>::iterator it;
+	std::vector<Tango::Attr *>::iterator it;
 	for (it=att_list.begin() ; it<att_list.end() ; ++it)
 		if ((*it)->get_name()==attname)
 			return (*it);

--- a/examples/interfacechangeEvents/IfchangeServerClass.cpp
+++ b/examples/interfacechangeEvents/IfchangeServerClass.cpp
@@ -75,13 +75,13 @@ IfchangeServerClass *IfchangeServerClass::_instance = NULL;
 
 //--------------------------------------------------------
 /**
- * method : 		IfchangeServerClass::IfchangeServerClass(string &s)
+ * method : 		IfchangeServerClass::IfchangeServerClass(std::string &s)
  * description : 	constructor for the IfchangeServerClass
  *
  * @param s	The class name
  */
 //--------------------------------------------------------
-IfchangeServerClass::IfchangeServerClass(string &s):Tango::DeviceClass(s)
+IfchangeServerClass::IfchangeServerClass(std::string &s):Tango::DeviceClass(s)
 {
 	cout2 << "Entering IfchangeServerClass constructor" << std::endl;
 	set_default_property();
@@ -125,7 +125,7 @@ IfchangeServerClass *IfchangeServerClass::init(const char *name)
 	{
 		try
 		{
-			string s(name);
+			std::string s(name);
 			_instance = new IfchangeServerClass(s);
 		}
 		catch (std::bad_alloc &)
@@ -222,7 +222,7 @@ CORBA::Any *iocmdClass::execute(Tango::DeviceImpl *device, TANGO_UNUSED(const CO
  *	Description : Get the class property for specified name.
  */
 //--------------------------------------------------------
-Tango::DbDatum IfchangeServerClass::get_class_property(string &prop_name)
+Tango::DbDatum IfchangeServerClass::get_class_property(std::string &prop_name)
 {
 	for (unsigned int i=0 ; i<cl_prop.size() ; i++)
 		if (cl_prop[i].name == prop_name)
@@ -237,7 +237,7 @@ Tango::DbDatum IfchangeServerClass::get_class_property(string &prop_name)
  *	Description : Return the default value for device property.
  */
 //--------------------------------------------------------
-Tango::DbDatum IfchangeServerClass::get_default_device_property(string &prop_name)
+Tango::DbDatum IfchangeServerClass::get_default_device_property(std::string &prop_name)
 {
 	for (unsigned int i=0 ; i<dev_def_prop.size() ; i++)
 		if (dev_def_prop[i].name == prop_name)
@@ -252,7 +252,7 @@ Tango::DbDatum IfchangeServerClass::get_default_device_property(string &prop_nam
  *	Description : Return the default value for class property.
  */
 //--------------------------------------------------------
-Tango::DbDatum IfchangeServerClass::get_default_class_property(string &prop_name)
+Tango::DbDatum IfchangeServerClass::get_default_class_property(std::string &prop_name)
 {
 	for (unsigned int i=0 ; i<cl_def_prop.size() ; i++)
 		if (cl_def_prop[i].name == prop_name)
@@ -276,7 +276,7 @@ void IfchangeServerClass::set_default_property()
 	string	prop_name;
 	string	prop_desc;
 	string	prop_def;
-	std::vector<string>	vect_data;
+	std::vector<std::string>	vect_data;
 
 	//	Set Default Class Properties
 
@@ -308,7 +308,7 @@ void IfchangeServerClass::write_class_property()
 
 	//	Put Description
 	Tango::DbDatum	description("Description");
-	std::vector<string>	str_desc;
+	std::vector<std::string>	str_desc;
 	str_desc.push_back("");
 	description << str_desc;
 	data.push_back(description);
@@ -320,7 +320,7 @@ void IfchangeServerClass::write_class_property()
 	// check for cvs information
 	string	src_path(CvsPath);
 	start = src_path.find("/");
-	if (start!=string::npos)
+	if (start!=std::string::npos)
 	{
 		end   = src_path.find(filename);
 		if (end>start)
@@ -328,10 +328,10 @@ void IfchangeServerClass::write_class_property()
 			string	strloc = src_path.substr(start, end-start);
 			//	Check if specific repository
 			start = strloc.find("/cvsroot/");
-			if (start!=string::npos && start>0)
+			if (start!=std::string::npos && start>0)
 			{
 				string	repository = strloc.substr(0, start);
-				if (repository.find("/segfs/")!=string::npos)
+				if (repository.find("/segfs/")!=std::string::npos)
 					strloc = "ESRF:" + strloc.substr(start, strloc.length()-start);
 			}
 			Tango::DbDatum	cvs_loc("cvs_location");
@@ -345,7 +345,7 @@ void IfchangeServerClass::write_class_property()
 	{
 		string	src_path(SvnPath);
 		start = src_path.find("://");
-		if (start!=string::npos)
+		if (start!=std::string::npos)
 		{
 			end = src_path.find(filename);
 			if (end>start)
@@ -370,7 +370,7 @@ void IfchangeServerClass::write_class_property()
 	string	endstr(" $");
 	
 	end   = tagname.find(endstr);
-	if (end!=string::npos && end>start)
+	if (end!=std::string::npos && end>start)
 	{
 		string	strtag = tagname.substr(start, end-start);
 		Tango::DbDatum	cvs_tag("cvs_tag");
@@ -384,13 +384,13 @@ void IfchangeServerClass::write_class_property()
 	start = header.length();
 	
 	end   = svnpath.find(endstr);
-	if (end!=string::npos && end>start)
+	if (end!=std::string::npos && end>start)
 	{
 		string	strloc = svnpath.substr(start, end-start);
 		
-		string tagstr ("/tags/");
+		std::string tagstr ("/tags/");
 		start = strloc.find(tagstr);
-		if ( start!=string::npos )
+		if ( start!=std::string::npos )
 		{
 			start = start + tagstr.length();
 			end   = strloc.find(filename);
@@ -413,7 +413,7 @@ void IfchangeServerClass::write_class_property()
 
 	//  Put inheritance
 	Tango::DbDatum	inher_datum("InheritedFrom");
-	std::vector<string> inheritance;
+	std::vector<std::string> inheritance;
 	inheritance.push_back("TANGO_BASE_CLASS");
 	inher_datum << inheritance;
 	data.push_back(inher_datum);
@@ -596,7 +596,7 @@ void IfchangeServerClass::create_static_attribute_list(std::vector<Tango::Attr *
 {
 	for (unsigned long i=0 ; i<att_list.size() ; i++)
 	{
-		string att_name(att_list[i]->get_name());
+		std::string att_name(att_list[i]->get_name());
 		transform(att_name.begin(), att_name.end(), att_name.begin(), ::tolower);
 		defaultAttList.push_back(att_name);
 	}
@@ -631,10 +631,10 @@ void IfchangeServerClass::erase_dynamic_attributes(const Tango::DevVarStringArra
 		std::vector<Tango::Attribute *>::iterator ite_att;
 		for (ite_att=dev_att_list.begin() ; ite_att != dev_att_list.end() ; ++ite_att)
 		{
-			string att_name((*ite_att)->get_name_lower());
+			std::string att_name((*ite_att)->get_name_lower());
 			if ((att_name == "state") || (att_name == "status"))
 				continue;
-			std::vector<string>::iterator ite_str = find(defaultAttList.begin(), defaultAttList.end(), att_name);
+			std::vector<std::string>::iterator ite_str = find(defaultAttList.begin(), defaultAttList.end(), att_name);
 			if (ite_str == defaultAttList.end())
 			{
 				cout2 << att_name << " is a UNWANTED dynamic attribute for device " << (*devlist_ptr)[i] << std::endl;
@@ -655,7 +655,7 @@ void IfchangeServerClass::erase_dynamic_attributes(const Tango::DevVarStringArra
  *	Description : returns Tango::Attr * object found by name
  */
 //--------------------------------------------------------
-Tango::Attr *IfchangeServerClass::get_attr_object_by_name(std::vector<Tango::Attr *> &att_list, string attname)
+Tango::Attr *IfchangeServerClass::get_attr_object_by_name(std::vector<Tango::Attr *> &att_list, std::string attname)
 {
 	std::vector<Tango::Attr *>::iterator it;
 	for (it=att_list.begin() ; it<att_list.end() ; ++it)

--- a/examples/interfacechangeEvents/IfchangeServerClass.cpp
+++ b/examples/interfacechangeEvents/IfchangeServerClass.cpp
@@ -147,7 +147,7 @@ IfchangeServerClass *IfchangeServerClass::instance()
 {
 	if (_instance == NULL)
 	{
-		cerr << "Class is not initialised !!" << std::endl;
+		std::cerr << "Class is not initialised !!" << std::endl;
 		exit(-1);
 	}
 	return _instance;

--- a/examples/interfacechangeEvents/IfchangeServerClass.h
+++ b/examples/interfacechangeEvents/IfchangeServerClass.h
@@ -80,7 +80,7 @@ public:
 class ioattrAttrib: public Tango::Attr
 {
 public:
-	ioattrAttrib(const string &att_name):Attr(att_name.c_str(), 
+	ioattrAttrib(const std::string &att_name):Attr(att_name.c_str(),
 			Tango::DEV_DOUBLE, Tango::READ) {};
 	~ioattrAttrib() {};
 	virtual void read(Tango::DeviceImpl *dev,Tango::Attribute &att)
@@ -192,12 +192,12 @@ class IfchangeServerClass : public Tango::DeviceClass
 		static IfchangeServerClass *init(const char *);
 		static IfchangeServerClass *instance();
 		~IfchangeServerClass();
-		Tango::DbDatum	get_class_property(string &);
-		Tango::DbDatum	get_default_device_property(string &);
-		Tango::DbDatum	get_default_class_property(string &);
+		Tango::DbDatum	get_class_property(std::string &);
+		Tango::DbDatum	get_default_device_property(std::string &);
+		Tango::DbDatum	get_default_class_property(std::string &);
 	
 	protected:
-		IfchangeServerClass(string &);
+		IfchangeServerClass(std::string &);
 		static IfchangeServerClass *_instance;
 		void command_factory();
 		void attribute_factory(std::vector<Tango::Attr *> &);
@@ -205,15 +205,15 @@ class IfchangeServerClass : public Tango::DeviceClass
 		void write_class_property();
 		void set_default_property();
 		void get_class_property();
-		string get_cvstag();
-		string get_cvsroot();
+		std::string get_cvstag();
+		std::string get_cvsroot();
 	
 	private:
 		void device_factory(const Tango::DevVarStringArray *);
 		void create_static_attribute_list(std::vector<Tango::Attr *> &);
 		void erase_dynamic_attributes(const Tango::DevVarStringArray *,std::vector<Tango::Attr *> &);
-		std::vector<string>	defaultAttList;
-		Tango::Attr *get_attr_object_by_name(std::vector<Tango::Attr *> &att_list, string attname);
+		std::vector<std::string>	defaultAttList;
+		Tango::Attr *get_attr_object_by_name(std::vector<Tango::Attr *> &att_list, std::string attname);
 };
 
 }	//	End of namespace

--- a/examples/interfacechangeEvents/IfchangeServerClass.h
+++ b/examples/interfacechangeEvents/IfchangeServerClass.h
@@ -200,7 +200,7 @@ class IfchangeServerClass : public Tango::DeviceClass
 		IfchangeServerClass(string &);
 		static IfchangeServerClass *_instance;
 		void command_factory();
-		void attribute_factory(vector<Tango::Attr *> &);
+		void attribute_factory(std::vector<Tango::Attr *> &);
 		void pipe_factory();
 		void write_class_property();
 		void set_default_property();
@@ -210,10 +210,10 @@ class IfchangeServerClass : public Tango::DeviceClass
 	
 	private:
 		void device_factory(const Tango::DevVarStringArray *);
-		void create_static_attribute_list(vector<Tango::Attr *> &);
-		void erase_dynamic_attributes(const Tango::DevVarStringArray *,vector<Tango::Attr *> &);
-		vector<string>	defaultAttList;
-		Tango::Attr *get_attr_object_by_name(vector<Tango::Attr *> &att_list, string attname);
+		void create_static_attribute_list(std::vector<Tango::Attr *> &);
+		void erase_dynamic_attributes(const Tango::DevVarStringArray *,std::vector<Tango::Attr *> &);
+		std::vector<string>	defaultAttList;
+		Tango::Attr *get_attr_object_by_name(std::vector<Tango::Attr *> &att_list, string attname);
 };
 
 }	//	End of namespace

--- a/examples/interfacechangeEvents/IfchangeServerDynAttrUtils.cpp
+++ b/examples/interfacechangeEvents/IfchangeServerDynAttrUtils.cpp
@@ -71,7 +71,7 @@ namespace IfchangeServer_ns
  *  parameter attname: attribute name to be cretated and added.
  */
 //--------------------------------------------------------
-void IfchangeServer::add_ioattr_dynamic_attribute(string attname)
+void IfchangeServer::add_ioattr_dynamic_attribute(std::string attname)
 {
 	//	Attribute : ioattr
 	ioattrAttrib	*ioattr = new ioattrAttrib(attname);
@@ -109,10 +109,10 @@ void IfchangeServer::add_ioattr_dynamic_attribute(string attname)
  *  parameter attname: attribute name to be removed.
  */
 //--------------------------------------------------------
-void IfchangeServer::remove_ioattr_dynamic_attribute(string attname)
+void IfchangeServer::remove_ioattr_dynamic_attribute(std::string attname)
 {
 	remove_attribute(attname, true);
-	map<string,Tango::DevDouble>::iterator ite;
+	map<std::string,Tango::DevDouble>::iterator ite;
     if ((ite=ioattr_data.find(attname))!=ioattr_data.end())
     {
     	/*----- PROTECTED REGION ID(IfchangeServer::remove_ioattr_dynamic_attribute) ENABLED START -----*/
@@ -133,9 +133,9 @@ void IfchangeServer::remove_ioattr_dynamic_attribute(string attname)
  *  parameter attname: the specified attribute name.
  */
 //--------------------------------------------------------
-Tango::DevDouble *IfchangeServer::get_ioattr_data_ptr(string &name)
+Tango::DevDouble *IfchangeServer::get_ioattr_data_ptr(std::string &name)
 {
-	map<string,Tango::DevDouble>::iterator ite;
+	map<std::string,Tango::DevDouble>::iterator ite;
     if ((ite=ioattr_data.find(name))==ioattr_data.end())
     {
 		TangoSys_OMemStream	tms;
@@ -161,7 +161,7 @@ Tango::DevDouble *IfchangeServer::get_ioattr_data_ptr(string &name)
  *  parameter device:  Set this flag to true if the command must be added for only this device.
  */
 //--------------------------------------------------------
-void IfchangeServer::add_iocmd_dynamic_command(string cmdname, bool device)
+void IfchangeServer::add_iocmd_dynamic_command(std::string cmdname, bool device)
 {
 	iocmdClass	*piocmdCmd =
 		new iocmdClass(cmdname.c_str(),
@@ -178,7 +178,7 @@ void IfchangeServer::add_iocmd_dynamic_command(string cmdname, bool device)
  *  parameter cmdname: command name to be removed.
  */
 //--------------------------------------------------------
-void IfchangeServer::remove_iocmd_dynamic_command(string cmdname)
+void IfchangeServer::remove_iocmd_dynamic_command(std::string cmdname)
 {
 	remove_command(cmdname, true);
 }

--- a/examples/interfacechangeEvents/main.cpp
+++ b/examples/interfacechangeEvents/main.cpp
@@ -65,20 +65,20 @@ int main(int argc,char *argv[])
 
 		// Run the endless loop
 		//----------------------------------------
-		cout << "Ready to accept request" << std::endl;
+		std::cout << "Ready to accept request" << std::endl;
 		tg->server_run();
 	}
 	catch (bad_alloc &)
 	{
-		cout << "Can't allocate memory to store device object !!!" << std::endl;
-		cout << "Exiting" << std::endl;
+		std::cout << "Can't allocate memory to store device object !!!" << std::endl;
+		std::cout << "Exiting" << std::endl;
 	}
 	catch (CORBA::Exception &e)
 	{
 		Tango::Except::print_exception(e);
 		
-		cout << "Received a CORBA_Exception" << std::endl;
-		cout << "Exiting" << std::endl;
+		std::cout << "Received a CORBA_Exception" << std::endl;
+		std::cout << "Exiting" << std::endl;
 	}
 	Tango::Util::instance()->server_cleanup();
 	return(0);

--- a/examples/interfacechangeEvents/main.cpp
+++ b/examples/interfacechangeEvents/main.cpp
@@ -65,20 +65,20 @@ int main(int argc,char *argv[])
 
 		// Run the endless loop
 		//----------------------------------------
-		cout << "Ready to accept request" << endl;
+		cout << "Ready to accept request" << std::endl;
 		tg->server_run();
 	}
 	catch (bad_alloc &)
 	{
-		cout << "Can't allocate memory to store device object !!!" << endl;
-		cout << "Exiting" << endl;
+		cout << "Can't allocate memory to store device object !!!" << std::endl;
+		cout << "Exiting" << std::endl;
 	}
 	catch (CORBA::Exception &e)
 	{
 		Tango::Except::print_exception(e);
 		
-		cout << "Received a CORBA_Exception" << endl;
-		cout << "Exiting" << endl;
+		cout << "Received a CORBA_Exception" << std::endl;
+		cout << "Exiting" << std::endl;
 	}
 	Tango::Util::instance()->server_cleanup();
 	return(0);

--- a/examples/interfacechangeEvents/main.cpp
+++ b/examples/interfacechangeEvents/main.cpp
@@ -68,7 +68,7 @@ int main(int argc,char *argv[])
 		std::cout << "Ready to accept request" << std::endl;
 		tg->server_run();
 	}
-	catch (bad_alloc &)
+	catch (std::bad_alloc &)
 	{
 		std::cout << "Can't allocate memory to store device object !!!" << std::endl;
 		std::cout << "Exiting" << std::endl;

--- a/examples/pipeEvents/PipeServer.cpp
+++ b/examples/pipeEvents/PipeServer.cpp
@@ -171,9 +171,9 @@ void PipeServer::always_executed_hook()
  *	Description : Hardware acquisition for attributes
  */
 //--------------------------------------------------------
-void PipeServer::read_attr_hardware(TANGO_UNUSED(vector<long> &attr_list))
+void PipeServer::read_attr_hardware(TANGO_UNUSED(std::vector<long> &attr_list))
 {
-	DEBUG_STREAM << "PipeServer::read_attr_hardware(vector<long> &attr_list) entering... " << endl;
+	DEBUG_STREAM << "PipeServer::read_attr_hardware(std::vector<long> &attr_list) entering... " << endl;
 	/*----- PROTECTED REGION ID(PipeServer::read_attr_hardware) ENABLED START -----*/
 	
 	//	Add your own code
@@ -210,7 +210,7 @@ void PipeServer::read_TestPipe(Tango::Pipe &pipe)
 	DEBUG_STREAM << "PipeServer::read_TestPipe(Tango::Pipe &pipe) entering... " << endl;
 	/*----- PROTECTED REGION ID(PipeServer::read_TestPipe) ENABLED START -----*/
 
-    vector<string> de_names;
+    std::vector<string> de_names;
     de_names.push_back("x");
     de_names.push_back("y");
     de_names.push_back("width");
@@ -326,7 +326,7 @@ void PipeServer::cmd_push_pipe_event(Tango::DevShort argin)
 	{
 		Tango::DevicePipeBlob dpb("PipeEventCase0");
 
-		vector<string> de_inner_inner_names;
+		std::vector<string> de_inner_inner_names;
 		de_inner_inner_names.push_back("InnerInnerFirstDE");
 		de_inner_inner_names.push_back("InneraaaaaaaInnerSecondDE");
 		inner_inner_blob.set_data_elt_names(de_inner_inner_names);
@@ -340,7 +340,7 @@ void PipeServer::cmd_push_pipe_event(Tango::DevShort argin)
 		inner_inner_blob["InneraaaaaaaInnerSecondDE"] << v_db;
 		inner_inner_blob["InnerInnerFirstDE"] << dl;
 
-		vector<string> de_inner_names;
+		std::vector<string> de_inner_names;
 		de_inner_names.push_back("InnerFirstDE");
 		de_inner_names.push_back("InnerSecondDE");
 		de_inner_names.push_back("InnerThirdDE");
@@ -352,7 +352,7 @@ void PipeServer::cmd_push_pipe_event(Tango::DevShort argin)
 
 		inner_blob << inner_str << inner_inner_blob << inner_bool;
 
-		vector<string> de_names;
+		std::vector<string> de_names;
 		de_names.push_back("1DE");
 		de_names.push_back("2DE");
 		dpb.set_data_elt_names(de_names);
@@ -369,7 +369,7 @@ void PipeServer::cmd_push_pipe_event(Tango::DevShort argin)
 	else if (argin == 1)
 	{
 		Tango::DevicePipeBlob dpb("PipeEventCase1");
-		vector<string> de_names;
+		std::vector<string> de_names;
 		de_names.push_back("Another_1DE");
 		de_names.push_back("Another_2DE");
 		dpb.set_data_elt_names(de_names);
@@ -385,7 +385,7 @@ void PipeServer::cmd_push_pipe_event(Tango::DevShort argin)
 	else if (argin == 2)
 	{
 		Tango::DevicePipeBlob dpb("PipeEventCase2");
-		vector<string> de_names;
+		std::vector<string> de_names;
 		de_names.push_back("Qwerty_1DE");
 		de_names.push_back("Azerty_2DE");
 		dpb.set_data_elt_names(de_names);
@@ -425,7 +425,7 @@ void PipeServer::cmd_push_pipe_event(Tango::DevShort argin)
 	else if (argin == 4)
 	{
 		Tango::DevicePipeBlob dpb("PipeEventCase4");
-		vector<string> de_names;
+		std::vector<string> de_names;
 		de_names.push_back("Lunes");
 		de_names.push_back("Martes");
 		dpb.set_data_elt_names(de_names);

--- a/examples/pipeEvents/PipeServer.cpp
+++ b/examples/pipeEvents/PipeServer.cpp
@@ -81,7 +81,7 @@ namespace PipeServer_ns
  *                implementing the classPipeServer
  */
 //--------------------------------------------------------
-PipeServer::PipeServer(Tango::DeviceClass *cl, string &s)
+PipeServer::PipeServer(Tango::DeviceClass *cl, std::string &s)
  : TANGO_BASE_CLASS(cl, s.c_str())
 {
 	/*----- PROTECTED REGION ID(PipeServer::constructor_1) ENABLED START -----*/
@@ -210,7 +210,7 @@ void PipeServer::read_TestPipe(Tango::Pipe &pipe)
 	DEBUG_STREAM << "PipeServer::read_TestPipe(Tango::Pipe &pipe) entering... " << std::endl;
 	/*----- PROTECTED REGION ID(PipeServer::read_TestPipe) ENABLED START -----*/
 
-    std::vector<string> de_names;
+    std::vector<std::string> de_names;
     de_names.push_back("x");
     de_names.push_back("y");
     de_names.push_back("width");
@@ -222,7 +222,7 @@ void PipeServer::read_TestPipe(Tango::Pipe &pipe)
     y=6.0;
     width=30.0;
     height=45.0;
-    string root_name = "theBlob";
+    std::string root_name = "theBlob";
 
     pipe.set_root_blob_name(root_name);
     pipe << x << y << width << height;
@@ -326,7 +326,7 @@ void PipeServer::cmd_push_pipe_event(Tango::DevShort argin)
 	{
 		Tango::DevicePipeBlob dpb("PipeEventCase0");
 
-		std::vector<string> de_inner_inner_names;
+		std::vector<std::string> de_inner_inner_names;
 		de_inner_inner_names.push_back("InnerInnerFirstDE");
 		de_inner_inner_names.push_back("InneraaaaaaaInnerSecondDE");
 		inner_inner_blob.set_data_elt_names(de_inner_inner_names);
@@ -340,7 +340,7 @@ void PipeServer::cmd_push_pipe_event(Tango::DevShort argin)
 		inner_inner_blob["InneraaaaaaaInnerSecondDE"] << v_db;
 		inner_inner_blob["InnerInnerFirstDE"] << dl;
 
-		std::vector<string> de_inner_names;
+		std::vector<std::string> de_inner_names;
 		de_inner_names.push_back("InnerFirstDE");
 		de_inner_names.push_back("InnerSecondDE");
 		de_inner_names.push_back("InnerThirdDE");
@@ -352,7 +352,7 @@ void PipeServer::cmd_push_pipe_event(Tango::DevShort argin)
 
 		inner_blob << inner_str << inner_inner_blob << inner_bool;
 
-		std::vector<string> de_names;
+		std::vector<std::string> de_names;
 		de_names.push_back("1DE");
 		de_names.push_back("2DE");
 		dpb.set_data_elt_names(de_names);
@@ -369,14 +369,14 @@ void PipeServer::cmd_push_pipe_event(Tango::DevShort argin)
 	else if (argin == 1)
 	{
 		Tango::DevicePipeBlob dpb("PipeEventCase1");
-		std::vector<string> de_names;
+		std::vector<std::string> de_names;
 		de_names.push_back("Another_1DE");
 		de_names.push_back("Another_2DE");
 		dpb.set_data_elt_names(de_names);
 
 		v_dl.clear();
 		v_dl.push_back(2);
-		string str("Barcelona");
+		std::string str("Barcelona");
 
 		dpb << v_dl << str;
 
@@ -385,7 +385,7 @@ void PipeServer::cmd_push_pipe_event(Tango::DevShort argin)
 	else if (argin == 2)
 	{
 		Tango::DevicePipeBlob dpb("PipeEventCase2");
-		std::vector<string> de_names;
+		std::vector<std::string> de_names;
 		de_names.push_back("Qwerty_1DE");
 		de_names.push_back("Azerty_2DE");
 		dpb.set_data_elt_names(de_names);
@@ -396,7 +396,7 @@ void PipeServer::cmd_push_pipe_event(Tango::DevShort argin)
 		v_df.push_back(6.284);
 		v_df.push_back(12.568);
 		v_df.push_back(25.136);
-		string str("Barcelona");
+		std::string str("Barcelona");
 
 		dpb << str << v_df;
 
@@ -425,12 +425,12 @@ void PipeServer::cmd_push_pipe_event(Tango::DevShort argin)
 	else if (argin == 4)
 	{
 		Tango::DevicePipeBlob dpb("PipeEventCase4");
-		std::vector<string> de_names;
+		std::vector<std::string> de_names;
 		de_names.push_back("Lunes");
 		de_names.push_back("Martes");
 		dpb.set_data_elt_names(de_names);
 
-		string str("Girona");
+		std::string str("Girona");
 
 		v_dl.clear();
 		for (int loop = 0;loop < 3000;loop++)

--- a/examples/pipeEvents/PipeServer.cpp
+++ b/examples/pipeEvents/PipeServer.cpp
@@ -239,71 +239,71 @@ void PipeServer::write_TestPipe(Tango::WPipe &pipe)
 {
 	DEBUG_STREAM << "PipeServer::write_TestPipe(Tango::WPipe &pipe) entering... " << std::endl;
 	/*----- PROTECTED REGION ID(PipeServer::write_TestPipe) ENABLED START -----*/
-    cout << "root blob name " << pipe.get_root_blob_name() << std::endl;
-    cout << "nb of data elements " << pipe.get_data_elt_nb() << std::endl;
+    std::cout << "root blob name " << pipe.get_root_blob_name() << std::endl;
+    std::cout << "nb of data elements " << pipe.get_data_elt_nb() << std::endl;
     try {
         for (auto i=0; i<pipe.get_data_elt_nb(); i++) {
-        	cout << "name " << pipe.get_data_elt_name(i) << std::endl;
+        	std::cout << "name " << pipe.get_data_elt_name(i) << std::endl;
         }
 		for (auto i = 0; i < pipe.get_data_elt_nb(); i++) {
-			cout << "name " << pipe.get_data_elt_name(i) << std::endl;
+			std::cout << "name " << pipe.get_data_elt_name(i) << std::endl;
 			int data_type = pipe.get_data_elt_type(i);
-			cout << "data_type " << data_type << std::endl;
+			std::cout << "data_type " << data_type << std::endl;
 			if (data_type == Tango::DEV_DOUBLE) {
 				Tango::DataElement<double> data;
 				pipe >> data;
-				cout << "value " << data.value << std::endl;
+				std::cout << "value " << data.value << std::endl;
 			} else if (data_type == Tango::DEV_BOOLEAN) {
 				Tango::DataElement<bool> data;
 				pipe >> data;
-				cout << "value " << data.value << std::endl;
+				std::cout << "value " << data.value << std::endl;
 			} else if (data_type == Tango::DEV_STRING) {
 				Tango::DataElement<std::string> data;
 				pipe >> data;
-				cout << "value " << data.value << std::endl;
+				std::cout << "value " << data.value << std::endl;
 			} else if (data_type == Tango::DEV_LONG64) {
 				Tango::DataElement<int64_t> data;
 				pipe >> data;
-				cout << "value " << data.value << std::endl;
+				std::cout << "value " << data.value << std::endl;
 			} else if (data_type == Tango::DEV_STATE) {
 				Tango::DataElement<Tango::DevState> data;
 				pipe >> data;
-				cout << "value " << data.value << std::endl;
+				std::cout << "value " << data.value << std::endl;
 			} else if (data_type == Tango::DEVVAR_DOUBLEARRAY) {
 				std::vector<double> data;
 				pipe >> data;
 				for (std::vector<double>::iterator it = data.begin() ; it != data.end(); ++it)
-					cout << *it << " ";
-				cout << std::endl;
+					std::cout << *it << " ";
+				std::cout << std::endl;
 			} else if (data_type == Tango::DEVVAR_LONG64ARRAY) {
 				std::vector<int64_t> data;
 				pipe >> data;
 				for (std::vector<int64_t>::iterator it = data.begin() ; it != data.end(); ++it)
-					cout << *it << " ";
-				cout << std::endl;
+					std::cout << *it << " ";
+				std::cout << std::endl;
 			} else if (data_type == Tango::DEVVAR_STATEARRAY) {
 				std::vector<Tango::DevState> data;
 				pipe >> data;
 				for (std::vector<Tango::DevState>::iterator it = data.begin() ; it != data.end(); ++it)
-					cout << *it << " ";
-				cout << std::endl;
+					std::cout << *it << " ";
+				std::cout << std::endl;
 			} else if (data_type == Tango::DEVVAR_STRINGARRAY) {
 				std::vector<std::string> data;
 				pipe >> data;
 				for (std::vector<std::string>::iterator it = data.begin() ; it != data.end(); ++it)
-					cout << *it << " ";
-				cout << std::endl;
+					std::cout << *it << " ";
+				std::cout << std::endl;
 			} else if (data_type == Tango::DEVVAR_BOOLEANARRAY) {
 				std::vector<bool> data;
 				pipe >> data;
 				for (std::vector<bool>::iterator it = data.begin() ; it != data.end(); ++it)
-					cout << *it << " ";
-				cout << std::endl;
+					std::cout << *it << " ";
+				std::cout << std::endl;
 			}
 		}
 	}
 	catch (exception &e) {
-		cout << "Exception: " << e.what() << std::endl;
+		std::cout << "Exception: " << e.what() << std::endl;
 	}
 	//	Add your own code here
 

--- a/examples/pipeEvents/PipeServer.cpp
+++ b/examples/pipeEvents/PipeServer.cpp
@@ -116,7 +116,7 @@ PipeServer::PipeServer(Tango::DeviceClass *cl, const char *s, const char *d)
 //--------------------------------------------------------
 void PipeServer::delete_device()
 {
-	DEBUG_STREAM << "PipeServer::delete_device() " << device_name << endl;
+	DEBUG_STREAM << "PipeServer::delete_device() " << device_name << std::endl;
 	/*----- PROTECTED REGION ID(PipeServer::delete_device) ENABLED START -----*/
 	
 	//	Delete device allocated objects
@@ -132,7 +132,7 @@ void PipeServer::delete_device()
 //--------------------------------------------------------
 void PipeServer::init_device()
 {
-	DEBUG_STREAM << "PipeServer::init_device() create device " << device_name << endl;
+	DEBUG_STREAM << "PipeServer::init_device() create device " << device_name << std::endl;
 	/*----- PROTECTED REGION ID(PipeServer::init_device_before) ENABLED START -----*/
 	
 	//	Initialization before get_device_property() call
@@ -157,7 +157,7 @@ void PipeServer::init_device()
 //--------------------------------------------------------
 void PipeServer::always_executed_hook()
 {
-	DEBUG_STREAM << "PipeServer::always_executed_hook()  " << device_name << endl;
+	DEBUG_STREAM << "PipeServer::always_executed_hook()  " << device_name << std::endl;
 	/*----- PROTECTED REGION ID(PipeServer::always_executed_hook) ENABLED START -----*/
 	
 	//	code always executed before all requests
@@ -173,7 +173,7 @@ void PipeServer::always_executed_hook()
 //--------------------------------------------------------
 void PipeServer::read_attr_hardware(TANGO_UNUSED(std::vector<long> &attr_list))
 {
-	DEBUG_STREAM << "PipeServer::read_attr_hardware(std::vector<long> &attr_list) entering... " << endl;
+	DEBUG_STREAM << "PipeServer::read_attr_hardware(std::vector<long> &attr_list) entering... " << std::endl;
 	/*----- PROTECTED REGION ID(PipeServer::read_attr_hardware) ENABLED START -----*/
 	
 	//	Add your own code
@@ -207,7 +207,7 @@ void PipeServer::add_dynamic_attributes()
 //--------------------------------------------------------
 void PipeServer::read_TestPipe(Tango::Pipe &pipe)
 {
-	DEBUG_STREAM << "PipeServer::read_TestPipe(Tango::Pipe &pipe) entering... " << endl;
+	DEBUG_STREAM << "PipeServer::read_TestPipe(Tango::Pipe &pipe) entering... " << std::endl;
 	/*----- PROTECTED REGION ID(PipeServer::read_TestPipe) ENABLED START -----*/
 
     std::vector<string> de_names;
@@ -237,73 +237,73 @@ void PipeServer::read_TestPipe(Tango::Pipe &pipe)
 //--------------------------------------------------------
 void PipeServer::write_TestPipe(Tango::WPipe &pipe)
 {
-	DEBUG_STREAM << "PipeServer::write_TestPipe(Tango::WPipe &pipe) entering... " << endl;
+	DEBUG_STREAM << "PipeServer::write_TestPipe(Tango::WPipe &pipe) entering... " << std::endl;
 	/*----- PROTECTED REGION ID(PipeServer::write_TestPipe) ENABLED START -----*/
-    cout << "root blob name " << pipe.get_root_blob_name() << endl;
-    cout << "nb of data elements " << pipe.get_data_elt_nb() << endl;
+    cout << "root blob name " << pipe.get_root_blob_name() << std::endl;
+    cout << "nb of data elements " << pipe.get_data_elt_nb() << std::endl;
     try {
         for (auto i=0; i<pipe.get_data_elt_nb(); i++) {
-        	cout << "name " << pipe.get_data_elt_name(i) << endl;
+        	cout << "name " << pipe.get_data_elt_name(i) << std::endl;
         }
 		for (auto i = 0; i < pipe.get_data_elt_nb(); i++) {
-			cout << "name " << pipe.get_data_elt_name(i) << endl;
+			cout << "name " << pipe.get_data_elt_name(i) << std::endl;
 			int data_type = pipe.get_data_elt_type(i);
-			cout << "data_type " << data_type << endl;
+			cout << "data_type " << data_type << std::endl;
 			if (data_type == Tango::DEV_DOUBLE) {
 				Tango::DataElement<double> data;
 				pipe >> data;
-				cout << "value " << data.value << endl;
+				cout << "value " << data.value << std::endl;
 			} else if (data_type == Tango::DEV_BOOLEAN) {
 				Tango::DataElement<bool> data;
 				pipe >> data;
-				cout << "value " << data.value << endl;
+				cout << "value " << data.value << std::endl;
 			} else if (data_type == Tango::DEV_STRING) {
 				Tango::DataElement<std::string> data;
 				pipe >> data;
-				cout << "value " << data.value << endl;
+				cout << "value " << data.value << std::endl;
 			} else if (data_type == Tango::DEV_LONG64) {
 				Tango::DataElement<int64_t> data;
 				pipe >> data;
-				cout << "value " << data.value << endl;
+				cout << "value " << data.value << std::endl;
 			} else if (data_type == Tango::DEV_STATE) {
 				Tango::DataElement<Tango::DevState> data;
 				pipe >> data;
-				cout << "value " << data.value << endl;
+				cout << "value " << data.value << std::endl;
 			} else if (data_type == Tango::DEVVAR_DOUBLEARRAY) {
 				std::vector<double> data;
 				pipe >> data;
 				for (std::vector<double>::iterator it = data.begin() ; it != data.end(); ++it)
 					cout << *it << " ";
-				cout << endl;
+				cout << std::endl;
 			} else if (data_type == Tango::DEVVAR_LONG64ARRAY) {
 				std::vector<int64_t> data;
 				pipe >> data;
 				for (std::vector<int64_t>::iterator it = data.begin() ; it != data.end(); ++it)
 					cout << *it << " ";
-				cout << endl;
+				cout << std::endl;
 			} else if (data_type == Tango::DEVVAR_STATEARRAY) {
 				std::vector<Tango::DevState> data;
 				pipe >> data;
 				for (std::vector<Tango::DevState>::iterator it = data.begin() ; it != data.end(); ++it)
 					cout << *it << " ";
-				cout << endl;
+				cout << std::endl;
 			} else if (data_type == Tango::DEVVAR_STRINGARRAY) {
 				std::vector<std::string> data;
 				pipe >> data;
 				for (std::vector<std::string>::iterator it = data.begin() ; it != data.end(); ++it)
 					cout << *it << " ";
-				cout << endl;
+				cout << std::endl;
 			} else if (data_type == Tango::DEVVAR_BOOLEANARRAY) {
 				std::vector<bool> data;
 				pipe >> data;
 				for (std::vector<bool>::iterator it = data.begin() ; it != data.end(); ++it)
 					cout << *it << " ";
-				cout << endl;
+				cout << std::endl;
 			}
 		}
 	}
 	catch (exception &e) {
-		cout << "Exception: " << e.what() << endl;
+		cout << "Exception: " << e.what() << std::endl;
 	}
 	//	Add your own code here
 
@@ -319,7 +319,7 @@ void PipeServer::write_TestPipe(Tango::WPipe &pipe)
 //--------------------------------------------------------
 void PipeServer::cmd_push_pipe_event(Tango::DevShort argin)
 {
-	DEBUG_STREAM << "PipeServer::cmd_push_pipe_event()  - " << device_name << endl;
+	DEBUG_STREAM << "PipeServer::cmd_push_pipe_event()  - " << device_name << std::endl;
 	/*----- PROTECTED REGION ID(PipeServer::cmd_push_pipe_event) ENABLED START -----*/
 
     if (argin == 0)

--- a/examples/pipeEvents/PipeServer.h
+++ b/examples/pipeEvents/PipeServer.h
@@ -68,7 +68,7 @@ class PipeServer : public TANGO_BASE_CLASS
 	Tango::DevicePipeBlob 		inner_inner_blob;
 	Tango::DevicePipeBlob 		inner_blob;
 
-	string						inner_str;
+	std::string						inner_str;
 	Tango::DevBoolean			inner_bool;
 	std::vector<Tango::DevLong>		v_dl;
 
@@ -83,7 +83,7 @@ public:
 	 *	@param cl	Class.
 	 *	@param s 	Device Name
 	 */
-	PipeServer(Tango::DeviceClass *cl,string &s);
+	PipeServer(Tango::DeviceClass *cl,std::string &s);
 	/**
 	 * Constructs a newly device object.
 	 *

--- a/examples/pipeEvents/PipeServer.h
+++ b/examples/pipeEvents/PipeServer.h
@@ -64,13 +64,13 @@ class PipeServer : public TANGO_BASE_CLASS
 //	Add your own data members
 
 	Tango::DevLong 				dl;
-	vector<double> 				v_db;
+	std::vector<double> 				v_db;
 	Tango::DevicePipeBlob 		inner_inner_blob;
 	Tango::DevicePipeBlob 		inner_blob;
 
 	string						inner_str;
 	Tango::DevBoolean			inner_bool;
-	vector<Tango::DevLong>		v_dl;
+	std::vector<Tango::DevLong>		v_dl;
 
     /*----- PROTECTED REGION END -----*/	//	PipeServer::Data Members
 
@@ -129,7 +129,7 @@ public:
 	 *	Description : Hardware acquisition for attributes.
 	 */
 	//--------------------------------------------------------
-	virtual void read_attr_hardware(vector<long> &attr_list);
+	virtual void read_attr_hardware(std::vector<long> &attr_list);
 
 
 	//--------------------------------------------------------

--- a/examples/pipeEvents/PipeServerClass.cpp
+++ b/examples/pipeEvents/PipeServerClass.cpp
@@ -83,7 +83,7 @@ PipeServerClass *PipeServerClass::_instance = NULL;
 //--------------------------------------------------------
 PipeServerClass::PipeServerClass(string &s):Tango::DeviceClass(s)
 {
-	cout2 << "Entering PipeServerClass constructor" << endl;
+	cout2 << "Entering PipeServerClass constructor" << std::endl;
 	set_default_property();
 	write_class_property();
 
@@ -91,7 +91,7 @@ PipeServerClass::PipeServerClass(string &s):Tango::DeviceClass(s)
 	
 	/*----- PROTECTED REGION END -----*/	//	PipeServerClass::constructor
 
-	cout2 << "Leaving PipeServerClass constructor" << endl;
+	cout2 << "Leaving PipeServerClass constructor" << std::endl;
 }
 
 //--------------------------------------------------------
@@ -147,7 +147,7 @@ PipeServerClass *PipeServerClass::instance()
 {
 	if (_instance == NULL)
 	{
-		cerr << "Class is not initialised !!" << endl;
+		cerr << "Class is not initialised !!" << std::endl;
 		exit(-1);
 	}
 	return _instance;
@@ -171,7 +171,7 @@ PipeServerClass *PipeServerClass::instance()
 //--------------------------------------------------------
 CORBA::Any *cmd_push_pipe_eventClass::execute(Tango::DeviceImpl *device, const CORBA::Any &in_any)
 {
-	cout2 << "cmd_push_pipe_eventClass::execute(): arrived" << endl;
+	cout2 << "cmd_push_pipe_eventClass::execute(): arrived" << std::endl;
 	Tango::DevShort argin;
 	extract(in_any, argin);
 	((static_cast<PipeServer *>(device))->cmd_push_pipe_event(argin));
@@ -410,7 +410,7 @@ void PipeServerClass::device_factory(const Tango::DevVarStringArray *devlist_ptr
 	//	Create devices and add it into the device list
 	for (unsigned long i=0 ; i<devlist_ptr->length() ; i++)
 	{
-		cout4 << "Device name : " << (*devlist_ptr)[i].in() << endl;
+		cout4 << "Device name : " << (*devlist_ptr)[i].in() << std::endl;
 		device_list.push_back(new PipeServer(this, (*devlist_ptr)[i]));
 	}
 
@@ -540,7 +540,7 @@ void PipeServerClass::create_static_attribute_list(std::vector<Tango::Attr *> &a
 		defaultAttList.push_back(att_name);
 	}
 
-	cout2 << defaultAttList.size() << " attributes in default list" << endl;
+	cout2 << defaultAttList.size() << " attributes in default list" << std::endl;
 
 	/*----- PROTECTED REGION ID(PipeServerClass::create_static_att_list) ENABLED START -----*/
 	
@@ -576,7 +576,7 @@ void PipeServerClass::erase_dynamic_attributes(const Tango::DevVarStringArray *d
 			std::vector<string>::iterator ite_str = find(defaultAttList.begin(), defaultAttList.end(), att_name);
 			if (ite_str == defaultAttList.end())
 			{
-				cout2 << att_name << " is a UNWANTED dynamic attribute for device " << (*devlist_ptr)[i] << endl;
+				cout2 << att_name << " is a UNWANTED dynamic attribute for device " << (*devlist_ptr)[i] << std::endl;
 				Tango::Attribute &att = dev->get_device_attr()->get_attr_by_name(att_name.c_str());
 				dev->remove_attribute(att_list[att.get_attr_idx()], true, false);
 				--ite_att;

--- a/examples/pipeEvents/PipeServerClass.cpp
+++ b/examples/pipeEvents/PipeServerClass.cpp
@@ -75,13 +75,13 @@ PipeServerClass *PipeServerClass::_instance = NULL;
 
 //--------------------------------------------------------
 /**
- * method : 		PipeServerClass::PipeServerClass(string &s)
+ * method : 		PipeServerClass::PipeServerClass(std::string &s)
  * description : 	constructor for the PipeServerClass
  *
  * @param s	The class name
  */
 //--------------------------------------------------------
-PipeServerClass::PipeServerClass(string &s):Tango::DeviceClass(s)
+PipeServerClass::PipeServerClass(std::string &s):Tango::DeviceClass(s)
 {
 	cout2 << "Entering PipeServerClass constructor" << std::endl;
 	set_default_property();
@@ -125,7 +125,7 @@ PipeServerClass *PipeServerClass::init(const char *name)
 	{
 		try
 		{
-			string s(name);
+			std::string s(name);
 			_instance = new PipeServerClass(s);
 		}
 		catch (std::bad_alloc &)
@@ -188,7 +188,7 @@ CORBA::Any *cmd_push_pipe_eventClass::execute(Tango::DeviceImpl *device, const C
  *	Description : Get the class property for specified name.
  */
 //--------------------------------------------------------
-Tango::DbDatum PipeServerClass::get_class_property(string &prop_name)
+Tango::DbDatum PipeServerClass::get_class_property(std::string &prop_name)
 {
 	for (unsigned int i=0 ; i<cl_prop.size() ; i++)
 		if (cl_prop[i].name == prop_name)
@@ -203,7 +203,7 @@ Tango::DbDatum PipeServerClass::get_class_property(string &prop_name)
  *	Description : Return the default value for device property.
  */
 //--------------------------------------------------------
-Tango::DbDatum PipeServerClass::get_default_device_property(string &prop_name)
+Tango::DbDatum PipeServerClass::get_default_device_property(std::string &prop_name)
 {
 	for (unsigned int i=0 ; i<dev_def_prop.size() ; i++)
 		if (dev_def_prop[i].name == prop_name)
@@ -218,7 +218,7 @@ Tango::DbDatum PipeServerClass::get_default_device_property(string &prop_name)
  *	Description : Return the default value for class property.
  */
 //--------------------------------------------------------
-Tango::DbDatum PipeServerClass::get_default_class_property(string &prop_name)
+Tango::DbDatum PipeServerClass::get_default_class_property(std::string &prop_name)
 {
 	for (unsigned int i=0 ; i<cl_def_prop.size() ; i++)
 		if (cl_def_prop[i].name == prop_name)
@@ -242,7 +242,7 @@ void PipeServerClass::set_default_property()
 	string	prop_name;
 	string	prop_desc;
 	string	prop_def;
-	std::vector<string>	vect_data;
+	std::vector<std::string>	vect_data;
 
 	//	Set Default Class Properties
 
@@ -274,7 +274,7 @@ void PipeServerClass::write_class_property()
 
 	//	Put Description
 	Tango::DbDatum	description("Description");
-	std::vector<string>	str_desc;
+	std::vector<std::string>	str_desc;
 	str_desc.push_back("");
 	description << str_desc;
 	data.push_back(description);
@@ -286,7 +286,7 @@ void PipeServerClass::write_class_property()
 	// check for cvs information
 	string	src_path(CvsPath);
 	start = src_path.find("/");
-	if (start!=string::npos)
+	if (start!=std::string::npos)
 	{
 		end   = src_path.find(filename);
 		if (end>start)
@@ -294,10 +294,10 @@ void PipeServerClass::write_class_property()
 			string	strloc = src_path.substr(start, end-start);
 			//	Check if specific repository
 			start = strloc.find("/cvsroot/");
-			if (start!=string::npos && start>0)
+			if (start!=std::string::npos && start>0)
 			{
 				string	repository = strloc.substr(0, start);
-				if (repository.find("/segfs/")!=string::npos)
+				if (repository.find("/segfs/")!=std::string::npos)
 					strloc = "ESRF:" + strloc.substr(start, strloc.length()-start);
 			}
 			Tango::DbDatum	cvs_loc("cvs_location");
@@ -311,7 +311,7 @@ void PipeServerClass::write_class_property()
 	{
 		string	src_path(SvnPath);
 		start = src_path.find("://");
-		if (start!=string::npos)
+		if (start!=std::string::npos)
 		{
 			end = src_path.find(filename);
 			if (end>start)
@@ -336,7 +336,7 @@ void PipeServerClass::write_class_property()
 	string	endstr(" $");
 	
 	end   = tagname.find(endstr);
-	if (end!=string::npos && end>start)
+	if (end!=std::string::npos && end>start)
 	{
 		string	strtag = tagname.substr(start, end-start);
 		Tango::DbDatum	cvs_tag("cvs_tag");
@@ -350,13 +350,13 @@ void PipeServerClass::write_class_property()
 	start = header.length();
 	
 	end   = svnpath.find(endstr);
-	if (end!=string::npos && end>start)
+	if (end!=std::string::npos && end>start)
 	{
 		string	strloc = svnpath.substr(start, end-start);
 		
-		string tagstr ("/tags/");
+		std::string tagstr ("/tags/");
 		start = strloc.find(tagstr);
-		if ( start!=string::npos )
+		if ( start!=std::string::npos )
 		{
 			start = start + tagstr.length();
 			end   = strloc.find(filename);
@@ -379,7 +379,7 @@ void PipeServerClass::write_class_property()
 
 	//  Put inheritance
 	Tango::DbDatum	inher_datum("InheritedFrom");
-	std::vector<string> inheritance;
+	std::vector<std::string> inheritance;
 	inheritance.push_back("TANGO_BASE_CLASS");
 	inher_datum << inheritance;
 	data.push_back(inher_datum);
@@ -535,7 +535,7 @@ void PipeServerClass::create_static_attribute_list(std::vector<Tango::Attr *> &a
 {
 	for (unsigned long i=0 ; i<att_list.size() ; i++)
 	{
-		string att_name(att_list[i]->get_name());
+		std::string att_name(att_list[i]->get_name());
 		transform(att_name.begin(), att_name.end(), att_name.begin(), ::tolower);
 		defaultAttList.push_back(att_name);
 	}
@@ -570,10 +570,10 @@ void PipeServerClass::erase_dynamic_attributes(const Tango::DevVarStringArray *d
 		std::vector<Tango::Attribute *>::iterator ite_att;
 		for (ite_att=dev_att_list.begin() ; ite_att != dev_att_list.end() ; ++ite_att)
 		{
-			string att_name((*ite_att)->get_name_lower());
+			std::string att_name((*ite_att)->get_name_lower());
 			if ((att_name == "state") || (att_name == "status"))
 				continue;
-			std::vector<string>::iterator ite_str = find(defaultAttList.begin(), defaultAttList.end(), att_name);
+			std::vector<std::string>::iterator ite_str = find(defaultAttList.begin(), defaultAttList.end(), att_name);
 			if (ite_str == defaultAttList.end())
 			{
 				cout2 << att_name << " is a UNWANTED dynamic attribute for device " << (*devlist_ptr)[i] << std::endl;
@@ -594,7 +594,7 @@ void PipeServerClass::erase_dynamic_attributes(const Tango::DevVarStringArray *d
  *	Description : returns Tango::Attr * object found by name
  */
 //--------------------------------------------------------
-Tango::Attr *PipeServerClass::get_attr_object_by_name(std::vector<Tango::Attr *> &att_list, string attname)
+Tango::Attr *PipeServerClass::get_attr_object_by_name(std::vector<Tango::Attr *> &att_list, std::string attname)
 {
 	std::vector<Tango::Attr *>::iterator it;
 	for (it=att_list.begin() ; it<att_list.end() ; ++it)

--- a/examples/pipeEvents/PipeServerClass.cpp
+++ b/examples/pipeEvents/PipeServerClass.cpp
@@ -128,7 +128,7 @@ PipeServerClass *PipeServerClass::init(const char *name)
 			string s(name);
 			_instance = new PipeServerClass(s);
 		}
-		catch (bad_alloc &)
+		catch (std::bad_alloc &)
 		{
 			throw;
 		}

--- a/examples/pipeEvents/PipeServerClass.cpp
+++ b/examples/pipeEvents/PipeServerClass.cpp
@@ -242,7 +242,7 @@ void PipeServerClass::set_default_property()
 	string	prop_name;
 	string	prop_desc;
 	string	prop_def;
-	vector<string>	vect_data;
+	std::vector<string>	vect_data;
 
 	//	Set Default Class Properties
 
@@ -274,7 +274,7 @@ void PipeServerClass::write_class_property()
 
 	//	Put Description
 	Tango::DbDatum	description("Description");
-	vector<string>	str_desc;
+	std::vector<string>	str_desc;
 	str_desc.push_back("");
 	description << str_desc;
 	data.push_back(description);
@@ -379,7 +379,7 @@ void PipeServerClass::write_class_property()
 
 	//  Put inheritance
 	Tango::DbDatum	inher_datum("InheritedFrom");
-	vector<string> inheritance;
+	std::vector<string> inheritance;
 	inheritance.push_back("TANGO_BASE_CLASS");
 	inher_datum << inheritance;
 	data.push_back(inher_datum);
@@ -444,7 +444,7 @@ void PipeServerClass::device_factory(const Tango::DevVarStringArray *devlist_ptr
  *                and store them in the attribute list
  */
 //--------------------------------------------------------
-void PipeServerClass::attribute_factory(vector<Tango::Attr *> &att_list)
+void PipeServerClass::attribute_factory(std::vector<Tango::Attr *> &att_list)
 {
 	/*----- PROTECTED REGION ID(PipeServerClass::attribute_factory_before) ENABLED START -----*/
 	
@@ -531,7 +531,7 @@ void PipeServerClass::command_factory()
  * @param	att_list	the ceated attribute list
  */
 //--------------------------------------------------------
-void PipeServerClass::create_static_attribute_list(vector<Tango::Attr *> &att_list)
+void PipeServerClass::create_static_attribute_list(std::vector<Tango::Attr *> &att_list)
 {
 	for (unsigned long i=0 ; i<att_list.size() ; i++)
 	{
@@ -557,7 +557,7 @@ void PipeServerClass::create_static_attribute_list(vector<Tango::Attr *> &att_li
  * @param	list of all attributes
  */
 //--------------------------------------------------------
-void PipeServerClass::erase_dynamic_attributes(const Tango::DevVarStringArray *devlist_ptr, vector<Tango::Attr *> &att_list)
+void PipeServerClass::erase_dynamic_attributes(const Tango::DevVarStringArray *devlist_ptr, std::vector<Tango::Attr *> &att_list)
 {
 	Tango::Util *tg = Tango::Util::instance();
 
@@ -566,14 +566,14 @@ void PipeServerClass::erase_dynamic_attributes(const Tango::DevVarStringArray *d
 		Tango::DeviceImpl *dev_impl = tg->get_device_by_name(((string)(*devlist_ptr)[i]).c_str());
 		PipeServer *dev = static_cast<PipeServer *> (dev_impl);
 
-		vector<Tango::Attribute *> &dev_att_list = dev->get_device_attr()->get_attribute_list();
-		vector<Tango::Attribute *>::iterator ite_att;
+		std::vector<Tango::Attribute *> &dev_att_list = dev->get_device_attr()->get_attribute_list();
+		std::vector<Tango::Attribute *>::iterator ite_att;
 		for (ite_att=dev_att_list.begin() ; ite_att != dev_att_list.end() ; ++ite_att)
 		{
 			string att_name((*ite_att)->get_name_lower());
 			if ((att_name == "state") || (att_name == "status"))
 				continue;
-			vector<string>::iterator ite_str = find(defaultAttList.begin(), defaultAttList.end(), att_name);
+			std::vector<string>::iterator ite_str = find(defaultAttList.begin(), defaultAttList.end(), att_name);
 			if (ite_str == defaultAttList.end())
 			{
 				cout2 << att_name << " is a UNWANTED dynamic attribute for device " << (*devlist_ptr)[i] << endl;
@@ -594,9 +594,9 @@ void PipeServerClass::erase_dynamic_attributes(const Tango::DevVarStringArray *d
  *	Description : returns Tango::Attr * object found by name
  */
 //--------------------------------------------------------
-Tango::Attr *PipeServerClass::get_attr_object_by_name(vector<Tango::Attr *> &att_list, string attname)
+Tango::Attr *PipeServerClass::get_attr_object_by_name(std::vector<Tango::Attr *> &att_list, string attname)
 {
-	vector<Tango::Attr *>::iterator it;
+	std::vector<Tango::Attr *>::iterator it;
 	for (it=att_list.begin() ; it<att_list.end() ; ++it)
 		if ((*it)->get_name()==attname)
 			return (*it);

--- a/examples/pipeEvents/PipeServerClass.cpp
+++ b/examples/pipeEvents/PipeServerClass.cpp
@@ -147,7 +147,7 @@ PipeServerClass *PipeServerClass::instance()
 {
 	if (_instance == NULL)
 	{
-		cerr << "Class is not initialised !!" << std::endl;
+		std::cerr << "Class is not initialised !!" << std::endl;
 		exit(-1);
 	}
 	return _instance;

--- a/examples/pipeEvents/PipeServerClass.h
+++ b/examples/pipeEvents/PipeServerClass.h
@@ -137,7 +137,7 @@ class PipeServerClass : public Tango::DeviceClass
 		PipeServerClass(string &);
 		static PipeServerClass *_instance;
 		void command_factory();
-		void attribute_factory(vector<Tango::Attr *> &);
+		void attribute_factory(std::vector<Tango::Attr *> &);
 		void pipe_factory();
 		void write_class_property();
 		void set_default_property();
@@ -147,10 +147,10 @@ class PipeServerClass : public Tango::DeviceClass
 	
 	private:
 		void device_factory(const Tango::DevVarStringArray *);
-		void create_static_attribute_list(vector<Tango::Attr *> &);
-		void erase_dynamic_attributes(const Tango::DevVarStringArray *,vector<Tango::Attr *> &);
-		vector<string>	defaultAttList;
-		Tango::Attr *get_attr_object_by_name(vector<Tango::Attr *> &att_list, string attname);
+		void create_static_attribute_list(std::vector<Tango::Attr *> &);
+		void erase_dynamic_attributes(const Tango::DevVarStringArray *,std::vector<Tango::Attr *> &);
+		std::vector<string>	defaultAttList;
+		Tango::Attr *get_attr_object_by_name(std::vector<Tango::Attr *> &att_list, string attname);
 };
 
 }	//	End of namespace

--- a/examples/pipeEvents/PipeServerClass.h
+++ b/examples/pipeEvents/PipeServerClass.h
@@ -63,7 +63,7 @@ namespace PipeServer_ns
 class TestPipeClass: public Tango::WPipe
 {
 public:
-	TestPipeClass(const string &name, Tango::DispLevel level)
+	TestPipeClass(const std::string &name, Tango::DispLevel level)
 		:WPipe(name, level) {};
 
 	~TestPipeClass() {};
@@ -129,12 +129,12 @@ class PipeServerClass : public Tango::DeviceClass
 		static PipeServerClass *init(const char *);
 		static PipeServerClass *instance();
 		~PipeServerClass();
-		Tango::DbDatum	get_class_property(string &);
-		Tango::DbDatum	get_default_device_property(string &);
-		Tango::DbDatum	get_default_class_property(string &);
+		Tango::DbDatum	get_class_property(std::string &);
+		Tango::DbDatum	get_default_device_property(std::string &);
+		Tango::DbDatum	get_default_class_property(std::string &);
 	
 	protected:
-		PipeServerClass(string &);
+		PipeServerClass(std::string &);
 		static PipeServerClass *_instance;
 		void command_factory();
 		void attribute_factory(std::vector<Tango::Attr *> &);
@@ -142,15 +142,15 @@ class PipeServerClass : public Tango::DeviceClass
 		void write_class_property();
 		void set_default_property();
 		void get_class_property();
-		string get_cvstag();
-		string get_cvsroot();
+		std::string get_cvstag();
+		std::string get_cvsroot();
 	
 	private:
 		void device_factory(const Tango::DevVarStringArray *);
 		void create_static_attribute_list(std::vector<Tango::Attr *> &);
 		void erase_dynamic_attributes(const Tango::DevVarStringArray *,std::vector<Tango::Attr *> &);
-		std::vector<string>	defaultAttList;
-		Tango::Attr *get_attr_object_by_name(std::vector<Tango::Attr *> &att_list, string attname);
+		std::vector<std::string>	defaultAttList;
+		Tango::Attr *get_attr_object_by_name(std::vector<Tango::Attr *> &att_list, std::string attname);
 };
 
 }	//	End of namespace

--- a/examples/pipeEvents/main.cpp
+++ b/examples/pipeEvents/main.cpp
@@ -65,20 +65,20 @@ int main(int argc,char *argv[])
 
 		// Run the endless loop
 		//----------------------------------------
-		cout << "Ready to accept request" << std::endl;
+		std::cout << "Ready to accept request" << std::endl;
 		tg->server_run();
 	}
 	catch (bad_alloc &)
 	{
-		cout << "Can't allocate memory to store device object !!!" << std::endl;
-		cout << "Exiting" << std::endl;
+		std::cout << "Can't allocate memory to store device object !!!" << std::endl;
+		std::cout << "Exiting" << std::endl;
 	}
 	catch (CORBA::Exception &e)
 	{
 		Tango::Except::print_exception(e);
 		
-		cout << "Received a CORBA_Exception" << std::endl;
-		cout << "Exiting" << std::endl;
+		std::cout << "Received a CORBA_Exception" << std::endl;
+		std::cout << "Exiting" << std::endl;
 	}
 	Tango::Util::instance()->server_cleanup();
 	return(0);

--- a/examples/pipeEvents/main.cpp
+++ b/examples/pipeEvents/main.cpp
@@ -65,20 +65,20 @@ int main(int argc,char *argv[])
 
 		// Run the endless loop
 		//----------------------------------------
-		cout << "Ready to accept request" << endl;
+		cout << "Ready to accept request" << std::endl;
 		tg->server_run();
 	}
 	catch (bad_alloc &)
 	{
-		cout << "Can't allocate memory to store device object !!!" << endl;
-		cout << "Exiting" << endl;
+		cout << "Can't allocate memory to store device object !!!" << std::endl;
+		cout << "Exiting" << std::endl;
 	}
 	catch (CORBA::Exception &e)
 	{
 		Tango::Except::print_exception(e);
 		
-		cout << "Received a CORBA_Exception" << endl;
-		cout << "Exiting" << endl;
+		cout << "Received a CORBA_Exception" << std::endl;
+		cout << "Exiting" << std::endl;
 	}
 	Tango::Util::instance()->server_cleanup();
 	return(0);

--- a/examples/pipeEvents/main.cpp
+++ b/examples/pipeEvents/main.cpp
@@ -68,7 +68,7 @@ int main(int argc,char *argv[])
 		std::cout << "Ready to accept request" << std::endl;
 		tg->server_run();
 	}
-	catch (bad_alloc &)
+	catch (std::bad_alloc &)
 	{
 		std::cout << "Can't allocate memory to store device object !!!" << std::endl;
 		std::cout << "Exiting" << std::endl;

--- a/examples/pipes/PipeServer.cpp
+++ b/examples/pipes/PipeServer.cpp
@@ -80,7 +80,7 @@ namespace PipeServer_ns
  *                implementing the classPipeServer
  */
 //--------------------------------------------------------
-PipeServer::PipeServer(Tango::DeviceClass *cl, string &s)
+PipeServer::PipeServer(Tango::DeviceClass *cl, std::string &s)
  : TANGO_BASE_CLASS(cl, s.c_str())
 {
 	/*----- PROTECTED REGION ID(PipeServer::constructor_1) ENABLED START -----*/
@@ -207,7 +207,7 @@ void PipeServer::read_TestPipe(Tango::Pipe &pipe)
 	DEBUG_STREAM << "PipeServer::read_TestPipe(Tango::Pipe &pipe) entering... " << std::endl;
 	/*----- PROTECTED REGION ID(PipeServer::read_TestPipe) ENABLED START -----*/
 	
-    std::vector<string> de_names;
+    std::vector<std::string> de_names;
     de_names.push_back("x");
     de_names.push_back("y");
     de_names.push_back("width");
@@ -219,7 +219,7 @@ void PipeServer::read_TestPipe(Tango::Pipe &pipe)
     y=6.0;
     width=30.0;
     height=45.0;
-    string root_name = "theBlob";
+    std::string root_name = "theBlob";
 
     pipe.set_root_blob_name(root_name);
     pipe << x << y << width << height;

--- a/examples/pipes/PipeServer.cpp
+++ b/examples/pipes/PipeServer.cpp
@@ -115,7 +115,7 @@ PipeServer::PipeServer(Tango::DeviceClass *cl, const char *s, const char *d)
 //--------------------------------------------------------
 void PipeServer::delete_device()
 {
-	DEBUG_STREAM << "PipeServer::delete_device() " << device_name << endl;
+	DEBUG_STREAM << "PipeServer::delete_device() " << device_name << std::endl;
 	/*----- PROTECTED REGION ID(PipeServer::delete_device) ENABLED START -----*/
 	
 	//	Delete device allocated objects
@@ -131,7 +131,7 @@ void PipeServer::delete_device()
 //--------------------------------------------------------
 void PipeServer::init_device()
 {
-	DEBUG_STREAM << "PipeServer::init_device() create device " << device_name << endl;
+	DEBUG_STREAM << "PipeServer::init_device() create device " << device_name << std::endl;
 	/*----- PROTECTED REGION ID(PipeServer::init_device_before) ENABLED START -----*/
 	
 	//	Initialization before get_device_property() call
@@ -155,7 +155,7 @@ void PipeServer::init_device()
 //--------------------------------------------------------
 void PipeServer::always_executed_hook()
 {
-	DEBUG_STREAM << "PipeServer::always_executed_hook()  " << device_name << endl;
+	DEBUG_STREAM << "PipeServer::always_executed_hook()  " << device_name << std::endl;
 	/*----- PROTECTED REGION ID(PipeServer::always_executed_hook) ENABLED START -----*/
 	
 	//	code always executed before all requests
@@ -171,7 +171,7 @@ void PipeServer::always_executed_hook()
 //--------------------------------------------------------
 void PipeServer::read_attr_hardware(TANGO_UNUSED(std::vector<long> &attr_list))
 {
-	DEBUG_STREAM << "PipeServer::read_attr_hardware(std::vector<long> &attr_list) entering... " << endl;
+	DEBUG_STREAM << "PipeServer::read_attr_hardware(std::vector<long> &attr_list) entering... " << std::endl;
 	/*----- PROTECTED REGION ID(PipeServer::read_attr_hardware) ENABLED START -----*/
 	
 	//	Add your own code
@@ -204,7 +204,7 @@ void PipeServer::add_dynamic_attributes()
 //--------------------------------------------------------
 void PipeServer::read_TestPipe(Tango::Pipe &pipe)
 {
-	DEBUG_STREAM << "PipeServer::read_TestPipe(Tango::Pipe &pipe) entering... " << endl;
+	DEBUG_STREAM << "PipeServer::read_TestPipe(Tango::Pipe &pipe) entering... " << std::endl;
 	/*----- PROTECTED REGION ID(PipeServer::read_TestPipe) ENABLED START -----*/
 	
     std::vector<string> de_names;
@@ -234,15 +234,15 @@ void PipeServer::read_TestPipe(Tango::Pipe &pipe)
 //--------------------------------------------------------
 void PipeServer::write_TestPipe(Tango::WPipe &pipe)
 {
-	DEBUG_STREAM << "PipeServer::write_TestPipe(Tango::WPipe &pipe) entering... " << endl;
+	DEBUG_STREAM << "PipeServer::write_TestPipe(Tango::WPipe &pipe) entering... " << std::endl;
 	/*----- PROTECTED REGION ID(PipeServer::write_TestPipe) ENABLED START -----*/
-    cout << "root blob name " << pipe.get_root_blob_name() << endl;
-    cout << "nb of data elements " << pipe.get_data_elt_nb() << endl;
+    cout << "root blob name " << pipe.get_root_blob_name() << std::endl;
+    cout << "nb of data elements " << pipe.get_data_elt_nb() << std::endl;
     try {
     	extract(pipe);
     }
     catch (exception &e) {
-    	cout << "Exception: " << e.what() << endl;
+    	cout << "Exception: " << e.what() << std::endl;
     }
 	//	Add your own code here
 	
@@ -269,64 +269,64 @@ void PipeServer::add_dynamic_commands()
 template<typename T>
 void PipeServer::extract(T& obj) {
 	for (unsigned i = 0; i < obj.get_data_elt_nb(); i++) {
-		cout << "name " << obj.get_data_elt_name(i) << endl;
+		cout << "name " << obj.get_data_elt_name(i) << std::endl;
 	}
 	for (unsigned i = 0; i < obj.get_data_elt_nb(); i++) {
-		cout << "name " << obj.get_data_elt_name(i) << endl;
+		cout << "name " << obj.get_data_elt_name(i) << std::endl;
 		int data_type = obj.get_data_elt_type(i);
-		cout << "data_type " << data_type << endl;
+		cout << "data_type " << data_type << std::endl;
 		if (data_type == Tango::DEV_DOUBLE) {
 			Tango::DataElement<double> data;
 			obj >> data;
-			cout << "value " << data.value << endl;
+			cout << "value " << data.value << std::endl;
 		} else if (data_type == Tango::DEV_BOOLEAN) {
 			Tango::DataElement<bool> data;
 			obj >> data;
-			cout << "value " << data.value << endl;
+			cout << "value " << data.value << std::endl;
 		} else if (data_type == Tango::DEV_STRING) {
 			Tango::DataElement < std::string > data;
 			obj >> data;
-			cout << "value " << data.value << endl;
+			cout << "value " << data.value << std::endl;
 		} else if (data_type == Tango::DEV_LONG64) {
 			Tango::DataElement < int64_t > data;
 			obj >> data;
-			cout << "value " << data.value << endl;
+			cout << "value " << data.value << std::endl;
 		} else if (data_type == Tango::DEV_STATE) {
 			Tango::DataElement < Tango::DevState > data;
 			obj >> data;
-			cout << "value " << data.value << endl;
+			cout << "value " << data.value << std::endl;
 		} else if (data_type == Tango::DEVVAR_DOUBLEARRAY) {
 			std::vector<double> data;
 			obj >> data;
 			for (std::vector<double>::iterator it = data.begin(); it != data.end(); ++it)
 				cout << *it << " ";
-			cout << endl;
+			cout << std::endl;
 		} else if (data_type == Tango::DEVVAR_LONG64ARRAY) {
 			std::vector < int64_t > data;
 			obj >> data;
 			for (std::vector<int64_t>::iterator it = data.begin(); it != data.end(); ++it)
 				cout << *it << " ";
-			cout << endl;
+			cout << std::endl;
 		} else if (data_type == Tango::DEVVAR_STATEARRAY) {
 			std::vector < Tango::DevState > data;
 			obj >> data;
 			for (std::vector<Tango::DevState>::iterator it = data.begin(); it != data.end(); ++it)
 				cout << *it << " ";
-			cout << endl;
+			cout << std::endl;
 		} else if (data_type == Tango::DEVVAR_STRINGARRAY) {
 			std::vector < std::string > data;
 			obj >> data;
 			for (std::vector<std::string>::iterator it = data.begin(); it != data.end(); ++it)
 				cout << *it << " ";
-			cout << endl;
+			cout << std::endl;
 		} else if (data_type == Tango::DEVVAR_BOOLEANARRAY) {
 			std::vector<bool> data;
 			obj >> data;
 			for (std::vector<bool>::iterator it = data.begin(); it != data.end(); ++it)
 				cout << *it << " ";
-			cout << endl;
+			cout << std::endl;
 		} else if (data_type == Tango::DEV_PIPE_BLOB) {
-			cout << "Found inner blob" << endl;
+			cout << "Found inner blob" << std::endl;
 			Tango::DevicePipeBlob blob;
 			obj >> blob;
 			extract (blob);

--- a/examples/pipes/PipeServer.cpp
+++ b/examples/pipes/PipeServer.cpp
@@ -169,9 +169,9 @@ void PipeServer::always_executed_hook()
  *	Description : Hardware acquisition for attributes
  */
 //--------------------------------------------------------
-void PipeServer::read_attr_hardware(TANGO_UNUSED(vector<long> &attr_list))
+void PipeServer::read_attr_hardware(TANGO_UNUSED(std::vector<long> &attr_list))
 {
-	DEBUG_STREAM << "PipeServer::read_attr_hardware(vector<long> &attr_list) entering... " << endl;
+	DEBUG_STREAM << "PipeServer::read_attr_hardware(std::vector<long> &attr_list) entering... " << endl;
 	/*----- PROTECTED REGION ID(PipeServer::read_attr_hardware) ENABLED START -----*/
 	
 	//	Add your own code
@@ -207,7 +207,7 @@ void PipeServer::read_TestPipe(Tango::Pipe &pipe)
 	DEBUG_STREAM << "PipeServer::read_TestPipe(Tango::Pipe &pipe) entering... " << endl;
 	/*----- PROTECTED REGION ID(PipeServer::read_TestPipe) ENABLED START -----*/
 	
-    vector<string> de_names;
+    std::vector<string> de_names;
     de_names.push_back("x");
     de_names.push_back("y");
     de_names.push_back("width");

--- a/examples/pipes/PipeServer.cpp
+++ b/examples/pipes/PipeServer.cpp
@@ -236,13 +236,13 @@ void PipeServer::write_TestPipe(Tango::WPipe &pipe)
 {
 	DEBUG_STREAM << "PipeServer::write_TestPipe(Tango::WPipe &pipe) entering... " << std::endl;
 	/*----- PROTECTED REGION ID(PipeServer::write_TestPipe) ENABLED START -----*/
-    cout << "root blob name " << pipe.get_root_blob_name() << std::endl;
-    cout << "nb of data elements " << pipe.get_data_elt_nb() << std::endl;
+    std::cout << "root blob name " << pipe.get_root_blob_name() << std::endl;
+    std::cout << "nb of data elements " << pipe.get_data_elt_nb() << std::endl;
     try {
     	extract(pipe);
     }
     catch (exception &e) {
-    	cout << "Exception: " << e.what() << std::endl;
+    	std::cout << "Exception: " << e.what() << std::endl;
     }
 	//	Add your own code here
 	
@@ -269,64 +269,64 @@ void PipeServer::add_dynamic_commands()
 template<typename T>
 void PipeServer::extract(T& obj) {
 	for (unsigned i = 0; i < obj.get_data_elt_nb(); i++) {
-		cout << "name " << obj.get_data_elt_name(i) << std::endl;
+		std::cout << "name " << obj.get_data_elt_name(i) << std::endl;
 	}
 	for (unsigned i = 0; i < obj.get_data_elt_nb(); i++) {
-		cout << "name " << obj.get_data_elt_name(i) << std::endl;
+		std::cout << "name " << obj.get_data_elt_name(i) << std::endl;
 		int data_type = obj.get_data_elt_type(i);
-		cout << "data_type " << data_type << std::endl;
+		std::cout << "data_type " << data_type << std::endl;
 		if (data_type == Tango::DEV_DOUBLE) {
 			Tango::DataElement<double> data;
 			obj >> data;
-			cout << "value " << data.value << std::endl;
+			std::cout << "value " << data.value << std::endl;
 		} else if (data_type == Tango::DEV_BOOLEAN) {
 			Tango::DataElement<bool> data;
 			obj >> data;
-			cout << "value " << data.value << std::endl;
+			std::cout << "value " << data.value << std::endl;
 		} else if (data_type == Tango::DEV_STRING) {
 			Tango::DataElement < std::string > data;
 			obj >> data;
-			cout << "value " << data.value << std::endl;
+			std::cout << "value " << data.value << std::endl;
 		} else if (data_type == Tango::DEV_LONG64) {
 			Tango::DataElement < int64_t > data;
 			obj >> data;
-			cout << "value " << data.value << std::endl;
+			std::cout << "value " << data.value << std::endl;
 		} else if (data_type == Tango::DEV_STATE) {
 			Tango::DataElement < Tango::DevState > data;
 			obj >> data;
-			cout << "value " << data.value << std::endl;
+			std::cout << "value " << data.value << std::endl;
 		} else if (data_type == Tango::DEVVAR_DOUBLEARRAY) {
 			std::vector<double> data;
 			obj >> data;
 			for (std::vector<double>::iterator it = data.begin(); it != data.end(); ++it)
-				cout << *it << " ";
-			cout << std::endl;
+				std::cout << *it << " ";
+			std::cout << std::endl;
 		} else if (data_type == Tango::DEVVAR_LONG64ARRAY) {
 			std::vector < int64_t > data;
 			obj >> data;
 			for (std::vector<int64_t>::iterator it = data.begin(); it != data.end(); ++it)
-				cout << *it << " ";
-			cout << std::endl;
+				std::cout << *it << " ";
+			std::cout << std::endl;
 		} else if (data_type == Tango::DEVVAR_STATEARRAY) {
 			std::vector < Tango::DevState > data;
 			obj >> data;
 			for (std::vector<Tango::DevState>::iterator it = data.begin(); it != data.end(); ++it)
-				cout << *it << " ";
-			cout << std::endl;
+				std::cout << *it << " ";
+			std::cout << std::endl;
 		} else if (data_type == Tango::DEVVAR_STRINGARRAY) {
 			std::vector < std::string > data;
 			obj >> data;
 			for (std::vector<std::string>::iterator it = data.begin(); it != data.end(); ++it)
-				cout << *it << " ";
-			cout << std::endl;
+				std::cout << *it << " ";
+			std::cout << std::endl;
 		} else if (data_type == Tango::DEVVAR_BOOLEANARRAY) {
 			std::vector<bool> data;
 			obj >> data;
 			for (std::vector<bool>::iterator it = data.begin(); it != data.end(); ++it)
-				cout << *it << " ";
-			cout << std::endl;
+				std::cout << *it << " ";
+			std::cout << std::endl;
 		} else if (data_type == Tango::DEV_PIPE_BLOB) {
-			cout << "Found inner blob" << std::endl;
+			std::cout << "Found inner blob" << std::endl;
 			Tango::DevicePipeBlob blob;
 			obj >> blob;
 			extract (blob);

--- a/examples/pipes/PipeServer.h
+++ b/examples/pipes/PipeServer.h
@@ -75,7 +75,7 @@ public:
 	 *	@param cl	Class.
 	 *	@param s 	Device Name
 	 */
-	PipeServer(Tango::DeviceClass *cl,string &s);
+	PipeServer(Tango::DeviceClass *cl,std::string &s);
 	/**
 	 * Constructs a newly device object.
 	 *

--- a/examples/pipes/PipeServer.h
+++ b/examples/pipes/PipeServer.h
@@ -121,7 +121,7 @@ public:
 	 *	Description : Hardware acquisition for attributes.
 	 */
 	//--------------------------------------------------------
-	virtual void read_attr_hardware(vector<long> &attr_list);
+	virtual void read_attr_hardware(std::vector<long> &attr_list);
 
 
 	//--------------------------------------------------------

--- a/examples/pipes/PipeServerClass.cpp
+++ b/examples/pipes/PipeServerClass.cpp
@@ -222,7 +222,7 @@ void PipeServerClass::set_default_property()
 	string	prop_name;
 	string	prop_desc;
 	string	prop_def;
-	vector<string>	vect_data;
+	std::vector<string>	vect_data;
 
 	//	Set Default Class Properties
 
@@ -254,7 +254,7 @@ void PipeServerClass::write_class_property()
 
 	//	Put Description
 	Tango::DbDatum	description("Description");
-	vector<string>	str_desc;
+	std::vector<string>	str_desc;
 	str_desc.push_back("");
 	description << str_desc;
 	data.push_back(description);
@@ -359,7 +359,7 @@ void PipeServerClass::write_class_property()
 
 	//  Put inheritance
 	Tango::DbDatum	inher_datum("InheritedFrom");
-	vector<string> inheritance;
+	std::vector<string> inheritance;
 	inheritance.push_back("TANGO_BASE_CLASS");
 	inher_datum << inheritance;
 	data.push_back(inher_datum);
@@ -424,7 +424,7 @@ void PipeServerClass::device_factory(const Tango::DevVarStringArray *devlist_ptr
  *                and store them in the attribute list
  */
 //--------------------------------------------------------
-void PipeServerClass::attribute_factory(vector<Tango::Attr *> &att_list)
+void PipeServerClass::attribute_factory(std::vector<Tango::Attr *> &att_list)
 {
 	/*----- PROTECTED REGION ID(PipeServerClass::attribute_factory_before) ENABLED START -----*/
 	
@@ -502,7 +502,7 @@ void PipeServerClass::command_factory()
  * @param	att_list	the ceated attribute list
  */
 //--------------------------------------------------------
-void PipeServerClass::create_static_attribute_list(vector<Tango::Attr *> &att_list)
+void PipeServerClass::create_static_attribute_list(std::vector<Tango::Attr *> &att_list)
 {
 	for (unsigned long i=0 ; i<att_list.size() ; i++)
 	{
@@ -528,7 +528,7 @@ void PipeServerClass::create_static_attribute_list(vector<Tango::Attr *> &att_li
  * @param	list of all attributes
  */
 //--------------------------------------------------------
-void PipeServerClass::erase_dynamic_attributes(const Tango::DevVarStringArray *devlist_ptr, vector<Tango::Attr *> &att_list)
+void PipeServerClass::erase_dynamic_attributes(const Tango::DevVarStringArray *devlist_ptr, std::vector<Tango::Attr *> &att_list)
 {
 	Tango::Util *tg = Tango::Util::instance();
 
@@ -537,14 +537,14 @@ void PipeServerClass::erase_dynamic_attributes(const Tango::DevVarStringArray *d
 		Tango::DeviceImpl *dev_impl = tg->get_device_by_name(((string)(*devlist_ptr)[i]).c_str());
 		PipeServer *dev = static_cast<PipeServer *> (dev_impl);
 
-		vector<Tango::Attribute *> &dev_att_list = dev->get_device_attr()->get_attribute_list();
-		vector<Tango::Attribute *>::iterator ite_att;
+		std::vector<Tango::Attribute *> &dev_att_list = dev->get_device_attr()->get_attribute_list();
+		std::vector<Tango::Attribute *>::iterator ite_att;
 		for (ite_att=dev_att_list.begin() ; ite_att != dev_att_list.end() ; ++ite_att)
 		{
 			string att_name((*ite_att)->get_name_lower());
 			if ((att_name == "state") || (att_name == "status"))
 				continue;
-			vector<string>::iterator ite_str = find(defaultAttList.begin(), defaultAttList.end(), att_name);
+			std::vector<string>::iterator ite_str = find(defaultAttList.begin(), defaultAttList.end(), att_name);
 			if (ite_str == defaultAttList.end())
 			{
 				cout2 << att_name << " is a UNWANTED dynamic attribute for device " << (*devlist_ptr)[i] << endl;
@@ -565,9 +565,9 @@ void PipeServerClass::erase_dynamic_attributes(const Tango::DevVarStringArray *d
  *	Description : returns Tango::Attr * object found by name
  */
 //--------------------------------------------------------
-Tango::Attr *PipeServerClass::get_attr_object_by_name(vector<Tango::Attr *> &att_list, string attname)
+Tango::Attr *PipeServerClass::get_attr_object_by_name(std::vector<Tango::Attr *> &att_list, string attname)
 {
-	vector<Tango::Attr *>::iterator it;
+	std::vector<Tango::Attr *>::iterator it;
 	for (it=att_list.begin() ; it<att_list.end() ; ++it)
 		if ((*it)->get_name()==attname)
 			return (*it);

--- a/examples/pipes/PipeServerClass.cpp
+++ b/examples/pipes/PipeServerClass.cpp
@@ -128,7 +128,7 @@ PipeServerClass *PipeServerClass::init(const char *name)
 			string s(name);
 			_instance = new PipeServerClass(s);
 		}
-		catch (bad_alloc &)
+		catch (std::bad_alloc &)
 		{
 			throw;
 		}

--- a/examples/pipes/PipeServerClass.cpp
+++ b/examples/pipes/PipeServerClass.cpp
@@ -75,13 +75,13 @@ PipeServerClass *PipeServerClass::_instance = NULL;
 
 //--------------------------------------------------------
 /**
- * method : 		PipeServerClass::PipeServerClass(string &s)
+ * method : 		PipeServerClass::PipeServerClass(std::string &s)
  * description : 	constructor for the PipeServerClass
  *
  * @param s	The class name
  */
 //--------------------------------------------------------
-PipeServerClass::PipeServerClass(string &s):Tango::DeviceClass(s)
+PipeServerClass::PipeServerClass(std::string &s):Tango::DeviceClass(s)
 {
 	cout2 << "Entering PipeServerClass constructor" << std::endl;
 	set_default_property();
@@ -125,7 +125,7 @@ PipeServerClass *PipeServerClass::init(const char *name)
 	{
 		try
 		{
-			string s(name);
+			std::string s(name);
 			_instance = new PipeServerClass(s);
 		}
 		catch (std::bad_alloc &)
@@ -168,7 +168,7 @@ PipeServerClass *PipeServerClass::instance()
  *	Description : Get the class property for specified name.
  */
 //--------------------------------------------------------
-Tango::DbDatum PipeServerClass::get_class_property(string &prop_name)
+Tango::DbDatum PipeServerClass::get_class_property(std::string &prop_name)
 {
 	for (unsigned int i=0 ; i<cl_prop.size() ; i++)
 		if (cl_prop[i].name == prop_name)
@@ -183,7 +183,7 @@ Tango::DbDatum PipeServerClass::get_class_property(string &prop_name)
  *	Description : Return the default value for device property.
  */
 //--------------------------------------------------------
-Tango::DbDatum PipeServerClass::get_default_device_property(string &prop_name)
+Tango::DbDatum PipeServerClass::get_default_device_property(std::string &prop_name)
 {
 	for (unsigned int i=0 ; i<dev_def_prop.size() ; i++)
 		if (dev_def_prop[i].name == prop_name)
@@ -198,7 +198,7 @@ Tango::DbDatum PipeServerClass::get_default_device_property(string &prop_name)
  *	Description : Return the default value for class property.
  */
 //--------------------------------------------------------
-Tango::DbDatum PipeServerClass::get_default_class_property(string &prop_name)
+Tango::DbDatum PipeServerClass::get_default_class_property(std::string &prop_name)
 {
 	for (unsigned int i=0 ; i<cl_def_prop.size() ; i++)
 		if (cl_def_prop[i].name == prop_name)
@@ -222,7 +222,7 @@ void PipeServerClass::set_default_property()
 	string	prop_name;
 	string	prop_desc;
 	string	prop_def;
-	std::vector<string>	vect_data;
+	std::vector<std::string>	vect_data;
 
 	//	Set Default Class Properties
 
@@ -254,7 +254,7 @@ void PipeServerClass::write_class_property()
 
 	//	Put Description
 	Tango::DbDatum	description("Description");
-	std::vector<string>	str_desc;
+	std::vector<std::string>	str_desc;
 	str_desc.push_back("");
 	description << str_desc;
 	data.push_back(description);
@@ -266,7 +266,7 @@ void PipeServerClass::write_class_property()
 	// check for cvs information
 	string	src_path(CvsPath);
 	start = src_path.find("/");
-	if (start!=string::npos)
+	if (start!=std::string::npos)
 	{
 		end   = src_path.find(filename);
 		if (end>start)
@@ -274,10 +274,10 @@ void PipeServerClass::write_class_property()
 			string	strloc = src_path.substr(start, end-start);
 			//	Check if specific repository
 			start = strloc.find("/cvsroot/");
-			if (start!=string::npos && start>0)
+			if (start!=std::string::npos && start>0)
 			{
 				string	repository = strloc.substr(0, start);
-				if (repository.find("/segfs/")!=string::npos)
+				if (repository.find("/segfs/")!=std::string::npos)
 					strloc = "ESRF:" + strloc.substr(start, strloc.length()-start);
 			}
 			Tango::DbDatum	cvs_loc("cvs_location");
@@ -291,7 +291,7 @@ void PipeServerClass::write_class_property()
 	{
 		string	src_path(SvnPath);
 		start = src_path.find("://");
-		if (start!=string::npos)
+		if (start!=std::string::npos)
 		{
 			end = src_path.find(filename);
 			if (end>start)
@@ -316,7 +316,7 @@ void PipeServerClass::write_class_property()
 	string	endstr(" $");
 	
 	end   = tagname.find(endstr);
-	if (end!=string::npos && end>start)
+	if (end!=std::string::npos && end>start)
 	{
 		string	strtag = tagname.substr(start, end-start);
 		Tango::DbDatum	cvs_tag("cvs_tag");
@@ -330,13 +330,13 @@ void PipeServerClass::write_class_property()
 	start = header.length();
 	
 	end   = svnpath.find(endstr);
-	if (end!=string::npos && end>start)
+	if (end!=std::string::npos && end>start)
 	{
 		string	strloc = svnpath.substr(start, end-start);
 		
-		string tagstr ("/tags/");
+		std::string tagstr ("/tags/");
 		start = strloc.find(tagstr);
-		if ( start!=string::npos )
+		if ( start!=std::string::npos )
 		{
 			start = start + tagstr.length();
 			end   = strloc.find(filename);
@@ -359,7 +359,7 @@ void PipeServerClass::write_class_property()
 
 	//  Put inheritance
 	Tango::DbDatum	inher_datum("InheritedFrom");
-	std::vector<string> inheritance;
+	std::vector<std::string> inheritance;
 	inheritance.push_back("TANGO_BASE_CLASS");
 	inher_datum << inheritance;
 	data.push_back(inher_datum);
@@ -506,7 +506,7 @@ void PipeServerClass::create_static_attribute_list(std::vector<Tango::Attr *> &a
 {
 	for (unsigned long i=0 ; i<att_list.size() ; i++)
 	{
-		string att_name(att_list[i]->get_name());
+		std::string att_name(att_list[i]->get_name());
 		transform(att_name.begin(), att_name.end(), att_name.begin(), ::tolower);
 		defaultAttList.push_back(att_name);
 	}
@@ -541,10 +541,10 @@ void PipeServerClass::erase_dynamic_attributes(const Tango::DevVarStringArray *d
 		std::vector<Tango::Attribute *>::iterator ite_att;
 		for (ite_att=dev_att_list.begin() ; ite_att != dev_att_list.end() ; ++ite_att)
 		{
-			string att_name((*ite_att)->get_name_lower());
+			std::string att_name((*ite_att)->get_name_lower());
 			if ((att_name == "state") || (att_name == "status"))
 				continue;
-			std::vector<string>::iterator ite_str = find(defaultAttList.begin(), defaultAttList.end(), att_name);
+			std::vector<std::string>::iterator ite_str = find(defaultAttList.begin(), defaultAttList.end(), att_name);
 			if (ite_str == defaultAttList.end())
 			{
 				cout2 << att_name << " is a UNWANTED dynamic attribute for device " << (*devlist_ptr)[i] << std::endl;
@@ -565,7 +565,7 @@ void PipeServerClass::erase_dynamic_attributes(const Tango::DevVarStringArray *d
  *	Description : returns Tango::Attr * object found by name
  */
 //--------------------------------------------------------
-Tango::Attr *PipeServerClass::get_attr_object_by_name(std::vector<Tango::Attr *> &att_list, string attname)
+Tango::Attr *PipeServerClass::get_attr_object_by_name(std::vector<Tango::Attr *> &att_list, std::string attname)
 {
 	std::vector<Tango::Attr *>::iterator it;
 	for (it=att_list.begin() ; it<att_list.end() ; ++it)

--- a/examples/pipes/PipeServerClass.cpp
+++ b/examples/pipes/PipeServerClass.cpp
@@ -83,7 +83,7 @@ PipeServerClass *PipeServerClass::_instance = NULL;
 //--------------------------------------------------------
 PipeServerClass::PipeServerClass(string &s):Tango::DeviceClass(s)
 {
-	cout2 << "Entering PipeServerClass constructor" << endl;
+	cout2 << "Entering PipeServerClass constructor" << std::endl;
 	set_default_property();
 	write_class_property();
 
@@ -91,7 +91,7 @@ PipeServerClass::PipeServerClass(string &s):Tango::DeviceClass(s)
 	
 	/*----- PROTECTED REGION END -----*/	//	PipeServerClass::constructor
 
-	cout2 << "Leaving PipeServerClass constructor" << endl;
+	cout2 << "Leaving PipeServerClass constructor" << std::endl;
 }
 
 //--------------------------------------------------------
@@ -147,7 +147,7 @@ PipeServerClass *PipeServerClass::instance()
 {
 	if (_instance == NULL)
 	{
-		cerr << "Class is not initialised !!" << endl;
+		cerr << "Class is not initialised !!" << std::endl;
 		exit(-1);
 	}
 	return _instance;
@@ -390,7 +390,7 @@ void PipeServerClass::device_factory(const Tango::DevVarStringArray *devlist_ptr
 	//	Create devices and add it into the device list
 	for (unsigned long i=0 ; i<devlist_ptr->length() ; i++)
 	{
-		cout4 << "Device name : " << (*devlist_ptr)[i].in() << endl;
+		cout4 << "Device name : " << (*devlist_ptr)[i].in() << std::endl;
 		device_list.push_back(new PipeServer(this, (*devlist_ptr)[i]));
 	}
 
@@ -511,7 +511,7 @@ void PipeServerClass::create_static_attribute_list(std::vector<Tango::Attr *> &a
 		defaultAttList.push_back(att_name);
 	}
 
-	cout2 << defaultAttList.size() << " attributes in default list" << endl;
+	cout2 << defaultAttList.size() << " attributes in default list" << std::endl;
 
 	/*----- PROTECTED REGION ID(PipeServerClass::create_static_att_list) ENABLED START -----*/
 	
@@ -547,7 +547,7 @@ void PipeServerClass::erase_dynamic_attributes(const Tango::DevVarStringArray *d
 			std::vector<string>::iterator ite_str = find(defaultAttList.begin(), defaultAttList.end(), att_name);
 			if (ite_str == defaultAttList.end())
 			{
-				cout2 << att_name << " is a UNWANTED dynamic attribute for device " << (*devlist_ptr)[i] << endl;
+				cout2 << att_name << " is a UNWANTED dynamic attribute for device " << (*devlist_ptr)[i] << std::endl;
 				Tango::Attribute &att = dev->get_device_attr()->get_attr_by_name(att_name.c_str());
 				dev->remove_attribute(att_list[att.get_attr_idx()], true, false);
 				--ite_att;

--- a/examples/pipes/PipeServerClass.cpp
+++ b/examples/pipes/PipeServerClass.cpp
@@ -147,7 +147,7 @@ PipeServerClass *PipeServerClass::instance()
 {
 	if (_instance == NULL)
 	{
-		cerr << "Class is not initialised !!" << std::endl;
+		std::cerr << "Class is not initialised !!" << std::endl;
 		exit(-1);
 	}
 	return _instance;

--- a/examples/pipes/PipeServerClass.h
+++ b/examples/pipes/PipeServerClass.h
@@ -110,7 +110,7 @@ class PipeServerClass : public Tango::DeviceClass
 		PipeServerClass(string &);
 		static PipeServerClass *_instance;
 		void command_factory();
-		void attribute_factory(vector<Tango::Attr *> &);
+		void attribute_factory(std::vector<Tango::Attr *> &);
 		void pipe_factory();
 		void write_class_property();
 		void set_default_property();
@@ -120,10 +120,10 @@ class PipeServerClass : public Tango::DeviceClass
 	
 	private:
 		void device_factory(const Tango::DevVarStringArray *);
-		void create_static_attribute_list(vector<Tango::Attr *> &);
-		void erase_dynamic_attributes(const Tango::DevVarStringArray *,vector<Tango::Attr *> &);
-		vector<string>	defaultAttList;
-		Tango::Attr *get_attr_object_by_name(vector<Tango::Attr *> &att_list, string attname);
+		void create_static_attribute_list(std::vector<Tango::Attr *> &);
+		void erase_dynamic_attributes(const Tango::DevVarStringArray *,std::vector<Tango::Attr *> &);
+		std::vector<string>	defaultAttList;
+		Tango::Attr *get_attr_object_by_name(std::vector<Tango::Attr *> &att_list, string attname);
 };
 
 }	//	End of namespace

--- a/examples/pipes/PipeServerClass.h
+++ b/examples/pipes/PipeServerClass.h
@@ -63,7 +63,7 @@ namespace PipeServer_ns
 class TestPipeClass: public Tango::WPipe
 {
 public:
-	TestPipeClass(const string &name, Tango::DispLevel level)
+	TestPipeClass(const std::string &name, Tango::DispLevel level)
 		:WPipe(name, level) {};
 
 	~TestPipeClass() {};
@@ -102,12 +102,12 @@ class PipeServerClass : public Tango::DeviceClass
 		static PipeServerClass *init(const char *);
 		static PipeServerClass *instance();
 		~PipeServerClass();
-		Tango::DbDatum	get_class_property(string &);
-		Tango::DbDatum	get_default_device_property(string &);
-		Tango::DbDatum	get_default_class_property(string &);
+		Tango::DbDatum	get_class_property(std::string &);
+		Tango::DbDatum	get_default_device_property(std::string &);
+		Tango::DbDatum	get_default_class_property(std::string &);
 	
 	protected:
-		PipeServerClass(string &);
+		PipeServerClass(std::string &);
 		static PipeServerClass *_instance;
 		void command_factory();
 		void attribute_factory(std::vector<Tango::Attr *> &);
@@ -115,15 +115,15 @@ class PipeServerClass : public Tango::DeviceClass
 		void write_class_property();
 		void set_default_property();
 		void get_class_property();
-		string get_cvstag();
-		string get_cvsroot();
+		std::string get_cvstag();
+		std::string get_cvsroot();
 	
 	private:
 		void device_factory(const Tango::DevVarStringArray *);
 		void create_static_attribute_list(std::vector<Tango::Attr *> &);
 		void erase_dynamic_attributes(const Tango::DevVarStringArray *,std::vector<Tango::Attr *> &);
-		std::vector<string>	defaultAttList;
-		Tango::Attr *get_attr_object_by_name(std::vector<Tango::Attr *> &att_list, string attname);
+		std::vector<std::string>	defaultAttList;
+		Tango::Attr *get_attr_object_by_name(std::vector<Tango::Attr *> &att_list, std::string attname);
 };
 
 }	//	End of namespace

--- a/examples/pipes/main.cpp
+++ b/examples/pipes/main.cpp
@@ -65,20 +65,20 @@ int main(int argc,char *argv[])
 
 		// Run the endless loop
 		//----------------------------------------
-		cout << "Ready to accept request" << std::endl;
+		std::cout << "Ready to accept request" << std::endl;
 		tg->server_run();
 	}
 	catch (bad_alloc &)
 	{
-		cout << "Can't allocate memory to store device object !!!" << std::endl;
-		cout << "Exiting" << std::endl;
+		std::cout << "Can't allocate memory to store device object !!!" << std::endl;
+		std::cout << "Exiting" << std::endl;
 	}
 	catch (CORBA::Exception &e)
 	{
 		Tango::Except::print_exception(e);
 		
-		cout << "Received a CORBA_Exception" << std::endl;
-		cout << "Exiting" << std::endl;
+		std::cout << "Received a CORBA_Exception" << std::endl;
+		std::cout << "Exiting" << std::endl;
 	}
 	Tango::Util::instance()->server_cleanup();
 	return(0);

--- a/examples/pipes/main.cpp
+++ b/examples/pipes/main.cpp
@@ -65,20 +65,20 @@ int main(int argc,char *argv[])
 
 		// Run the endless loop
 		//----------------------------------------
-		cout << "Ready to accept request" << endl;
+		cout << "Ready to accept request" << std::endl;
 		tg->server_run();
 	}
 	catch (bad_alloc &)
 	{
-		cout << "Can't allocate memory to store device object !!!" << endl;
-		cout << "Exiting" << endl;
+		cout << "Can't allocate memory to store device object !!!" << std::endl;
+		cout << "Exiting" << std::endl;
 	}
 	catch (CORBA::Exception &e)
 	{
 		Tango::Except::print_exception(e);
 		
-		cout << "Received a CORBA_Exception" << endl;
-		cout << "Exiting" << endl;
+		cout << "Received a CORBA_Exception" << std::endl;
+		cout << "Exiting" << std::endl;
 	}
 	Tango::Util::instance()->server_cleanup();
 	return(0);

--- a/examples/pipes/main.cpp
+++ b/examples/pipes/main.cpp
@@ -68,7 +68,7 @@ int main(int argc,char *argv[])
 		std::cout << "Ready to accept request" << std::endl;
 		tg->server_run();
 	}
-	catch (bad_alloc &)
+	catch (std::bad_alloc &)
 	{
 		std::cout << "Can't allocate memory to store device object !!!" << std::endl;
 		std::cout << "Exiting" << std::endl;

--- a/ext/connection.cpp
+++ b/ext/connection.cpp
@@ -19,18 +19,18 @@ namespace PyConnection
     using namespace boost::python;
 
     static
-    Tango::DeviceData command_inout(Tango::Connection& self, const string & cmd_name, const Tango::DeviceData &argin)
+    Tango::DeviceData command_inout(Tango::Connection& self, const std::string & cmd_name, const Tango::DeviceData &argin)
     {
         AutoPythonAllowThreads guard;
-        return self.command_inout(const_cast<string&>(cmd_name), const_cast<Tango::DeviceData&>(argin));
+        return self.command_inout(const_cast<std::string&>(cmd_name), const_cast<Tango::DeviceData&>(argin));
     }
 
 
     static
-    long command_inout_asynch_id(Tango::Connection& self, const string &cmd_name, const Tango::DeviceData &argin, bool forget)
+    long command_inout_asynch_id(Tango::Connection& self, const std::string &cmd_name, const Tango::DeviceData &argin, bool forget)
     {
         AutoPythonAllowThreads guard;
-        return self.command_inout_asynch(const_cast<string&>(cmd_name), const_cast<Tango::DeviceData&>(argin), forget);
+        return self.command_inout_asynch(const_cast<std::string&>(cmd_name), const_cast<Tango::DeviceData&>(argin), forget);
     }
 
 
@@ -49,7 +49,7 @@ namespace PyConnection
     }
 
     static
-    void command_inout_asynch_cb(object py_self, const string & cmd_name, const Tango::DeviceData &argin, object py_cb)
+    void command_inout_asynch_cb(object py_self, const std::string & cmd_name, const Tango::DeviceData &argin, object py_cb)
     {
         Tango::Connection* self = extract<Tango::Connection*>(py_self);
         PyCallBackAutoDie* cb = extract<PyCallBackAutoDie*>(py_cb);
@@ -57,7 +57,7 @@ namespace PyConnection
 
         try {
             AutoPythonAllowThreads guard;
-            self->command_inout_asynch(const_cast<string&>(cmd_name), const_cast<Tango::DeviceData&>(argin), *cb);
+            self->command_inout_asynch(const_cast<std::string&>(cmd_name), const_cast<Tango::DeviceData&>(argin), *cb);
         } catch (...) {
             cb->unset_autokill_references();
             throw;
@@ -80,7 +80,7 @@ namespace PyConnection
     
     str get_fqdn()
     {
-        string fqdn;
+        std::string fqdn;
         Tango::Connection::get_fqdn(fqdn);
         return str(fqdn.c_str());
     }

--- a/ext/database.cpp
+++ b/ext/database.cpp
@@ -316,19 +316,19 @@ void export_database()
             (Tango::DbDevFullInfo (Tango::Database::*) (const std::string &))
             get_device_info_)
         .def("get_device_name",
-            (Tango::DbDatum (Tango::Database::*) (const string &, const string &))
+            (Tango::DbDatum (Tango::Database::*) (const std::string &, const std::string &))
             get_device_name_)
         .def("get_device_exported",
-            (Tango::DbDatum (Tango::Database::*) (const string &))
+            (Tango::DbDatum (Tango::Database::*) (const std::string &))
             get_device_exported_)
         .def("get_device_domain",
-            (Tango::DbDatum (Tango::Database::*) (const string &))
+            (Tango::DbDatum (Tango::Database::*) (const std::string &))
             get_device_domain_)
         .def("get_device_family",
-            (Tango::DbDatum (Tango::Database::*) (const string &))
+            (Tango::DbDatum (Tango::Database::*) (const std::string &))
             get_device_family_)
         .def("get_device_member",
-            (Tango::DbDatum (Tango::Database::*) (const string &))
+            (Tango::DbDatum (Tango::Database::*) (const std::string &))
             get_device_member_)
         .def("get_device_alias", &PyDatabase::get_device_alias)
         .def("get_alias", &PyDatabase::get_alias)

--- a/ext/device_proxy.cpp
+++ b/ext/device_proxy.cpp
@@ -458,7 +458,7 @@ namespace PyDeviceProxy
             device_data_hist =
                 self.command_history(const_cast<std::string&>(cmd_name), depth);
         }
-        vector<Tango::DeviceDataHistory>::iterator it = device_data_hist->begin();
+        std::vector<Tango::DeviceDataHistory>::iterator it = device_data_hist->begin();
         for(;it != device_data_hist->end(); ++it)
         {
             Tango::DeviceDataHistory& hist = *it;
@@ -471,7 +471,7 @@ namespace PyDeviceProxy
     static inline bopy::object
             attribute_history(Tango::DeviceProxy& self, const std::string & attr_name, int depth, PyTango::ExtractAs extract_as)
     {
-        unique_pointer< vector<Tango::DeviceAttributeHistory> > att_hist;
+        unique_pointer< std::vector<Tango::DeviceAttributeHistory> > att_hist;
         {
             AutoPythonAllowThreads guard;
             att_hist.reset(self.attribute_history(const_cast<std::string&>(attr_name), depth));

--- a/ext/device_proxy.cpp
+++ b/ext/device_proxy.cpp
@@ -98,7 +98,7 @@ namespace PyDeviceProxy
                          const char *method)
     {
         TangoSys_OMemStream o;
-        o << "Wrong Python type for pipe " << name << ends;
+        o << "Wrong Python type for pipe " << name << std::ends;
         Tango::Except::throw_exception("PyDs_WrongPythonDataTypeForPipe",
                        o.str(), method);
     }

--- a/ext/device_proxy.cpp
+++ b/ext/device_proxy.cpp
@@ -310,7 +310,7 @@ namespace PyDeviceProxy
         bopy::ssize_t n = bopy::len(py_value);
         std::vector < std::string > elem_names;
         for (size_t i = 0; i < n; ++i) {
-            string s = bopy::extract < std::string > (py_value[i]["name"]);
+            std::string s = bopy::extract < std::string > (py_value[i]["name"]);
             elem_names.push_back(bopy::extract<std::string>(py_value[i]["name"]));
         }
         obj.set_data_elt_names(elem_names);
@@ -384,7 +384,7 @@ namespace PyDeviceProxy
         self.write_attribute(da);
     }
 
-    static inline void write_attribute(Tango::DeviceProxy& self, const string & attr_name, bopy::object py_value)
+    static inline void write_attribute(Tango::DeviceProxy& self, const std::string & attr_name, bopy::object py_value)
     {
         Tango::DeviceAttribute dev_attr;
         PyDeviceAttribute::reset(dev_attr, attr_name, self, py_value);
@@ -403,7 +403,7 @@ namespace PyDeviceProxy
         self.write_attributes(dev_attrs);
     }
 
-    static inline bopy::object write_read_attribute(Tango::DeviceProxy& self, const string & attr_name, bopy::object py_value, PyTango::ExtractAs extract_as)
+    static inline bopy::object write_read_attribute(Tango::DeviceProxy& self, const std::string & attr_name, bopy::object py_value, PyTango::ExtractAs extract_as)
     {
         Tango::DeviceAttribute w_dev_attr;
         unique_pointer<Tango::DeviceAttribute> r_dev_attr;
@@ -587,7 +587,7 @@ namespace PyDeviceProxy
 
     static int subscribe_event_attrib(
             bopy::object py_self,
-            const string &attr_name,
+            const std::string &attr_name,
             Tango::EventType event,
             bopy::object py_cb_or_queuesize,
             bopy::object &py_filters,
@@ -942,7 +942,7 @@ void export_device_proxy()
             ( arg_("self"), arg_("attr_names"), arg_("extract_as")=PyTango::ExtractAsNumpy ) )
 
         .def("_write_attribute",
-            (void (*)(Tango::DeviceProxy&, const string &, bopy::object ))
+            (void (*)(Tango::DeviceProxy&, const std::string &, bopy::object ))
             &PyDeviceProxy::write_attribute,
             ( arg_("self"), arg_("attr_name"), arg_("value") ) )
 

--- a/ext/exception.cpp
+++ b/ext/exception.cpp
@@ -58,7 +58,7 @@ namespace Tango
 
 void sequencePyDevError_2_DevErrorList(PyObject *value, Tango::DevErrorList &del)
 {
-    long len = max((int)PySequence_Size(value), 0);
+    long len = std::max((int)PySequence_Size(value), 0);
     del.length(len);
 
     for (long loop = 0; loop < len; ++loop)

--- a/ext/exception.cpp
+++ b/ext/exception.cpp
@@ -477,6 +477,6 @@ void export_exceptions()
     NamedDevFailedList
         .def("get_faulty_attr_nb", &Tango::NamedDevFailedList::get_faulty_attr_nb) // size_t
         .def("call_failed", &Tango::NamedDevFailedList::call_failed) // bool
-        .def_readonly("err_list", &Tango::NamedDevFailedList::err_list) // vector<NamedDevFailed>
+        .def_readonly("err_list", &Tango::NamedDevFailedList::err_list) // std::vector<NamedDevFailed>
     ;
 }

--- a/ext/exception.cpp
+++ b/ext/exception.cpp
@@ -58,7 +58,7 @@ namespace Tango
 
 void sequencePyDevError_2_DevErrorList(PyObject *value, Tango::DevErrorList &del)
 {
-    long len = std::max((int)PySequence_Size(value), 0);
+    long len = (std::max)((int)PySequence_Size(value), 0);
     del.length(len);
 
     for (long loop = 0; loop < len; ++loop)

--- a/ext/fast_from_py.h
+++ b/ext/fast_from_py.h
@@ -478,7 +478,7 @@ inline TANGO_const2type(Tango::DEV_ENCODED)*
     fast_python_to_tango_buffer_sequence<Tango::DEV_ENCODED>(PyObject*, long*, long*, const std::string & fname, bool isImage, long& res_dim_x, long& res_dim_y)
 {
     TangoSys_OMemStream o;
-    o << "DevEncoded is only supported for SCALAR attributes." << ends;
+    o << "DevEncoded is only supported for SCALAR attributes." << std::ends;
     Tango::Except::throw_exception(
             "PyDs_WrongPythonDataTypeForAttribute",
             o.str(), fname + "()");

--- a/ext/fast_from_py.h
+++ b/ext/fast_from_py.h
@@ -80,7 +80,7 @@ struct from_py<tangoTypeConst> \
     struct from_py<tangoTypeConst> \
     { \
         typedef TANGO_const2type(tangoTypeConst) TangoScalarType; \
-        typedef numeric_limits<TangoScalarType> TangoScalarTypeLimits; \
+        typedef std::numeric_limits<TangoScalarType> TangoScalarTypeLimits; \
     \
         static inline void convert(const boost::python::object &o, TangoScalarType &tg) \
         { \
@@ -114,7 +114,7 @@ struct from_py<tangoTypeConst> \
     struct from_py<tangoTypeConst> \
     { \
         typedef TANGO_const2type(tangoTypeConst) TangoScalarType; \
-        typedef numeric_limits<TangoScalarType> TangoScalarTypeLimits; \
+        typedef std::numeric_limits<TangoScalarType> TangoScalarTypeLimits; \
     \
         static inline void convert(const boost::python::object &o, TangoScalarType &tg) \
         { \
@@ -196,7 +196,7 @@ struct array_element_from_py<Tango::DEVVAR_CHARARRAY>
     static const long tangoArrayTypeConst = Tango::DEVVAR_CHARARRAY;
 
     typedef TANGO_const2scalartype(tangoArrayTypeConst) TangoScalarType;
-    typedef numeric_limits<TangoScalarType> TangoScalarTypeLimits;
+    typedef std::numeric_limits<TangoScalarType> TangoScalarTypeLimits;
 
     static inline void convert(const boost::python::object &o, TangoScalarType &tg)
     {

--- a/ext/from_py.h
+++ b/ext/from_py.h
@@ -273,74 +273,74 @@ void from_py_object(bopy::object &, Tango::AttributeConfig_5 &);
 template<typename T>
 void from_py_object(bopy::object &py_obj, Tango::MultiAttrProp<T> &multi_attr_prop)
 {
-	multi_attr_prop.label = bopy::extract<string>(bopy::str(py_obj.attr("label")));
-	multi_attr_prop.description = bopy::extract<string>(bopy::str(py_obj.attr("description")));
-	multi_attr_prop.unit = bopy::extract<string>(bopy::str(py_obj.attr("unit")));
-	multi_attr_prop.standard_unit = bopy::extract<string>(bopy::str(py_obj.attr("standard_unit")));
-	multi_attr_prop.display_unit = bopy::extract<string>(bopy::str(py_obj.attr("display_unit")));
-	multi_attr_prop.format = bopy::extract<string>(bopy::str(py_obj.attr("format")));
+	multi_attr_prop.label = bopy::extract<std::string>(bopy::str(py_obj.attr("label")));
+	multi_attr_prop.description = bopy::extract<std::string>(bopy::str(py_obj.attr("description")));
+	multi_attr_prop.unit = bopy::extract<std::string>(bopy::str(py_obj.attr("unit")));
+	multi_attr_prop.standard_unit = bopy::extract<std::string>(bopy::str(py_obj.attr("standard_unit")));
+	multi_attr_prop.display_unit = bopy::extract<std::string>(bopy::str(py_obj.attr("display_unit")));
+	multi_attr_prop.format = bopy::extract<std::string>(bopy::str(py_obj.attr("format")));
 
-	bopy::extract<string> min_value(py_obj.attr("min_value"));
+	bopy::extract<std::string> min_value(py_obj.attr("min_value"));
 	if(min_value.check())
 		multi_attr_prop.min_value = min_value();
 	else
 		multi_attr_prop.min_value = bopy::extract<T>(py_obj.attr("min_value"));
 
-	bopy::extract<string> max_value(py_obj.attr("max_value"));
+	bopy::extract<std::string> max_value(py_obj.attr("max_value"));
 	if(max_value.check())
 		multi_attr_prop.max_value = max_value();
 	else
 		multi_attr_prop.max_value = bopy::extract<T>(py_obj.attr("max_value"));
 
-	bopy::extract<string> min_alarm(py_obj.attr("min_alarm"));
+	bopy::extract<std::string> min_alarm(py_obj.attr("min_alarm"));
 	if(min_alarm.check())
 		multi_attr_prop.min_alarm = min_alarm();
 	else
 		multi_attr_prop.min_alarm = bopy::extract<T>(py_obj.attr("min_alarm"));
 
-	bopy::extract<string> max_alarm(py_obj.attr("max_alarm"));
+	bopy::extract<std::string> max_alarm(py_obj.attr("max_alarm"));
 	if(max_alarm.check())
 		multi_attr_prop.max_alarm = max_alarm();
 	else
 		multi_attr_prop.max_alarm = bopy::extract<T>(py_obj.attr("max_alarm"));
 
-	bopy::extract<string> min_warning(py_obj.attr("min_warning"));
+	bopy::extract<std::string> min_warning(py_obj.attr("min_warning"));
 	if(min_warning.check())
 		multi_attr_prop.min_warning = min_warning();
 	else
 		multi_attr_prop.min_warning = bopy::extract<T>(py_obj.attr("min_warning"));
 
-	bopy::extract<string> max_warning(py_obj.attr("max_warning"));
+	bopy::extract<std::string> max_warning(py_obj.attr("max_warning"));
 	if(max_warning.check())
 		multi_attr_prop.max_warning = max_warning();
 	else
 		multi_attr_prop.max_warning = bopy::extract<T>(py_obj.attr("max_warning"));
 
-	bopy::extract<string> delta_t(py_obj.attr("delta_t"));
+	bopy::extract<std::string> delta_t(py_obj.attr("delta_t"));
 	if(delta_t.check())
 		multi_attr_prop.delta_t = delta_t();
 	else
 		multi_attr_prop.delta_t = bopy::extract<Tango::DevLong>(py_obj.attr("delta_t")); // Property type is Tango::DevLong!
 
-	bopy::extract<string> delta_val(py_obj.attr("delta_val"));
+	bopy::extract<std::string> delta_val(py_obj.attr("delta_val"));
 	if(delta_val.check())
 		multi_attr_prop.delta_val = delta_val();
 	else
 		multi_attr_prop.delta_val = bopy::extract<T>(py_obj.attr("delta_val"));
 
-	bopy::extract<string> event_period(py_obj.attr("event_period"));
+	bopy::extract<std::string> event_period(py_obj.attr("event_period"));
 	if(event_period.check())
 		multi_attr_prop.event_period = event_period();
 	else
 		multi_attr_prop.event_period = bopy::extract<Tango::DevLong>(py_obj.attr("event_period")); // Property type is Tango::DevLong!
 
-	bopy::extract<string> archive_period(py_obj.attr("archive_period"));
+	bopy::extract<std::string> archive_period(py_obj.attr("archive_period"));
 	if(archive_period.check())
 		multi_attr_prop.archive_period = archive_period();
 	else
 		multi_attr_prop.archive_period = bopy::extract<Tango::DevLong>(py_obj.attr("archive_period")); // Property type is Tango::DevLong!
 
-	bopy::extract<string> rel_change(py_obj.attr("rel_change"));
+	bopy::extract<std::string> rel_change(py_obj.attr("rel_change"));
 	if(rel_change.check())
 		multi_attr_prop.rel_change = rel_change();
 	else
@@ -357,7 +357,7 @@ void from_py_object(bopy::object &py_obj, Tango::MultiAttrProp<T> &multi_attr_pr
 			multi_attr_prop.rel_change = bopy::extract<Tango::DevDouble>(py_obj.attr("rel_change")); // Property type is Tango::DevDouble!
 	}
 
-	bopy::extract<string> abs_change(py_obj.attr("abs_change"));
+	bopy::extract<std::string> abs_change(py_obj.attr("abs_change"));
 	if(abs_change.check())
 		multi_attr_prop.abs_change = abs_change();
 	else
@@ -374,7 +374,7 @@ void from_py_object(bopy::object &py_obj, Tango::MultiAttrProp<T> &multi_attr_pr
 			multi_attr_prop.abs_change = bopy::extract<Tango::DevDouble>(py_obj.attr("abs_change")); // Property type is Tango::DevDouble!
 	}
 
-	bopy::extract<string> archive_rel_change(py_obj.attr("archive_rel_change"));
+	bopy::extract<std::string> archive_rel_change(py_obj.attr("archive_rel_change"));
 	if(archive_rel_change.check())
 		multi_attr_prop.archive_rel_change = archive_rel_change();
 	else
@@ -391,7 +391,7 @@ void from_py_object(bopy::object &py_obj, Tango::MultiAttrProp<T> &multi_attr_pr
 			multi_attr_prop.archive_rel_change = bopy::extract<Tango::DevDouble>(py_obj.attr("archive_rel_change")); // Property type is Tango::DevDouble!
 	}
 
-	bopy::extract<string> archive_abs_change(py_obj.attr("archive_abs_change"));
+	bopy::extract<std::string> archive_abs_change(py_obj.attr("archive_abs_change"));
 	if(archive_abs_change.check())
 		multi_attr_prop.archive_abs_change = archive_abs_change();
 	else
@@ -412,74 +412,74 @@ void from_py_object(bopy::object &py_obj, Tango::MultiAttrProp<T> &multi_attr_pr
 template<>
 inline void from_py_object(bopy::object &py_obj, Tango::MultiAttrProp<Tango::DevEncoded> &multi_attr_prop)
 {
-	multi_attr_prop.label = bopy::extract<string>(bopy::str(py_obj.attr("label")));
-	multi_attr_prop.description = bopy::extract<string>(bopy::str(py_obj.attr("description")));
-	multi_attr_prop.unit = bopy::extract<string>(bopy::str(py_obj.attr("unit")));
-	multi_attr_prop.standard_unit = bopy::extract<string>(bopy::str(py_obj.attr("standard_unit")));
-	multi_attr_prop.display_unit = bopy::extract<string>(bopy::str(py_obj.attr("display_unit")));
-	multi_attr_prop.format = bopy::extract<string>(bopy::str(py_obj.attr("format")));
+	multi_attr_prop.label = bopy::extract<std::string>(bopy::str(py_obj.attr("label")));
+	multi_attr_prop.description = bopy::extract<std::string>(bopy::str(py_obj.attr("description")));
+	multi_attr_prop.unit = bopy::extract<std::string>(bopy::str(py_obj.attr("unit")));
+	multi_attr_prop.standard_unit = bopy::extract<std::string>(bopy::str(py_obj.attr("standard_unit")));
+	multi_attr_prop.display_unit = bopy::extract<std::string>(bopy::str(py_obj.attr("display_unit")));
+	multi_attr_prop.format = bopy::extract<std::string>(bopy::str(py_obj.attr("format")));
 
-	bopy::extract<string> min_value(py_obj.attr("min_value"));
+	bopy::extract<std::string> min_value(py_obj.attr("min_value"));
 	if(min_value.check())
 		multi_attr_prop.min_value = min_value();
 	else
 		multi_attr_prop.min_value = bopy::extract<Tango::DevUChar>(py_obj.attr("min_value"));
 
-	bopy::extract<string> max_value(py_obj.attr("max_value"));
+	bopy::extract<std::string> max_value(py_obj.attr("max_value"));
 	if(max_value.check())
 		multi_attr_prop.max_value = max_value();
 	else
 		multi_attr_prop.max_value = bopy::extract<Tango::DevUChar>(py_obj.attr("max_value"));
 
-	bopy::extract<string> min_alarm(py_obj.attr("min_alarm"));
+	bopy::extract<std::string> min_alarm(py_obj.attr("min_alarm"));
 	if(min_alarm.check())
 		multi_attr_prop.min_alarm = min_alarm();
 	else
 		multi_attr_prop.min_alarm = bopy::extract<Tango::DevUChar>(py_obj.attr("min_alarm"));
 
-	bopy::extract<string> max_alarm(py_obj.attr("max_alarm"));
+	bopy::extract<std::string> max_alarm(py_obj.attr("max_alarm"));
 	if(max_alarm.check())
 		multi_attr_prop.max_alarm = max_alarm();
 	else
 		multi_attr_prop.max_alarm = bopy::extract<Tango::DevUChar>(py_obj.attr("max_alarm"));
 
-	bopy::extract<string> min_warning(py_obj.attr("min_warning"));
+	bopy::extract<std::string> min_warning(py_obj.attr("min_warning"));
 	if(min_warning.check())
 		multi_attr_prop.min_warning = min_warning();
 	else
 		multi_attr_prop.min_warning = bopy::extract<Tango::DevUChar>(py_obj.attr("min_warning"));
 
-	bopy::extract<string> max_warning(py_obj.attr("max_warning"));
+	bopy::extract<std::string> max_warning(py_obj.attr("max_warning"));
 	if(max_warning.check())
 		multi_attr_prop.max_warning = max_warning();
 	else
 		multi_attr_prop.max_warning = bopy::extract<Tango::DevUChar>(py_obj.attr("max_warning"));
 
-	bopy::extract<string> delta_t(py_obj.attr("delta_t"));
+	bopy::extract<std::string> delta_t(py_obj.attr("delta_t"));
 	if(delta_t.check())
 		multi_attr_prop.delta_t = delta_t();
 	else
 		multi_attr_prop.delta_t = bopy::extract<Tango::DevLong>(py_obj.attr("delta_t")); // Property type is Tango::DevLong!
 
-	bopy::extract<string> delta_val(py_obj.attr("delta_val"));
+	bopy::extract<std::string> delta_val(py_obj.attr("delta_val"));
 	if(delta_val.check())
 		multi_attr_prop.delta_val = delta_val();
 	else
 		multi_attr_prop.delta_val = bopy::extract<Tango::DevUChar>(py_obj.attr("delta_val"));
 
-	bopy::extract<string> event_period(py_obj.attr("event_period"));
+	bopy::extract<std::string> event_period(py_obj.attr("event_period"));
 	if(event_period.check())
 		multi_attr_prop.event_period = event_period();
 	else
 		multi_attr_prop.event_period = bopy::extract<Tango::DevLong>(py_obj.attr("event_period")); // Property type is Tango::DevLong!
 
-	bopy::extract<string> archive_period(py_obj.attr("archive_period"));
+	bopy::extract<std::string> archive_period(py_obj.attr("archive_period"));
 	if(archive_period.check())
 		multi_attr_prop.archive_period = archive_period();
 	else
 		multi_attr_prop.archive_period = bopy::extract<Tango::DevLong>(py_obj.attr("archive_period")); // Property type is Tango::DevLong!
 
-	bopy::extract<string> rel_change(py_obj.attr("rel_change"));
+	bopy::extract<std::string> rel_change(py_obj.attr("rel_change"));
 	if(rel_change.check())
 		multi_attr_prop.rel_change = rel_change();
 	else
@@ -496,7 +496,7 @@ inline void from_py_object(bopy::object &py_obj, Tango::MultiAttrProp<Tango::Dev
 			multi_attr_prop.rel_change = bopy::extract<Tango::DevDouble>(py_obj.attr("rel_change")); // Property type is Tango::DevDouble!
 	}
 
-	bopy::extract<string> abs_change(py_obj.attr("abs_change"));
+	bopy::extract<std::string> abs_change(py_obj.attr("abs_change"));
 	if(abs_change.check())
 		multi_attr_prop.abs_change = abs_change();
 	else
@@ -513,7 +513,7 @@ inline void from_py_object(bopy::object &py_obj, Tango::MultiAttrProp<Tango::Dev
 			multi_attr_prop.abs_change = bopy::extract<Tango::DevDouble>(py_obj.attr("abs_change")); // Property type is Tango::DevDouble!
 	}
 
-	bopy::extract<string> archive_rel_change(py_obj.attr("archive_rel_change"));
+	bopy::extract<std::string> archive_rel_change(py_obj.attr("archive_rel_change"));
 	if(archive_rel_change.check())
 		multi_attr_prop.archive_rel_change = archive_rel_change();
 	else
@@ -530,7 +530,7 @@ inline void from_py_object(bopy::object &py_obj, Tango::MultiAttrProp<Tango::Dev
 			multi_attr_prop.archive_rel_change = bopy::extract<Tango::DevDouble>(py_obj.attr("archive_rel_change")); // Property type is Tango::DevDouble!
 	}
 
-	bopy::extract<string> archive_abs_change(py_obj.attr("archive_abs_change"));
+	bopy::extract<std::string> archive_abs_change(py_obj.attr("archive_abs_change"));
 	if(archive_abs_change.check())
 		multi_attr_prop.archive_abs_change = archive_abs_change();
 	else
@@ -551,76 +551,76 @@ inline void from_py_object(bopy::object &py_obj, Tango::MultiAttrProp<Tango::Dev
 template<>
 inline void from_py_object(bopy::object &py_obj, Tango::MultiAttrProp<Tango::DevString> &multi_attr_prop)
 {
-	string empty_str("");
+	std::string empty_str("");
 
-	multi_attr_prop.label = bopy::extract<string>(bopy::str(py_obj.attr("label")));
-	multi_attr_prop.description = bopy::extract<string>(bopy::str(py_obj.attr("description")));
-	multi_attr_prop.unit = bopy::extract<string>(bopy::str(py_obj.attr("unit")));
-	multi_attr_prop.standard_unit = bopy::extract<string>(bopy::str(py_obj.attr("standard_unit")));
-	multi_attr_prop.display_unit = bopy::extract<string>(bopy::str(py_obj.attr("display_unit")));
-	multi_attr_prop.format = bopy::extract<string>(bopy::str(py_obj.attr("format")));
+	multi_attr_prop.label = bopy::extract<std::string>(bopy::str(py_obj.attr("label")));
+	multi_attr_prop.description = bopy::extract<std::string>(bopy::str(py_obj.attr("description")));
+	multi_attr_prop.unit = bopy::extract<std::string>(bopy::str(py_obj.attr("unit")));
+	multi_attr_prop.standard_unit = bopy::extract<std::string>(bopy::str(py_obj.attr("standard_unit")));
+	multi_attr_prop.display_unit = bopy::extract<std::string>(bopy::str(py_obj.attr("display_unit")));
+	multi_attr_prop.format = bopy::extract<std::string>(bopy::str(py_obj.attr("format")));
 
-	bopy::extract<string> min_value(py_obj.attr("min_value"));
+	bopy::extract<std::string> min_value(py_obj.attr("min_value"));
 	if(min_value.check())
 		multi_attr_prop.min_value = min_value();
 	else
 		multi_attr_prop.min_value = empty_str;
 
-	bopy::extract<string> max_value(py_obj.attr("max_value"));
+	bopy::extract<std::string> max_value(py_obj.attr("max_value"));
 	if(max_value.check())
 		multi_attr_prop.max_value = max_value();
 	else
 		multi_attr_prop.max_value = empty_str;
 
-	bopy::extract<string> min_alarm(py_obj.attr("min_alarm"));
+	bopy::extract<std::string> min_alarm(py_obj.attr("min_alarm"));
 	if(min_alarm.check())
 		multi_attr_prop.min_alarm = min_alarm();
 	else
 		multi_attr_prop.min_alarm = empty_str;
 
-	bopy::extract<string> max_alarm(py_obj.attr("max_alarm"));
+	bopy::extract<std::string> max_alarm(py_obj.attr("max_alarm"));
 	if(max_alarm.check())
 		multi_attr_prop.max_alarm = max_alarm();
 	else
 		multi_attr_prop.max_alarm = empty_str;
 
-	bopy::extract<string> min_warning(py_obj.attr("min_warning"));
+	bopy::extract<std::string> min_warning(py_obj.attr("min_warning"));
 	if(min_warning.check())
 		multi_attr_prop.min_warning = min_warning();
 	else
 		multi_attr_prop.min_warning = empty_str;
 
-	bopy::extract<string> max_warning(py_obj.attr("max_warning"));
+	bopy::extract<std::string> max_warning(py_obj.attr("max_warning"));
 	if(max_warning.check())
 		multi_attr_prop.max_warning = max_warning();
 	else
 		multi_attr_prop.max_warning = empty_str;
 
-	bopy::extract<string> delta_t(py_obj.attr("delta_t"));
+	bopy::extract<std::string> delta_t(py_obj.attr("delta_t"));
 	if(delta_t.check())
 		multi_attr_prop.delta_t = delta_t();
 	else
 		multi_attr_prop.delta_t = bopy::extract<Tango::DevLong>(py_obj.attr("delta_t")); // Property type is Tango::DevLong!
 
-	bopy::extract<string> delta_val(py_obj.attr("delta_val"));
+	bopy::extract<std::string> delta_val(py_obj.attr("delta_val"));
 	if(delta_val.check())
 		multi_attr_prop.delta_val = delta_val();
 	else
 		multi_attr_prop.delta_val = empty_str;
 
-	bopy::extract<string> event_period(py_obj.attr("event_period"));
+	bopy::extract<std::string> event_period(py_obj.attr("event_period"));
 	if(event_period.check())
 		multi_attr_prop.event_period = event_period();
 	else
 		multi_attr_prop.event_period = bopy::extract<Tango::DevLong>(py_obj.attr("event_period")); // Property type is Tango::DevLong!
 
-	bopy::extract<string> archive_period(py_obj.attr("archive_period"));
+	bopy::extract<std::string> archive_period(py_obj.attr("archive_period"));
 	if(archive_period.check())
 		multi_attr_prop.archive_period = archive_period();
 	else
 		multi_attr_prop.archive_period = bopy::extract<Tango::DevLong>(py_obj.attr("archive_period")); // Property type is Tango::DevLong!
 
-	bopy::extract<string> rel_change(py_obj.attr("rel_change"));
+	bopy::extract<std::string> rel_change(py_obj.attr("rel_change"));
 	if(rel_change.check())
 		multi_attr_prop.rel_change = rel_change();
 	else
@@ -637,7 +637,7 @@ inline void from_py_object(bopy::object &py_obj, Tango::MultiAttrProp<Tango::Dev
 			multi_attr_prop.rel_change = bopy::extract<Tango::DevDouble>(py_obj.attr("rel_change")); // Property type is Tango::DevDouble!
 	}
 
-	bopy::extract<string> abs_change(py_obj.attr("abs_change"));
+	bopy::extract<std::string> abs_change(py_obj.attr("abs_change"));
 	if(abs_change.check())
 		multi_attr_prop.abs_change = abs_change();
 	else
@@ -654,7 +654,7 @@ inline void from_py_object(bopy::object &py_obj, Tango::MultiAttrProp<Tango::Dev
 			multi_attr_prop.abs_change = bopy::extract<Tango::DevDouble>(py_obj.attr("abs_change")); // Property type is Tango::DevDouble!
 	}
 
-	bopy::extract<string> archive_rel_change(py_obj.attr("archive_rel_change"));
+	bopy::extract<std::string> archive_rel_change(py_obj.attr("archive_rel_change"));
 	if(archive_rel_change.check())
 		multi_attr_prop.archive_rel_change = archive_rel_change();
 	else
@@ -671,7 +671,7 @@ inline void from_py_object(bopy::object &py_obj, Tango::MultiAttrProp<Tango::Dev
 			multi_attr_prop.archive_rel_change = bopy::extract<Tango::DevDouble>(py_obj.attr("archive_rel_change")); // Property type is Tango::DevDouble!
 	}
 
-	bopy::extract<string> archive_abs_change(py_obj.attr("archive_abs_change"));
+	bopy::extract<std::string> archive_abs_change(py_obj.attr("archive_abs_change"));
 	if(archive_abs_change.check())
 		multi_attr_prop.archive_abs_change = archive_abs_change();
 	else

--- a/ext/from_py.h
+++ b/ext/from_py.h
@@ -348,7 +348,7 @@ void from_py_object(bopy::object &py_obj, Tango::MultiAttrProp<T> &multi_attr_pr
 		bopy::object prop_py_obj = bopy::object(py_obj.attr("rel_change"));
 		if(PySequence_Check(prop_py_obj.ptr()))
 		{
-			vector<Tango::DevDouble> change_vec;
+			std::vector<Tango::DevDouble> change_vec;
 			for(long i = 0; i < bopy::len(prop_py_obj); i++)
 				change_vec.push_back(bopy::extract<Tango::DevDouble>(prop_py_obj[i]));
 			multi_attr_prop.rel_change = change_vec;
@@ -365,7 +365,7 @@ void from_py_object(bopy::object &py_obj, Tango::MultiAttrProp<T> &multi_attr_pr
 		bopy::object prop_py_obj = bopy::object(py_obj.attr("abs_change"));
 		if(PySequence_Check(prop_py_obj.ptr()))
 		{
-			vector<Tango::DevDouble> change_vec;
+			std::vector<Tango::DevDouble> change_vec;
 			for(long i = 0; i < bopy::len(prop_py_obj); i++)
 				change_vec.push_back(bopy::extract<Tango::DevDouble>(prop_py_obj[i]));
 			multi_attr_prop.abs_change = change_vec;
@@ -382,7 +382,7 @@ void from_py_object(bopy::object &py_obj, Tango::MultiAttrProp<T> &multi_attr_pr
 		bopy::object prop_py_obj = bopy::object(py_obj.attr("archive_rel_change"));
 		if(PySequence_Check(prop_py_obj.ptr()))
 		{
-			vector<Tango::DevDouble> change_vec;
+			std::vector<Tango::DevDouble> change_vec;
 			for(long i = 0; i < bopy::len(prop_py_obj); i++)
 				change_vec.push_back(bopy::extract<Tango::DevDouble>(prop_py_obj[i]));
 			multi_attr_prop.archive_rel_change = change_vec;
@@ -399,7 +399,7 @@ void from_py_object(bopy::object &py_obj, Tango::MultiAttrProp<T> &multi_attr_pr
 		bopy::object prop_py_obj = bopy::object(py_obj.attr("archive_abs_change"));
 		if(PySequence_Check(prop_py_obj.ptr()))
 		{
-			vector<Tango::DevDouble> change_vec;
+			std::vector<Tango::DevDouble> change_vec;
 			for(long i = 0; i < bopy::len(prop_py_obj); i++)
 				change_vec.push_back(bopy::extract<Tango::DevDouble>(prop_py_obj[i]));
 			multi_attr_prop.archive_abs_change = change_vec;
@@ -487,7 +487,7 @@ inline void from_py_object(bopy::object &py_obj, Tango::MultiAttrProp<Tango::Dev
 		bopy::object prop_py_obj = bopy::object(py_obj.attr("rel_change"));
 		if(PySequence_Check(prop_py_obj.ptr()))
 		{
-			vector<Tango::DevDouble> change_vec;
+			std::vector<Tango::DevDouble> change_vec;
 			for(long i = 0; i < bopy::len(prop_py_obj); i++)
 				change_vec.push_back(bopy::extract<Tango::DevDouble>(prop_py_obj[i]));
 			multi_attr_prop.rel_change = change_vec;
@@ -504,7 +504,7 @@ inline void from_py_object(bopy::object &py_obj, Tango::MultiAttrProp<Tango::Dev
 		bopy::object prop_py_obj = bopy::object(py_obj.attr("abs_change"));
 		if(PySequence_Check(prop_py_obj.ptr()))
 		{
-			vector<Tango::DevDouble> change_vec;
+			std::vector<Tango::DevDouble> change_vec;
 			for(long i = 0; i < bopy::len(prop_py_obj); i++)
 				change_vec.push_back(bopy::extract<Tango::DevDouble>(prop_py_obj[i]));
 			multi_attr_prop.abs_change = change_vec;
@@ -521,7 +521,7 @@ inline void from_py_object(bopy::object &py_obj, Tango::MultiAttrProp<Tango::Dev
 		bopy::object prop_py_obj = bopy::object(py_obj.attr("archive_rel_change"));
 		if(PySequence_Check(prop_py_obj.ptr()))
 		{
-			vector<Tango::DevDouble> change_vec;
+			std::vector<Tango::DevDouble> change_vec;
 			for(long i = 0; i < bopy::len(prop_py_obj); i++)
 				change_vec.push_back(bopy::extract<Tango::DevDouble>(prop_py_obj[i]));
 			multi_attr_prop.archive_rel_change = change_vec;
@@ -538,7 +538,7 @@ inline void from_py_object(bopy::object &py_obj, Tango::MultiAttrProp<Tango::Dev
 		bopy::object prop_py_obj = bopy::object(py_obj.attr("archive_abs_change"));
 		if(PySequence_Check(prop_py_obj.ptr()))
 		{
-			vector<Tango::DevDouble> change_vec;
+			std::vector<Tango::DevDouble> change_vec;
 			for(long i = 0; i < bopy::len(prop_py_obj); i++)
 				change_vec.push_back(bopy::extract<Tango::DevDouble>(prop_py_obj[i]));
 			multi_attr_prop.archive_abs_change = change_vec;
@@ -628,7 +628,7 @@ inline void from_py_object(bopy::object &py_obj, Tango::MultiAttrProp<Tango::Dev
 		bopy::object prop_py_obj = bopy::object(py_obj.attr("rel_change"));
 		if(PySequence_Check(prop_py_obj.ptr()))
 		{
-			vector<Tango::DevDouble> change_vec;
+			std::vector<Tango::DevDouble> change_vec;
 			for(long i = 0; i < bopy::len(prop_py_obj); i++)
 				change_vec.push_back(bopy::extract<Tango::DevDouble>(prop_py_obj[i]));
 			multi_attr_prop.rel_change = change_vec;
@@ -645,7 +645,7 @@ inline void from_py_object(bopy::object &py_obj, Tango::MultiAttrProp<Tango::Dev
 		bopy::object prop_py_obj = bopy::object(py_obj.attr("abs_change"));
 		if(PySequence_Check(prop_py_obj.ptr()))
 		{
-			vector<Tango::DevDouble> change_vec;
+			std::vector<Tango::DevDouble> change_vec;
 			for(long i = 0; i < bopy::len(prop_py_obj); i++)
 				change_vec.push_back(bopy::extract<Tango::DevDouble>(prop_py_obj[i]));
 			multi_attr_prop.abs_change = change_vec;
@@ -662,7 +662,7 @@ inline void from_py_object(bopy::object &py_obj, Tango::MultiAttrProp<Tango::Dev
 		bopy::object prop_py_obj = bopy::object(py_obj.attr("archive_rel_change"));
 		if(PySequence_Check(prop_py_obj.ptr()))
 		{
-			vector<Tango::DevDouble> change_vec;
+			std::vector<Tango::DevDouble> change_vec;
 			for(long i = 0; i < bopy::len(prop_py_obj); i++)
 				change_vec.push_back(bopy::extract<Tango::DevDouble>(prop_py_obj[i]));
 			multi_attr_prop.archive_rel_change = change_vec;
@@ -679,7 +679,7 @@ inline void from_py_object(bopy::object &py_obj, Tango::MultiAttrProp<Tango::Dev
 		bopy::object prop_py_obj = bopy::object(py_obj.attr("archive_abs_change"));
 		if(PySequence_Check(prop_py_obj.ptr()))
 		{
-			vector<Tango::DevDouble> change_vec;
+			std::vector<Tango::DevDouble> change_vec;
 			for(long i = 0; i < bopy::len(prop_py_obj); i++)
 				change_vec.push_back(bopy::extract<Tango::DevDouble>(prop_py_obj[i]));
 			multi_attr_prop.archive_abs_change = change_vec;

--- a/ext/server/attr.cpp
+++ b/ext/server/attr.cpp
@@ -106,7 +106,7 @@ bool PyAttr::_is_method(Tango::DeviceImpl *dev, const std::string &name)
     return is_method_defined(__dev_py, name);
 }
 
-void PyAttr::set_user_prop(vector<Tango::AttrProperty> &user_prop,
+void PyAttr::set_user_prop(std::vector<Tango::AttrProperty> &user_prop,
                            Tango::UserDefaultAttrProp &def_prop)
 {
 
@@ -166,7 +166,7 @@ void PyAttr::set_user_prop(vector<Tango::AttrProperty> &user_prop,
             def_prop.set_archive_event_period(prop_value);
         else if (prop_name == "enum_labels") {
             // Convert string back to vector
-            vector<string> labels;
+            std::vector<string> labels;
             string label_str = prop.get_value();
             size_t offset = 0, pos = 0;
             while( (pos = label_str.find(",", offset)) != string::npos) {

--- a/ext/server/attr.cpp
+++ b/ext/server/attr.cpp
@@ -121,7 +121,7 @@ void PyAttr::set_user_prop(std::vector<Tango::AttrProperty> &user_prop,
     for (size_t loop = 0;loop < nb_prop;loop++)
     {
         Tango::AttrProperty  prop = user_prop[loop];
-        string &prop_name = prop.get_name();
+        std::string &prop_name = prop.get_name();
         const char *prop_value = prop.get_value().c_str();
 
         if (prop_name == "label")
@@ -166,10 +166,10 @@ void PyAttr::set_user_prop(std::vector<Tango::AttrProperty> &user_prop,
             def_prop.set_archive_event_period(prop_value);
         else if (prop_name == "enum_labels") {
             // Convert string back to vector
-            std::vector<string> labels;
-            string label_str = prop.get_value();
+            std::vector<std::string> labels;
+            std::string label_str = prop.get_value();
             size_t offset = 0, pos = 0;
-            while( (pos = label_str.find(",", offset)) != string::npos) {
+            while( (pos = label_str.find(",", offset)) != std::string::npos) {
                 labels.push_back(label_str.substr(offset, pos-offset));
                 offset = pos + 1;
             }

--- a/ext/server/attribute.cpp
+++ b/ext/server/attribute.cpp
@@ -36,7 +36,7 @@ inline static void throw_wrong_python_data_type(const std::string &att_name,
                                          const char *method)
 {
     TangoSys_OMemStream o;
-    o << "Wrong Python type for attribute " << att_name << ends;
+    o << "Wrong Python type for attribute " << att_name << std::ends;
     Tango::Except::throw_exception(
             (const char *)"PyDs_WrongPythonDataTypeForAttribute",
             o.str(), method);
@@ -49,7 +49,7 @@ inline static void throw_wrong_python_data_type_in_array(const std::string &att_
     TangoSys_OMemStream o;
     o << "Wrong Python type for attribute " << att_name
       << ".\nElement with index " << idx << " in sequence does not "
-      << "have a correct type." << ends;
+      << "have a correct type." << std::ends;
 
     Tango::Except::throw_exception(
             (const char *)"PyDs_WrongPythonDataTypeForAttribute",
@@ -263,7 +263,7 @@ namespace PyAttribute
                 
             TangoSys_OMemStream o;
             o << "Wrong Python type for attribute " << att.get_name()
-              << " of type " << arg_type << ". Expected a sequence." << ends;
+              << " of type " << arg_type << ". Expected a sequence." << std::ends;
 
             Tango::Except::throw_exception(
                     "PyDs_WrongPythonDataTypeForAttribute",
@@ -306,9 +306,9 @@ namespace PyAttribute
                     o << "(data, dim_x) on scalar attribute ";
 
                 if (quality)
-                    o << att.get_name() << ". Use set_value_date_quality(data) instead" << ends;
+                    o << att.get_name() << ". Use set_value_date_quality(data) instead" << std::ends;
                 else
-                    o << att.get_name() << ". Use set_value(data) instead" << ends;
+                    o << att.get_name() << ". Use set_value(data) instead" << std::ends;
 
                 Tango::Except::throw_exception(
                         "PyDs_WrongPythonDataTypeForAttribute",
@@ -454,7 +454,7 @@ namespace PyAttribute
         }
         TangoSys_OMemStream o;
         o << "Wrong Python argument type for attribute " << self.get_name()
-            << ". Expected a DevFailed." << ends;
+            << ". Expected a DevFailed." << std::ends;
         Tango::Except::throw_exception(
                 "PyDs_WrongPythonDataTypeForAttribute",
                 o.str(),

--- a/ext/server/attribute.cpp
+++ b/ext/server/attribute.cpp
@@ -435,7 +435,7 @@ namespace PyAttribute
     {
         Tango::AttributeConfig_3 tg_attr_cfg;
         from_py_object(attr_cfg, tg_attr_cfg);
-        string tg_dev_name = bopy::extract<string>(dev_name);
+        std::string tg_dev_name = bopy::extract<std::string>(dev_name);
         att.set_upd_properties(tg_attr_cfg,tg_dev_name);
     }
 
@@ -482,7 +482,7 @@ namespace PyAttribute
     template<>
     inline void _set_min_alarm<Tango::DevEncoded>(Tango::Attribute &self, bopy::object value)
     {
-    	string err_msg = "Attribute properties cannot be set with Tango::DevEncoded data type";
+    	std::string err_msg = "Attribute properties cannot be set with Tango::DevEncoded data type";
     	Tango::Except::throw_exception((const char *)"API_MethodArgument",
     				  (const char *)err_msg.c_str(),
     				  (const char *)"Attribute::set_min_alarm()");
@@ -492,7 +492,7 @@ namespace PyAttribute
 
     inline void set_min_alarm(Tango::Attribute &self, bopy::object value)
     {
-        bopy::extract<string> value_convert(value);
+        bopy::extract<std::string> value_convert(value);
         
     	if (value_convert.check())
     	{
@@ -525,7 +525,7 @@ namespace PyAttribute
     template<>
     inline void _set_max_alarm<Tango::DevEncoded>(Tango::Attribute &self, bopy::object value)
     {
-    	string err_msg = "Attribute properties cannot be set with Tango::DevEncoded data type";
+    	std::string err_msg = "Attribute properties cannot be set with Tango::DevEncoded data type";
     	Tango::Except::throw_exception((const char *)"API_MethodArgument",
     				  (const char *)err_msg.c_str(),
     				  (const char *)"Attribute::set_max_alarm()");
@@ -535,7 +535,7 @@ namespace PyAttribute
 
     inline void set_max_alarm(Tango::Attribute &self, bopy::object value)
     {
-        bopy::extract<string> value_convert(value);
+        bopy::extract<std::string> value_convert(value);
         
     	if (value_convert.check())
     	{
@@ -568,7 +568,7 @@ namespace PyAttribute
     template<>
     inline void _set_min_warning<Tango::DevEncoded>(Tango::Attribute &self, bopy::object value)
     {
-    	string err_msg = "Attribute properties cannot be set with Tango::DevEncoded data type";
+    	std::string err_msg = "Attribute properties cannot be set with Tango::DevEncoded data type";
     	Tango::Except::throw_exception((const char *)"API_MethodArgument",
     				  (const char *)err_msg.c_str(),
     				  (const char *)"Attribute::set_min_warning()");
@@ -578,7 +578,7 @@ namespace PyAttribute
 
     inline void set_min_warning(Tango::Attribute &self, bopy::object value)
     {
-        bopy::extract<string> value_convert(value);
+        bopy::extract<std::string> value_convert(value);
         
     	if (value_convert.check())
     	{
@@ -611,7 +611,7 @@ namespace PyAttribute
     template<>
     inline void _set_max_warning<Tango::DevEncoded>(Tango::Attribute &self, bopy::object value)
     {
-    	string err_msg = "Attribute properties cannot be set with Tango::DevEncoded data type";
+    	std::string err_msg = "Attribute properties cannot be set with Tango::DevEncoded data type";
     	Tango::Except::throw_exception((const char *)"API_MethodArgument",
     				  (const char *)err_msg.c_str(),
     				  (const char *)"Attribute::set_max_warning()");
@@ -621,7 +621,7 @@ namespace PyAttribute
 
     inline void set_max_warning(Tango::Attribute &self, bopy::object value)
     {
-        bopy::extract<string> value_convert(value);
+        bopy::extract<std::string> value_convert(value);
         
     	if (value_convert.check())
     	{

--- a/ext/server/command.cpp
+++ b/ext/server/command.cpp
@@ -83,7 +83,7 @@ void throw_bad_type(const char *type)
     TangoSys_OMemStream o;
 
     o << "Incompatible command argument type, expected type is : Tango::" 
-      << type << ends;
+      << type << std::ends;
     Tango::Except::throw_exception(
             "API_IncompatibleCmdArgumentType",
             o.str(),

--- a/ext/server/command.cpp
+++ b/ext/server/command.cpp
@@ -69,7 +69,7 @@ void allocate_any(CORBA::Any *&any_ptr)
     {
         any_ptr = new CORBA::Any();
     }
-    catch (bad_alloc)
+    catch (std::bad_alloc)
     {
         Tango::Except::throw_exception(
             "API_MemoryAllocation",

--- a/ext/server/command.h
+++ b/ext/server/command.h
@@ -18,8 +18,8 @@
 class PyCmd : public Tango::Command
 {
 public:
-    PyCmd(string &name, Tango::CmdArgType in, Tango::CmdArgType out,
-          string &in_desc, string &out_desc, Tango::DispLevel  level)
+    PyCmd(std::string &name, Tango::CmdArgType in, Tango::CmdArgType out,
+          std::string &in_desc, std::string &out_desc, Tango::DispLevel  level)
     :Tango::Command(name,in,out,in_desc,out_desc, level),py_allowed_defined(false)	{};
 
     PyCmd(const char *name, Tango::CmdArgType in, Tango::CmdArgType out)
@@ -34,11 +34,11 @@ public:
     virtual CORBA::Any *execute (Tango::DeviceImpl *dev, const CORBA::Any &any);
     virtual bool is_allowed (Tango::DeviceImpl *dev, const CORBA::Any &any);
 
-    void set_allowed(const string &name) {py_allowed_defined=true;py_allowed_name=name;}
+    void set_allowed(const std::string &name) {py_allowed_defined=true;py_allowed_name=name;}
 
 private:
     bool py_allowed_defined;
-    string	py_allowed_name;
+    std::string	py_allowed_name;
 };
 
 #endif

--- a/ext/server/device_class.cpp
+++ b/ext/server/device_class.cpp
@@ -129,7 +129,7 @@ void CppDeviceClass::create_attribute(std::vector<Tango::Attr *> &att_list,
             TangoSys_OMemStream o;
             o << "Attribute " << attr_name << " has an unexpected data format\n"
               << "Please report this bug to the PyTango development team"
-              << ends;
+              << std::ends;
             Tango::Except::throw_exception(
                     (const char *)"PyDs_UnexpectedAttributeFormat",
                     o.str(),

--- a/ext/server/device_class.cpp
+++ b/ext/server/device_class.cpp
@@ -36,8 +36,8 @@ using namespace boost::python;
     try { boost::python::call_method<void>(m_self, #name, __VA_ARGS__); } \
     __AUX_CATCH_PY_EXCEPTION
 
-CppDeviceClass::CppDeviceClass(const string &name)
-    :Tango::DeviceClass(const_cast<string&>(name))
+CppDeviceClass::CppDeviceClass(const std::string &name)
+    :Tango::DeviceClass(const_cast<std::string&>(name))
 {}
 
 CppDeviceClass::~CppDeviceClass()
@@ -399,13 +399,13 @@ BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS (export_device_overload,
 
 void export_device_class()
 {
-    void (Tango::DeviceClass::*add_wiz_dev_prop_)(string &,string &) =
+    void (Tango::DeviceClass::*add_wiz_dev_prop_)(std::string &,std::string &) =
         &Tango::DeviceClass::add_wiz_dev_prop;
-    void (Tango::DeviceClass::*add_wiz_dev_prop__)(string &,string &,string &) =
+    void (Tango::DeviceClass::*add_wiz_dev_prop__)(std::string &,std::string &,std::string &) =
         &Tango::DeviceClass::add_wiz_dev_prop;
-    void (Tango::DeviceClass::*add_wiz_class_prop_)(string &,string &) =
+    void (Tango::DeviceClass::*add_wiz_class_prop_)(std::string &,std::string &) =
         &Tango::DeviceClass::add_wiz_class_prop;
-    void (Tango::DeviceClass::*add_wiz_class_prop__)(string &,string &,string &) =
+    void (Tango::DeviceClass::*add_wiz_class_prop__)(std::string &,std::string &,std::string &) =
         &Tango::DeviceClass::add_wiz_class_prop;
 
     class_<CppDeviceClass, auto_ptr<CppDeviceClassWrap>, boost::noncopyable>("DeviceClass",

--- a/ext/server/device_class.cpp
+++ b/ext/server/device_class.cpp
@@ -70,7 +70,7 @@ void CppDeviceClass::create_command(const std::string &cmd_name,
         command_list.push_back(cmd_ptr);
 }
 
-void CppDeviceClass::create_fwd_attribute(vector<Tango::Attr *> &att_list,
+void CppDeviceClass::create_fwd_attribute(std::vector<Tango::Attr *> &att_list,
 		const std::string &attr_name,
 		Tango::UserDefaultFwdAttrProp *att_prop)
 {
@@ -79,7 +79,7 @@ void CppDeviceClass::create_fwd_attribute(vector<Tango::Attr *> &att_list,
 	att_list.push_back(attr_ptr);
 }
 
-void CppDeviceClass::create_attribute(vector<Tango::Attr *> &att_list,
+void CppDeviceClass::create_attribute(std::vector<Tango::Attr *> &att_list,
 				      const std::string &attr_name,
 				      Tango::CmdArgType attr_type,
 				      Tango::AttrDataFormat attr_format,
@@ -156,7 +156,7 @@ void CppDeviceClass::create_attribute(vector<Tango::Attr *> &att_list,
 
     att_list.push_back(attr_ptr);
 }
-void CppDeviceClass::create_pipe(vector<Tango::Pipe *> &pipe_list,
+void CppDeviceClass::create_pipe(std::vector<Tango::Pipe *> &pipe_list,
 				 const std::string &name,
 				 Tango::PipeWriteType access,
 				 Tango::DispLevel display_level,
@@ -330,8 +330,8 @@ namespace PyDeviceClass
     object get_device_list(CppDeviceClass &self)
     {
         boost::python::list py_dev_list;
-        vector<Tango::DeviceImpl *> dev_list = self.get_device_list();
-        for(vector<Tango::DeviceImpl *>::iterator it = dev_list.begin(); it != dev_list.end(); ++it)
+        std::vector<Tango::DeviceImpl *> dev_list = self.get_device_list();
+        for(std::vector<Tango::DeviceImpl *>::iterator it = dev_list.begin(); it != dev_list.end(); ++it)
         {
             object py_value = object(
                         handle<>(
@@ -346,8 +346,8 @@ namespace PyDeviceClass
     object get_command_list(CppDeviceClass &self)
     {
         boost::python::list py_cmd_list;
-        vector<Tango::Command *> cmd_list = self.get_command_list();
-        for(vector<Tango::Command *>::iterator it = cmd_list.begin(); 
+        std::vector<Tango::Command *> cmd_list = self.get_command_list();
+        for(std::vector<Tango::Command *>::iterator it = cmd_list.begin(); 
 	    it != cmd_list.end(); ++it)
         {
             object py_value = object(
@@ -363,9 +363,9 @@ namespace PyDeviceClass
     object get_pipe_list(CppDeviceClass &self, const std::string& dev_name)
     {
         boost::python::list py_pipe_list;
-        vector<Tango::Pipe *> pipe_list = self.get_pipe_list(dev_name);
-//        vector<Tango::Pipe *> pipe_list = self.get_pipe_list();
-        for(vector<Tango::Pipe *>::iterator it = pipe_list.begin();
+        std::vector<Tango::Pipe *> pipe_list = self.get_pipe_list(dev_name);
+//        std::vector<Tango::Pipe *> pipe_list = self.get_pipe_list();
+        for(std::vector<Tango::Pipe *>::iterator it = pipe_list.begin();
 	    it != pipe_list.end(); ++it)
         {
             object py_value = object(

--- a/ext/server/device_class.cpp
+++ b/ext/server/device_class.cpp
@@ -408,7 +408,7 @@ void export_device_class()
     void (Tango::DeviceClass::*add_wiz_class_prop__)(std::string &,std::string &,std::string &) =
         &Tango::DeviceClass::add_wiz_class_prop;
 
-    class_<CppDeviceClass, auto_ptr<CppDeviceClassWrap>, boost::noncopyable>("DeviceClass",
+    class_<CppDeviceClass, std::auto_ptr<CppDeviceClassWrap>, boost::noncopyable>("DeviceClass",
         init<const std::string &>())
 
         .def("device_factory", &CppDeviceClassWrap::device_factory)
@@ -467,6 +467,6 @@ void export_device_class()
         .def("get_class_attr", &Tango::DeviceClass::get_class_attr,
             return_value_policy<reference_existing_object>())
     ;
-    implicitly_convertible<auto_ptr<CppDeviceClassWrap>, auto_ptr<CppDeviceClass> >();
+    implicitly_convertible<std::auto_ptr<CppDeviceClassWrap>, std::auto_ptr<CppDeviceClass> >();
 }
 

--- a/ext/server/device_class.h
+++ b/ext/server/device_class.h
@@ -64,7 +64,7 @@ public:
      * This method is intended to be called by python to register a new
      * attribute.
      */
-    void create_attribute(vector<Tango::Attr *> &att_list,
+    void create_attribute(std::vector<Tango::Attr *> &att_list,
                           const std::string &attr_name,
                           Tango::CmdArgType attr_type,
                           Tango::AttrDataFormat attr_format,
@@ -78,7 +78,7 @@ public:
                           const std::string &is_allowed_name,
                           Tango::UserDefaultAttrProp *att_prop);
 
-    void create_fwd_attribute(vector<Tango::Attr *> &att_list,
+    void create_fwd_attribute(std::vector<Tango::Attr *> &att_list,
                               const std::string &attr_name,
                               Tango::UserDefaultFwdAttrProp *att_prop);
 
@@ -87,7 +87,7 @@ public:
      * This method is intended to be called by python to register a new
      * pipe.
      */
-    void create_pipe(vector<Tango::Pipe *> &pipe_list,
+    void create_pipe(std::vector<Tango::Pipe *> &pipe_list,
 		     const std::string &name,
 		     Tango::PipeWriteType access,
 		     Tango::DispLevel display_level,

--- a/ext/server/device_class.h
+++ b/ext/server/device_class.h
@@ -18,7 +18,7 @@
 class CppDeviceClass: public Tango::DeviceClass
 {
 public:
-    CppDeviceClass(const string &);
+    CppDeviceClass(const std::string &);
 
     virtual ~CppDeviceClass();
 

--- a/ext/server/device_impl.cpp
+++ b/ext/server/device_impl.cpp
@@ -601,7 +601,7 @@ namespace PyDeviceImpl
         Tango::Attr *attr_ptr = NULL;
 
         long x, y;
-        vector<Tango::AttrProperty> &def_prop = new_attr.get_user_default_properties();
+        std::vector<Tango::AttrProperty> &def_prop = new_attr.get_user_default_properties();
         Tango::AttrDataFormat attr_format = new_attr.get_format();
         long attr_type = new_attr.get_type();
 
@@ -1011,22 +1011,22 @@ void Device_3ImplWrap::default_always_executed_hook()
     this->Tango::Device_3Impl::always_executed_hook();
 }
 
-void Device_3ImplWrap::read_attr_hardware(vector<long> &attr_list)
+void Device_3ImplWrap::read_attr_hardware(std::vector<long> &attr_list)
 {
     CALL_DEVICE_METHOD_VARGS(Device_3Impl, read_attr_hardware, attr_list)
 }
 
-void Device_3ImplWrap::default_read_attr_hardware(vector<long> &attr_list)
+void Device_3ImplWrap::default_read_attr_hardware(std::vector<long> &attr_list)
 {
     this->Tango::Device_3Impl::read_attr_hardware(attr_list);
 }
 
-void Device_3ImplWrap::write_attr_hardware(vector<long> &attr_list)
+void Device_3ImplWrap::write_attr_hardware(std::vector<long> &attr_list)
 {
     CALL_DEVICE_METHOD_VARGS(Device_3Impl, write_attr_hardware, attr_list)
 }
 
-void Device_3ImplWrap::default_write_attr_hardware(vector<long> &attr_list)
+void Device_3ImplWrap::default_write_attr_hardware(std::vector<long> &attr_list)
 {
     this->Tango::Device_3Impl::write_attr_hardware(attr_list);
 }
@@ -1186,22 +1186,22 @@ void Device_4ImplWrap::default_always_executed_hook()
     this->Tango::Device_4Impl::always_executed_hook();
 }
 
-void Device_4ImplWrap::read_attr_hardware(vector<long> &attr_list)
+void Device_4ImplWrap::read_attr_hardware(std::vector<long> &attr_list)
 {
     CALL_DEVICE_METHOD_VARGS(Device_4Impl, read_attr_hardware, attr_list)
 }
 
-void Device_4ImplWrap::default_read_attr_hardware(vector<long> &attr_list)
+void Device_4ImplWrap::default_read_attr_hardware(std::vector<long> &attr_list)
 {
     this->Tango::Device_4Impl::read_attr_hardware(attr_list);
 }
 
-void Device_4ImplWrap::write_attr_hardware(vector<long> &attr_list)
+void Device_4ImplWrap::write_attr_hardware(std::vector<long> &attr_list)
 {
     CALL_DEVICE_METHOD_VARGS(Device_4Impl, write_attr_hardware, attr_list)
 }
 
-void Device_4ImplWrap::default_write_attr_hardware(vector<long> &attr_list)
+void Device_4ImplWrap::default_write_attr_hardware(std::vector<long> &attr_list)
 {
     this->Tango::Device_4Impl::write_attr_hardware(attr_list);
 }
@@ -1354,22 +1354,22 @@ void Device_5ImplWrap::default_always_executed_hook()
     this->Tango::Device_5Impl::always_executed_hook();
 }
 
-void Device_5ImplWrap::read_attr_hardware(vector<long> &attr_list)
+void Device_5ImplWrap::read_attr_hardware(std::vector<long> &attr_list)
 {
     CALL_DEVICE_METHOD_VARGS(Device_5Impl, read_attr_hardware, attr_list)
 }
 
-void Device_5ImplWrap::default_read_attr_hardware(vector<long> &attr_list)
+void Device_5ImplWrap::default_read_attr_hardware(std::vector<long> &attr_list)
 {
     this->Tango::Device_5Impl::read_attr_hardware(attr_list);
 }
 
-void Device_5ImplWrap::write_attr_hardware(vector<long> &attr_list)
+void Device_5ImplWrap::write_attr_hardware(std::vector<long> &attr_list)
 {
     CALL_DEVICE_METHOD_VARGS(Device_5Impl, write_attr_hardware, attr_list)
 }
 
-void Device_5ImplWrap::default_write_attr_hardware(vector<long> &attr_list)
+void Device_5ImplWrap::default_write_attr_hardware(std::vector<long> &attr_list)
 {
     this->Tango::Device_5Impl::write_attr_hardware(attr_list);
 }

--- a/ext/server/device_impl.cpp
+++ b/ext/server/device_impl.cpp
@@ -665,7 +665,7 @@ namespace PyDeviceImpl
     void remove_attribute(Tango::DeviceImpl &self, const char *att_name,
                           bool clean_db = true)
     {
-        string str(att_name);
+        std::string str(att_name);
         self.remove_attribute(str, false, clean_db);
     }
 
@@ -695,7 +695,7 @@ namespace PyDeviceImpl
         self.remove_command(name, free_it, clean_db);
     }
 
-    inline void debug(Tango::DeviceImpl &self, const string &msg)
+    inline void debug(Tango::DeviceImpl &self, const std::string &msg)
     {
         if (self.get_logger()->is_debug_enabled()) {
 	    self.get_logger()->debug_stream() 
@@ -703,7 +703,7 @@ namespace PyDeviceImpl
 	}
     }
 
-    inline void info(Tango::DeviceImpl &self, const string &msg)
+    inline void info(Tango::DeviceImpl &self, const std::string &msg)
     {
         if (self.get_logger()->is_info_enabled()) {
 	    self.get_logger()->info_stream() 
@@ -711,7 +711,7 @@ namespace PyDeviceImpl
 	}
     }
 
-    inline void warn(Tango::DeviceImpl &self, const string &msg)
+    inline void warn(Tango::DeviceImpl &self, const std::string &msg)
     {
         if (self.get_logger()->is_warn_enabled()) {
 	    self.get_logger()->warn_stream() 
@@ -719,7 +719,7 @@ namespace PyDeviceImpl
 	}
     }
 
-    inline void error(Tango::DeviceImpl &self, const string &msg)
+    inline void error(Tango::DeviceImpl &self, const std::string &msg)
     {
         if (self.get_logger()->is_error_enabled()) {
 	    self.get_logger()->error_stream() 
@@ -727,7 +727,7 @@ namespace PyDeviceImpl
 	}
     }
 
-    inline void fatal(Tango::DeviceImpl &self, const string &msg)
+    inline void fatal(Tango::DeviceImpl &self, const std::string &msg)
     {
         if (self.get_logger()->is_fatal_enabled()) {
 	    self.get_logger()->fatal_stream() 

--- a/ext/server/device_impl.cpp
+++ b/ext/server/device_impl.cpp
@@ -528,7 +528,7 @@ namespace PyDeviceImpl
             TangoSys_OMemStream o;
             o << "Wrong definition of attribute " << attr_name
               << "\nThe attribute method " << method_name
-              << " does not exist in your class!" << ends;
+              << " does not exist in your class!" << std::ends;
 
             Tango::Except::throw_exception(
                     (const char *)"PyDs_WrongCommandDefinition",
@@ -541,7 +541,7 @@ namespace PyDeviceImpl
             TangoSys_OMemStream o;
             o << "Wrong definition of attribute " << attr_name
               << "\nThe object " << method_name
-              << " exists in your class but is not a Python method" << ends;
+              << " exists in your class but is not a Python method" << std::ends;
 
             Tango::Except::throw_exception(
                     (const char *)"PyDs_WrongCommandDefinition",
@@ -632,7 +632,7 @@ namespace PyDeviceImpl
                 TangoSys_OMemStream o;
                 o << "Attribute " << attr_name << " has an unexpected data format\n"
                   << "Please report this bug to the PyTango development team"
-                  << ends;
+                  << std::ends;
                 Tango::Except::throw_exception(
                         (const char *)"PyDs_UnexpectedAttributeFormat",
                         o.str(),

--- a/ext/server/device_impl.cpp
+++ b/ext/server/device_impl.cpp
@@ -1471,7 +1471,7 @@ void export_device_impl()
     void (Tango::DeviceImpl::*stop_polling1)() = &Tango::DeviceImpl::stop_polling;
     void (Tango::DeviceImpl::*stop_polling2)(bool) = &Tango::DeviceImpl::stop_polling;
     
-    class_<Tango::DeviceImpl, auto_ptr<DeviceImplWrap>, boost::noncopyable>("DeviceImpl",
+    class_<Tango::DeviceImpl, std::auto_ptr<DeviceImplWrap>, boost::noncopyable>("DeviceImpl",
         init<CppDeviceClass *, const char *,
              optional<const char *, Tango::DevState, const char *> >())
 
@@ -1711,7 +1711,7 @@ void export_device_impl()
 	.def("is_there_subscriber",
 	     &Tango::DeviceImpl::is_there_subscriber)
     ;
-    implicitly_convertible<auto_ptr<DeviceImplWrap>, auto_ptr<Tango::DeviceImpl> >();
+    implicitly_convertible<std::auto_ptr<DeviceImplWrap>, std::auto_ptr<Tango::DeviceImpl> >();
     
     class_<Tango::Device_2Impl, Device_2ImplWrap,
            bases<Tango::DeviceImpl>,
@@ -1748,7 +1748,7 @@ void export_device_impl()
         .def("set_attribute_config_3", &PyDevice_3Impl::set_attribute_config_3)
     ;
 
-    class_<Tango::Device_4Impl, auto_ptr<Device_4ImplWrap>,
+    class_<Tango::Device_4Impl, std::auto_ptr<Device_4ImplWrap>,
            bases<Tango::Device_3Impl>,
            boost::noncopyable>
            ("Device_4Impl",
@@ -1770,9 +1770,9 @@ void export_device_impl()
         .def("signal_handler", &Tango::Device_4Impl::signal_handler,
             &Device_4ImplWrap::default_signal_handler)
     ;
-    implicitly_convertible<auto_ptr<Device_4ImplWrap>, auto_ptr<Tango::Device_4Impl> >();
+    implicitly_convertible<std::auto_ptr<Device_4ImplWrap>, std::auto_ptr<Tango::Device_4Impl> >();
 
-    class_<Tango::Device_5Impl, auto_ptr<Device_5ImplWrap>,
+    class_<Tango::Device_5Impl, std::auto_ptr<Device_5ImplWrap>,
            bases<Tango::Device_4Impl>,
            boost::noncopyable>
            ("Device_5Impl",
@@ -1794,7 +1794,7 @@ void export_device_impl()
         .def("signal_handler", &Tango::Device_5Impl::signal_handler,
             &Device_5ImplWrap::default_signal_handler)
     ;
-    implicitly_convertible<auto_ptr<Device_5ImplWrap>, auto_ptr<Tango::Device_5Impl> >();
+    implicitly_convertible<std::auto_ptr<Device_5ImplWrap>, std::auto_ptr<Tango::Device_5Impl> >();
 
 }
 //namespace PyDevIntrThread

--- a/ext/server/device_impl.h
+++ b/ext/server/device_impl.h
@@ -204,22 +204,22 @@ public:
     /**
      * Necessary read_attr_hardware implementation to call python
      */
-    virtual void read_attr_hardware(vector<long> &attr_list);
+    virtual void read_attr_hardware(std::vector<long> &attr_list);
 
     /**
      * Executes default read_attr_hardware implementation
      */
-    void default_read_attr_hardware(vector<long> &attr_list);
+    void default_read_attr_hardware(std::vector<long> &attr_list);
 
     /**
      * Necessary write_attr_hardware implementation to call python
      */
-    virtual void write_attr_hardware(vector<long> &attr_list);
+    virtual void write_attr_hardware(std::vector<long> &attr_list);
 
     /**
      * Executes default write_attr_hardware implementation
      */
-    void default_write_attr_hardware(vector<long> &attr_list);
+    void default_write_attr_hardware(std::vector<long> &attr_list);
 
     /**
      * Necessary dev_state implementation to call python
@@ -331,22 +331,22 @@ public:
     /**
      * Necessary read_attr_hardware implementation to call python
      */
-    virtual void read_attr_hardware(vector<long> &attr_list);
+    virtual void read_attr_hardware(std::vector<long> &attr_list);
 
     /**
      * Executes default read_attr_hardware implementation
      */
-    void default_read_attr_hardware(vector<long> &attr_list);
+    void default_read_attr_hardware(std::vector<long> &attr_list);
 
     /**
      * Necessary write_attr_hardware implementation to call python
      */
-    virtual void write_attr_hardware(vector<long> &attr_list);
+    virtual void write_attr_hardware(std::vector<long> &attr_list);
 
     /**
      * Executes default write_attr_hardware implementation
      */
-    void default_write_attr_hardware(vector<long> &attr_list);
+    void default_write_attr_hardware(std::vector<long> &attr_list);
 
     /**
      * Necessary dev_state implementation to call python
@@ -458,22 +458,22 @@ public:
     /**
      * Necessary read_attr_hardware implementation to call python
      */
-    virtual void read_attr_hardware(vector<long> &attr_list);
+    virtual void read_attr_hardware(std::vector<long> &attr_list);
 
     /**
      * Executes default read_attr_hardware implementation
      */
-    void default_read_attr_hardware(vector<long> &attr_list);
+    void default_read_attr_hardware(std::vector<long> &attr_list);
 
     /**
      * Necessary write_attr_hardware implementation to call python
      */
-    virtual void write_attr_hardware(vector<long> &attr_list);
+    virtual void write_attr_hardware(std::vector<long> &attr_list);
 
     /**
      * Executes default write_attr_hardware implementation
      */
-    void default_write_attr_hardware(vector<long> &attr_list);
+    void default_write_attr_hardware(std::vector<long> &attr_list);
 
     /**
      * Necessary dev_state implementation to call python

--- a/ext/server/pipe.cpp
+++ b/ext/server/pipe.cpp
@@ -507,7 +507,7 @@ namespace PyDevicePipe
 	}
 
 	void __append(Tango::DevicePipeBlob& dpb, const std::string& name, bopy::object& value) {
-		if (__check_type<string>(value)) {
+		if (__check_type<std::string>(value)) {
 			__append_scalar<Tango::DevicePipeBlob, Tango::DEV_STRING>(dpb, name, value);
 		} else if (__check_type<int>(value)) {
 			__append_scalar<Tango::DevicePipeBlob, Tango::DEV_LONG64>(dpb, name, value);
@@ -516,7 +516,7 @@ namespace PyDevicePipe
 		} else if (__check_type<bool>(value)) {
 			__append_scalar<Tango::DevicePipeBlob, Tango::DEV_BOOLEAN>(dpb, name, value);
 		} else if (__check_type<bopy::list>(value)) {
-			if (__check_type<string>(value[0])) {
+			if (__check_type<std::string>(value[0])) {
 				__append_array<Tango::DevicePipeBlob, Tango::DEVVAR_STRINGARRAY>(dpb, name, value);
 			} else if (__check_type<int>(value[0])) {
 				__append_array<Tango::DevicePipeBlob, Tango::DEVVAR_LONG64ARRAY>(dpb, name, value);

--- a/ext/server/pipe.cpp
+++ b/ext/server/pipe.cpp
@@ -110,7 +110,7 @@ namespace PyTango { namespace Pipe {
 					     const char *method)
     {
 	TangoSys_OMemStream o;
-	o << "Wrong Python type for pipe " << name << ends;
+	o << "Wrong Python type for pipe " << name << std::ends;
 	Tango::Except::throw_exception("PyDs_WrongPythonDataTypeForPipe",
 				       o.str(), method);
     }
@@ -469,7 +469,7 @@ namespace PyDevicePipe
 {
 	static void throw_wrong_python_data_type(const std::string &name, const char *method) {
 		TangoSys_OMemStream o;
-		o << "Wrong Python type for pipe " << name << ends;
+		o << "Wrong Python type for pipe " << name << std::ends;
 		Tango::Except::throw_exception("PyDs_WrongPythonDataTypeForPipe",
 				o.str(), method);
 	}

--- a/ext/server/tango_util.cpp
+++ b/ext/server/tango_util.cpp
@@ -115,8 +115,8 @@ namespace PyUtil
     inline object get_device_list_by_class(Tango::Util &self, const string &class_name)
     {
         boost::python::list py_dev_list;
-        vector<Tango::DeviceImpl *> &dev_list = self.get_device_list_by_class(class_name);
-        for(vector<Tango::DeviceImpl *>::iterator it = dev_list.begin(); it != dev_list.end(); ++it)
+        std::vector<Tango::DeviceImpl *> &dev_list = self.get_device_list_by_class(class_name);
+        for(std::vector<Tango::DeviceImpl *>::iterator it = dev_list.begin(); it != dev_list.end(); ++it)
         {
             object py_value = object(
                         handle<>(
@@ -144,8 +144,8 @@ namespace PyUtil
     inline object get_device_list(Tango::Util &self, const string &name)
     {
         boost::python::list py_dev_list;
-        vector<Tango::DeviceImpl *> dev_list = self.get_device_list(name);
-        for(vector<Tango::DeviceImpl *>::iterator it = dev_list.begin(); it != dev_list.end(); ++it)
+        std::vector<Tango::DeviceImpl *> dev_list = self.get_device_list(name);
+        for(std::vector<Tango::DeviceImpl *>::iterator it = dev_list.begin(); it != dev_list.end(); ++it)
         {
             object py_value = object(
                         handle<>(

--- a/ext/server/tango_util.cpp
+++ b/ext/server/tango_util.cpp
@@ -112,7 +112,7 @@ namespace PyUtil
         return Tango::Util::instance(b);
     }
 
-    inline object get_device_list_by_class(Tango::Util &self, const string &class_name)
+    inline object get_device_list_by_class(Tango::Util &self, const std::string &class_name)
     {
         boost::python::list py_dev_list;
         std::vector<Tango::DeviceImpl *> &dev_list = self.get_device_list_by_class(class_name);
@@ -129,7 +129,7 @@ namespace PyUtil
         return py_dev_list;
     }
 
-    inline object get_device_by_name(Tango::Util &self, const string &dev_name)
+    inline object get_device_by_name(Tango::Util &self, const std::string &dev_name)
     {
         Tango::DeviceImpl *value = self.get_device_by_name(dev_name);
         object py_value = object(
@@ -141,7 +141,7 @@ namespace PyUtil
         return py_value;
     }
 
-    inline object get_device_list(Tango::Util &self, const string &name)
+    inline object get_device_list(Tango::Util &self, const std::string &name)
     {
         boost::python::list py_dev_list;
         std::vector<Tango::DeviceImpl *> dev_list = self.get_device_list(name);

--- a/ext/server/wattribute.cpp
+++ b/ext/server/wattribute.cpp
@@ -48,7 +48,7 @@ inline static void throw_wrong_python_data_type(const std::string &att_name,
                                          const char *method)
 {
     TangoSys_OMemStream o;
-    o << "Wrong Python type for attribute " << att_name << ends;
+    o << "Wrong Python type for attribute " << att_name << std::ends;
     Tango::Except::throw_exception(
             "PyDs_WrongPythonDataTypeForAttribute",
             o.str(),
@@ -380,7 +380,7 @@ namespace PyWAttribute
                 TangoSys_OMemStream o;
                 o << "Wrong Python type for attribute " << att.get_name()
                   << "of type " << Tango::CmdArgTypeName[type]
-                  << ". Expected a sequence." << ends;
+                  << ". Expected a sequence." << std::ends;
 
                 Tango::Except::throw_exception(
                         "PyDs_WrongPythonDataTypeForAttribute",
@@ -405,7 +405,7 @@ namespace PyWAttribute
             TangoSys_OMemStream o;
             o << "Cannot call set_value(data, dim_x) on scalar attribute "
               << att.get_name() << ". Use set_write_value(data) instead"
-              << ends;
+              << std::ends;
 
             Tango::Except::throw_exception(
                     "PyDs_WrongPythonDataTypeForAttribute",
@@ -419,7 +419,7 @@ namespace PyWAttribute
                 TangoSys_OMemStream o;
                 o << "Wrong Python type for attribute " << att.get_name()
                   << "of type " << Tango::CmdArgTypeName[type]
-                  << ". Expected a sequence" << ends;
+                  << ". Expected a sequence" << std::ends;
 
                 Tango::Except::throw_exception(
                         "PyDs_WrongPythonDataTypeForAttribute",
@@ -443,7 +443,7 @@ namespace PyWAttribute
             TangoSys_OMemStream o;
             o << "Cannot call set_write_value(data, dim_x, dim_y) "
               << "on scalar attribute " << att.get_name()
-              << ". Use set_write_value(data) instead" << ends;
+              << ". Use set_write_value(data) instead" << std::ends;
 
             Tango::Except::throw_exception(
                     (const char *)"PyDs_WrongPythonDataTypeForAttribute",
@@ -457,7 +457,7 @@ namespace PyWAttribute
                 TangoSys_OMemStream o;
                 o << "Wrong Python type for attribute " << att.get_name()
                   << "of type " << Tango::CmdArgTypeName[type]
-                  << ". Expected a sequence" << ends;
+                  << ". Expected a sequence" << std::ends;
 
                 Tango::Except::throw_exception(
                         (const char *)"PyDs_WrongPythonDataTypeForAttribute",

--- a/ext/server/wattribute.cpp
+++ b/ext/server/wattribute.cpp
@@ -126,7 +126,7 @@ namespace PyWAttribute
     template<>
     inline void __set_min_value<Tango::DevEncoded>(Tango::WAttribute &self, boost::python::object value)
     {
-    	string err_msg = "Attribute properties cannot be set with Tango::DevEncoded data type";
+    	std::string err_msg = "Attribute properties cannot be set with Tango::DevEncoded data type";
     	Tango::Except::throw_exception((const char *)"API_MethodArgument",
     				  (const char *)err_msg.c_str(),
     				  (const char *)"WAttribute::set_min_value()");
@@ -143,7 +143,7 @@ namespace PyWAttribute
 
     inline void set_min_value(Tango::WAttribute &self, boost::python::object value)
     {
-        bopy::extract<string> value_convert(value);
+        bopy::extract<std::string> value_convert(value);
         
     	if (value_convert.check())
     	{
@@ -185,7 +185,7 @@ namespace PyWAttribute
     template<>
     inline void __set_max_value<Tango::DevEncoded>(Tango::WAttribute &self, boost::python::object value)
     {
-    	string err_msg = "Attribute properties cannot be set with Tango::DevEncoded data type";
+    	std::string err_msg = "Attribute properties cannot be set with Tango::DevEncoded data type";
     	Tango::Except::throw_exception((const char *)"API_MethodArgument",
     				  (const char *)err_msg.c_str(),
     				  (const char *)"WAttribute::set_max_value()");
@@ -202,7 +202,7 @@ namespace PyWAttribute
 
     inline void set_max_value(Tango::WAttribute &self, boost::python::object value)
     {
-        bopy::extract<string> value_convert(value);
+        bopy::extract<std::string> value_convert(value);
         
     	if (value_convert.check())
     	{


### PR DESCRIPTION
Allow to compile with `TANGO_USE_USING_NAMESPACE=OFF` in `cppTango`.

Add `std::` prefix to:

- cout
- cerr
- endl
- ends
- vector
- string
- bad_alloc
- numeric_limits
- max
- auto_ptr

Should `std::auto_ptr` be replaced with `unique_pointer` instead?