### PR TITLE
WIP: Fix read/write/is_allowed not called for dynamic attribute in async mode server

### DIFF
--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -688,13 +688,13 @@ def test_dyn_attr_async_read(typed_values, server_green_mode):
 
     class TestDevice(Device):
         green_mode = server_green_mode
-        _is_testattr_allowed = True
 
         def __init__(self, *args, **kwargs):
             super(TestDevice, self).__init__(*args, **kwargs)
 
             attr = Attr("TestAttr", dtype, AttrWriteType.READ_WRITE)
             self.add_attribute(attr, self.read_attr, self.write_attr, self.is_attr_allowed)
+            self._is_testattr_allowed = True
 
         def read_attr(self, attr):
             attr.set_value(self.attr_value)
@@ -705,13 +705,17 @@ def test_dyn_attr_async_read(typed_values, server_green_mode):
         def is_attr_allowed(self, req_type):
             return self._is_testattr_allowed
 
+        @command
+        def make_allowed(self, yesno):
+            self._is_testattr_allowed = yesno
+
     with DeviceTestContext(TestDevice) as proxy:
         proxy._is_testattr_allowed = True
         for value in values:
             proxy.TestAttr = value
             assert_close(proxy.TestAttr, expected(value))
 
-        proxy._is_testattr_allowed = False
+        proxy.make_allowed(False)
         for value in values:
             with pytest.raises(DevFailed):
                 proxy.TestAttr = value

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -683,8 +683,8 @@ def test_exeption_propagation(server_green_mode):
 def test_dyn_attr_async_read(typed_values, server_green_mode):
     py_dtype, values, expected = typed_values
 
-    import tango.device_proxy.__get_tango_type as get_tango_type
-    dtype = get_tango_type(py_dtype)
+    from tango.device_proxy import __get_tango_type
+    dtype = __get_tango_type(py_dtype)
 
     class TestDevice(Device):
         green_mode = server_green_mode

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -710,7 +710,7 @@ def test_dyn_attr_async_read(typed_values, server_green_mode):
             self._is_testattr_allowed = yesno
 
     with DeviceTestContext(TestDevice) as proxy:
-        proxy._is_testattr_allowed = True
+        proxy.make_allowed(True)
         for value in values:
             proxy.TestAttr = value
             assert_close(proxy.TestAttr, expected(value))

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -713,5 +713,5 @@ def test_dyn_attr_async_read(typed_values, server_green_mode):
 
         proxy._is_testattr_allowed = False
         for value in values:
-            with pytest.raises(DevFailed) as record:
+            with pytest.raises(DevFailed):
                 proxy.TestAttr = value

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -5,7 +5,7 @@ import textwrap
 import pytest
 import enum
 
-from tango import AttrData, AttrWriteType, DevFailed, DevEncoded, \
+from tango import Attr, AttrData, AttrWriteType, DevFailed, DevEncoded, \
     DevEnum, DevState, GreenMode, READ_WRITE, SCALAR
 from tango.server import Device
 from tango.server import command, attribute, device_property
@@ -425,7 +425,7 @@ def test_device_property_with_default_value(typed_values, server_green_mode):
                            properties={'prop_with_db_value': value}) as proxy:
         assert_close(proxy.get_prop_without_db_value(), expected(default))
         assert_close(proxy.get_prop_with_db_value(), expected(value))
-    
+
 
 def test_device_get_device_properties_when_init_device(server_green_mode):
 
@@ -677,3 +677,28 @@ def test_exeption_propagation(server_green_mode):
         with pytest.raises(DevFailed) as record:
             proxy.cmd()
         assert "ZeroDivisionError" in record.value.args[0].desc
+
+# Test server dynamic attributes async mode
+
+def test_dyn_attr_async_read(typed_values, server_green_mode):
+    dtype, values, expected = typed_values
+
+    class TestDevice(Device):
+        green_mode = server_green_mode
+
+        def __init__(self, *args, **kwargs):
+            super(TestDevice, self).__init__(*args, **kwargs)
+
+            attr = Attr("Attribute", dtype, AttrWriteType.READ_WRITE)
+            self.add_attribute(attr, self.read_attr, self.write_attr)
+
+        def read_attr(self, attr):
+            attr.set_value(self.attr_value)
+
+        def write_attr(self, attr):
+            self.attr_value = attr.get_write_value()
+
+    with DeviceTestContext(TestDevice) as proxy:
+        for value in values:
+            proxy.Attribute = value
+            assert_close(proxy.attr, expected(value))

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -709,7 +709,7 @@ def test_dyn_attr_async_read(typed_values, server_green_mode):
         proxy._is_testattr_allowed = True
         for value in values:
             proxy.TestAttr = value
-            assert_close(proxy.attr, expected(value))
+            assert_close(proxy.TestAttr, expected(value))
 
         proxy._is_testattr_allowed = False
         for value in values:

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -705,7 +705,7 @@ def test_dyn_attr_async_read(typed_values, server_green_mode):
         def is_attr_allowed(self, req_type):
             return self._is_testattr_allowed
 
-        @command
+        @command(dtype_in=bool)
         def make_allowed(self, yesno):
             self._is_testattr_allowed = yesno
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -688,12 +688,13 @@ def test_dyn_attr_async_read(typed_values, server_green_mode):
 
     class TestDevice(Device):
         green_mode = server_green_mode
+        _is_testattr_allowed = True
 
         def __init__(self, *args, **kwargs):
             super(TestDevice, self).__init__(*args, **kwargs)
 
             attr = Attr("TestAttr", dtype, AttrWriteType.READ_WRITE)
-            self.add_attribute(attr, self.read_attr, self.write_attr)
+            self.add_attribute(attr, self.read_attr, self.write_attr, self.is_attr_allowed)
 
         def read_attr(self, attr):
             attr.set_value(self.attr_value)
@@ -701,7 +702,16 @@ def test_dyn_attr_async_read(typed_values, server_green_mode):
         def write_attr(self, attr):
             self.attr_value = attr.get_write_value()
 
+        def is_attr_allowed(self, req_type):
+            return self._is_testattr_allowed
+
     with DeviceTestContext(TestDevice) as proxy:
+        proxy._is_testattr_allowed = True
         for value in values:
             proxy.TestAttr = value
             assert_close(proxy.attr, expected(value))
+
+        proxy._is_testattr_allowed = False
+        for value in values:
+            with pytest.raises(DevFailed) as record:
+                proxy.TestAttr = value

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -681,7 +681,10 @@ def test_exeption_propagation(server_green_mode):
 # Test server dynamic attributes async mode
 
 def test_dyn_attr_async_read(typed_values, server_green_mode):
-    dtype, values, expected = typed_values
+    py_dtype, values, expected = typed_values
+
+    import tango.device_proxy.__get_tango_type as get_tango_type
+    dtype = get_tango_type(py_dtype)
 
     class TestDevice(Device):
         green_mode = server_green_mode

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -692,7 +692,7 @@ def test_dyn_attr_async_read(typed_values, server_green_mode):
         def __init__(self, *args, **kwargs):
             super(TestDevice, self).__init__(*args, **kwargs)
 
-            attr = Attr("Attribute", dtype, AttrWriteType.READ_WRITE)
+            attr = Attr("TestAttr", dtype, AttrWriteType.READ_WRITE)
             self.add_attribute(attr, self.read_attr, self.write_attr)
 
         def read_attr(self, attr):
@@ -703,5 +703,5 @@ def test_dyn_attr_async_read(typed_values, server_green_mode):
 
     with DeviceTestContext(TestDevice) as proxy:
         for value in values:
-            proxy.Attribute = value
+            proxy.TestAttr = value
             assert_close(proxy.attr, expected(value))


### PR DESCRIPTION
PR with fix for #173.

Currently it is a draft with (failing) tests only.   This PR is to continue the work started by @stanislaw55 in PR #337, rebased onto `develop`.  I cannot push changes to the forked repo.