### PR TITLE
Typo on Sphinx  documentation

### DIFF
--- a/tango/device_server.py
+++ b/tango/device_server.py
@@ -203,14 +203,14 @@ def __Attribute__get_properties(self, attr_cfg=None):
 
         Get attribute properties.
 
-        Parameters :
-            - conf : the config object to be filled with
-                     the attribute configuration. Default is None meaning the
-                     method will create internally a new AttributeConfig_5
-                     and return it.
-                     Can be AttributeConfig, AttributeConfig_2,
-                     AttributeConfig_3, AttributeConfig_5 or
-                     MultiAttrProp
+        Parameters:
+            conf: the config object to be filled with
+                  the attribute configuration. Default is None meaning the
+                  method will create internally a new AttributeConfig_5
+                  and return it.
+                  Can be AttributeConfig, AttributeConfig_2,
+                  AttributeConfig_3, AttributeConfig_5 or
+                  MultiAttrProp
 
         Return:
             AttributeConfig: the config object filled with attribute configuration information
@@ -234,11 +234,10 @@ def __Attribute__set_properties(self, attr_cfg, dev=None):
         This method sets the attribute properties value with the content
         of the fileds in the AttributeConfig/ AttributeConfig_3 object
 
-        Parameters :
-            - conf : (AttributeConfig or AttributeConfig_3) the config
-                     object.
-            - dev : (DeviceImpl) the device (not used, maintained
-                    for backward compatibility)
+        Parameters:
+            conf (AttributeConfig or AttributeConfig_3): the config object.
+            dev (DeviceImpl): the device (not used, maintained
+                              for backward compatibility)
 
         New in PyTango 7.1.4
     """
@@ -273,10 +272,10 @@ def __DeviceImpl__get_device_properties(self, ds_class=None):
         Utility method that fetches all the device properties from the database
         and converts them into members of this DeviceImpl.
 
-        Parameters :
-            - ds_class : (DeviceClass) the DeviceClass object. Optional. Default value is
-                         None meaning that the corresponding DeviceClass object for this
-                         DeviceImpl will be used
+        Parameters:
+            ds_class (DeviceClass): the DeviceClass object. Optional. Default value is
+                None meaning that the corresponding DeviceClass object for this
+                DeviceImpl will be used
 
         Raises:
             DevFailed:
@@ -313,13 +312,13 @@ def __DeviceImpl__add_attribute(self, attr, r_meth=None, w_meth=None, is_allo_me
         to the device class attribute list. Therefore, all devices belonging to the
         same class created after this attribute addition will also have this attribute.
 
-        Parameters :
-            - attr : (Attr or AttrData) the new attribute to be added to the list.
-            - r_meth : (callable) the read method to be called on a read request
-            - w_meth : (callable) the write method to be called on a write request
-                       (if attr is writable)
-            - is_allo_meth: (callable) the method that is called to check if it
-                            is possible to access the attribute or not
+        Parameters:
+            attr (Attr or AttrData): the new attribute to be added to the list.
+            r_meth (callable): the read method to be called on a read request
+            w_meth (callable): the write method to be called on a write request
+                               (if attr is writable)
+            is_allo_meth (callable): the method that is called to check if it
+                               is possible to access the attribute or not
 
         Return:
             Attr: the newly created attribute.
@@ -376,8 +375,8 @@ def __DeviceImpl__remove_attribute(self, attr_name):
 
         Remove one attribute from the device attribute list.
 
-        Parameters :
-            - attr_name : (str) attribute name
+        Parameters:
+            attr_name (str): attribute name
 
         Raises:
             DevFailed:
@@ -429,10 +428,10 @@ def __DeviceImpl__add_command(self, cmd, device_level=True):
 
         Add a new command to the device command list.
 
-        Parameters :
-            - cmd          : the new command to be added to the list
-            - device_level : Set this flag to true if the command must be added
-                             for only this device
+        Parameters:
+            cmd: the new command to be added to the list
+            device_level: Set this flag to true if the command must be added
+                          for only this device
 
         Return:
             Command:
@@ -465,11 +464,11 @@ def __DeviceImpl__remove_command(self, cmd_name, free_it=False, clean_db=True):
 
         Remove one command from the device command list.
 
-        Parameters :
-            - cmd_name : (str) command name to be removed from the list
-            - free_it  : Boolean set to true if the command object must be freed.
-            - clean_db : Clean command related information (included polling info
-                         if the command is polled) from database.
+        Parameters:
+            cmd_name (str): command name to be removed from the list
+            free_it (bool): set to true if the command object must be freed.
+            clean_db: Clean command related information (included polling info
+                      if the command is polled) from database.
 
         Raises:
             DevFailed:
@@ -497,8 +496,8 @@ def __DeviceImpl__debug_stream(self, msg, *args):
 
             print(msg, file=self.log_debug)
 
-        Parameters :
-            - msg : (str) the message to be sent to the debug stream
+        Parameters:
+            msg (str): the message to be sent to the debug stream
     """
     self.__debug_stream(msg % args)
 
@@ -513,8 +512,8 @@ def __DeviceImpl__info_stream(self, msg, *args):
 
             print(msg, file=self.log_info)
 
-        Parameters :
-            - msg : (str) the message to be sent to the info stream
+        Parameters:
+            msg (str): the message to be sent to the info stream
     """
     self.__info_stream(msg % args)
 
@@ -529,8 +528,8 @@ def __DeviceImpl__warn_stream(self, msg, *args):
 
             print(msg, file=self.log_warn)
 
-        Parameters :
-            - msg : (str) the message to be sent to the warn stream
+        Parameters:
+            msg (str): the message to be sent to the warn stream
     """
     self.__warn_stream(msg % args)
 
@@ -545,8 +544,8 @@ def __DeviceImpl__error_stream(self, msg, *args):
 
             print(msg, file=self.log_error)
 
-        Parameters :
-            - msg : (str) the message to be sent to the error stream
+        Parameters:
+            msg (str): the message to be sent to the error stream
     """
     self.__error_stream(msg % args)
 
@@ -561,8 +560,8 @@ def __DeviceImpl__fatal_stream(self, msg, *args):
 
             print(msg, file=self.log_fatal)
 
-        Parameters :
-            - msg : (str) the message to be sent to the fatal stream
+        Parameters:
+            msg (str): the message to be sent to the fatal stream
     """
     self.__fatal_stream(msg % args)
 
@@ -635,10 +634,10 @@ def __Logger__log(self, level, msg, *args):
 
         Sends the given message to the tango the selected stream.
 
-        Parameters :
-            - level: (Level.LevelLevel) Log level
-            - msg : (str) the message to be sent to the stream
-            - args: (seq<str>) list of optional message arguments
+        Parameters:
+            level (Level.LevelLevel): Log level
+            msg (str): the message to be sent to the stream
+            args (seq<str>): list of optional message arguments
     """
     self.__log(level, msg % args)
 
@@ -650,10 +649,10 @@ def __Logger__log_unconditionally(self, level, msg, *args):
         Sends the given message to the tango the selected stream,
         without checking the level.
 
-        Parameters :
-            - level: (Level.LevelLevel) Log level
-            - msg : (str) the message to be sent to the stream
-            - args: (seq<str>) list of optional message arguments
+        Parameters:
+            level (Level.LevelLevel): Log level
+            msg (str): the message to be sent to the stream
+            args (seq<str>): list of optional message arguments
     """
     self.__log_unconditionally(level, msg % args)
 
@@ -664,9 +663,9 @@ def __Logger__debug(self, msg, *args):
 
         Sends the given message to the tango debug stream.
 
-        Parameters :
-            - msg : (str) the message to be sent to the debug stream
-            - args: (seq<str>) list of optional message arguments
+        Parameters:
+            msg (str): the message to be sent to the debug stream
+            args (seq<str>): list of optional message arguments
     """
     self.__debug(msg % args)
 
@@ -677,9 +676,9 @@ def __Logger__info(self, msg, *args):
 
         Sends the given message to the tango info stream.
 
-        Parameters :
-            - msg : (str) the message to be sent to the info stream
-            - args: (seq<str>) list of optional message arguments
+        Parameters:
+            msg (str): the message to be sent to the info stream
+            args (seq<str>): list of optional message arguments
     """
     self.__info(msg % args)
 
@@ -690,9 +689,9 @@ def __Logger__warn(self, msg, *args):
 
         Sends the given message to the tango warn stream.
 
-        Parameters :
-            - msg : (str) the message to be sent to the warn stream
-            - args: (seq<str>) list of optional message arguments
+        Parameters:
+            msg (str): the message to be sent to the warn stream
+            args (seq<str>): list of optional message arguments
     """
     self.__warn(msg % args)
 
@@ -703,9 +702,9 @@ def __Logger__error(self, msg, *args):
 
         Sends the given message to the tango error stream.
 
-        Parameters :
-            - msg : (str) the message to be sent to the error stream
-            - args: (seq<str>) list of optional message arguments
+        Parameters:
+            msg (str): the message to be sent to the error stream
+            args (seq<str>): list of optional message arguments
     """
     self.__error(msg % args)
 
@@ -716,9 +715,9 @@ def __Logger__fatal(self, msg, *args):
 
         Sends the given message to the tango fatal stream.
 
-        Parameters :
-            - msg : (str) the message to be sent to the fatal stream
-            - args: (seq<str>) list of optional message arguments
+        Parameters:
+            msg (str): the message to be sent to the fatal stream
+            args (seq<str>): list of optional message arguments
     """
     self.__fatal(msg % args)
 
@@ -729,8 +728,8 @@ def __UserDefaultAttrProp_set_enum_labels(self, enum_labels):
 
         Set default enumeration labels.
 
-        Parameters :
-            - enum_labels : (seq<str>) list of enumeration labels
+        Parameters:
+            enum_labels (seq<str>): list of enumeration labels
 
         New in PyTango 9.2.0
     """
@@ -784,8 +783,8 @@ def __doc_DeviceImpl():
 
         Set device state.
 
-        Parameters :
-            - new_state : (DevState) the new device state
+        Parameters:
+            new_state (DevState): the new device state
     """)
 
     document_method("get_state", """
@@ -832,8 +831,8 @@ def __doc_DeviceImpl():
         Register this device as device to be informed when signal signo
         is sent to to the device server process
 
-        Parameters :
-            - signo : (int) signal identifier
+        Parameters:
+            signo (int): signal identifier
     """)
 
     document_method("unregister_signal", """
@@ -844,8 +843,8 @@ def __doc_DeviceImpl():
         Unregister this device as device to be informed when signal signo
         is sent to to the device server process
 
-        Parameters :
-            - signo : (int) signal identifier
+        Parameters:
+            signo (int): signal identifier
     """)
 
     document_method("get_status", """
@@ -862,8 +861,8 @@ def __doc_DeviceImpl():
 
         Set device status.
 
-        Parameters :
-            - new_status : (str) the new device status
+        Parameters:
+            new_status (str): the new device status
     """)
 
     document_method("append_status", """
@@ -871,9 +870,9 @@ def __doc_DeviceImpl():
 
         Appends a string to the device status.
 
-        Parameters :
-            status : (str) the string to be appened to the device status
-            new_line : (bool) If true, appends a new line character before the string. Default is False
+        Parameters:
+            status (str): the string to be appened to the device status
+            new_line (bool): If true, appends a new line character before the string. Default is False
     """)
 
     document_method("dev_state", """
@@ -923,11 +922,11 @@ def __doc_DeviceImpl():
         change event are verified and the event is only pushed if they are fullfilled.
         If detect is set to false the event is fired without any value checking!
 
-        Parameters :
-            - attr_name : (str) attribute name
-            - implemented : (bool) True when the server fires change events manually.
-            - detect : (bool) Triggers the verification of the change event properties
-                       when set to true. Default value is true.
+        Parameters:
+            attr_name (str): attribute name
+            implemented (bool): True when the server fires change events manually.
+            detect (bool): Triggers the verification of the change event properties
+                           when set to true. Default value is true.
     """)
 
     document_method("set_archive_event", """
@@ -940,11 +939,11 @@ def __doc_DeviceImpl():
         archive event are verified and the event is only pushed if they are fullfilled.
         If detect is set to false the event is fired without any value checking!
 
-        Parameters :
-            - attr_name : (str) attribute name
-            - implemented : (bool) True when the server fires change events manually.
-            - detect : (bool) Triggers the verification of the change event properties
-                       when set to true. Default value is true.
+        Parameters:
+            attr_name (str): attribute name
+            implemented (bool): True when the server fires change events manually.
+            detect (bool): Triggers the verification of the change event properties
+                           when set to true. Default value is true.
     """)
 
     document_method("push_change_event", """
@@ -960,18 +959,18 @@ def __doc_DeviceImpl():
         The event is pushed to the notification daemon.
 
         Parameters:
-            - attr_name : (str) attribute name
-            - data : the data to be sent as attribute event data. Data must be compatible with the
-                     attribute type and format.
-                     for SPECTRUM and IMAGE attributes, data can be any type of sequence of elements
-                     compatible with the attribute type
-            - str_data : (str) special variation for DevEncoded data type. In this case 'data' must
-                         be a str or an object with the buffer interface.
-            - except: (DevFailed) Instead of data, you may want to send an exception.
-            - dim_x : (int) the attribute x length. Default value is 1
-            - dim_y : (int) the attribute y length. Default value is 0
-            - time_stamp : (double) the time stamp
-            - quality : (AttrQuality) the attribute quality factor
+            attr_name (str): attribute name
+            data: the data to be sent as attribute event data. Data must be compatible with the
+                  attribute type and format.
+                  for SPECTRUM and IMAGE attributes, data can be any type of sequence of elements
+                  compatible with the attribute type
+            str_data (str): special variation for DevEncoded data type. In this case 'data' must
+                            be a str or an object with the buffer interface.
+            except (DevFailed): Instead of data, you may want to send an exception.
+            dim_x (int): the attribute x length. Default value is 1
+            dim_y (int): the attribute y length. Default value is 0
+            time_stamp (double): the time stamp
+            quality (AttrQuality): the attribute quality factor
 
         Raises:
             DevFailed: If the attribute data type is not coherent.
@@ -990,18 +989,18 @@ def __doc_DeviceImpl():
         The event is pushed to the notification daemon.
 
         Parameters:
-            - attr_name : (str) attribute name
-            - data : the data to be sent as attribute event data. Data must be compatible with the
-                     attribute type and format.
-                     for SPECTRUM and IMAGE attributes, data can be any type of sequence of elements
-                     compatible with the attribute type
-            - str_data : (str) special variation for DevEncoded data type. In this case 'data' must
-                         be a str or an object with the buffer interface.
-            - except: (DevFailed) Instead of data, you may want to send an exception.
-            - dim_x : (int) the attribute x length. Default value is 1
-            - dim_y : (int) the attribute y length. Default value is 0
-            - time_stamp : (double) the time stamp
-            - quality : (AttrQuality) the attribute quality factor
+            attr_name (str): attribute name
+            data: the data to be sent as attribute event data. Data must be compatible with the
+                  attribute type and format.
+                  for SPECTRUM and IMAGE attributes, data can be any type of sequence of elements
+                  compatible with the attribute type
+            str_data (str): special variation for DevEncoded data type. In this case 'data' must
+                            be a str or an object with the buffer interface.
+            except (DevFailed): Instead of data, you may want to send an exception.
+            dim_x (int): the attribute x length. Default value is 1
+            dim_y (int): the attribute y length. Default value is 0
+            time_stamp (double): the time stamp
+            quality (AttrQuality): the attribute quality factor
 
         Raises:
             DevFailed: If the attribute data type is not coherent.
@@ -1019,19 +1018,19 @@ def __doc_DeviceImpl():
         The event is pushed to the notification daemon.
 
         Parameters:
-            - attr_name : (str) attribute name
-            - filt_names : (sequence<str>) the filterable fields name
-            - filt_vals : (sequence<double>) the filterable fields value
-            - data : the data to be sent as attribute event data. Data must be compatible with the
-                     attribute type and format.
-                     for SPECTRUM and IMAGE attributes, data can be any type of sequence of elements
-                     compatible with the attribute type
-            - str_data : (str) special variation for DevEncoded data type. In this case 'data' must
-                         be a str or an object with the buffer interface.
-            - dim_x : (int) the attribute x length. Default value is 1
-            - dim_y : (int) the attribute y length. Default value is 0
-            - time_stamp : (double) the time stamp
-            - quality : (AttrQuality) the attribute quality factor
+            attr_name (str): attribute name
+            filt_names (sequence<str>): the filterable fields name
+            filt_vals (sequence<double>): the filterable fields value
+            data: the data to be sent as attribute event data. Data must be compatible with the
+                  attribute type and format.
+                  for SPECTRUM and IMAGE attributes, data can be any type of sequence of elements
+                  compatible with the attribute type
+            str_data (str): special variation for DevEncoded data type. In this case 'data' must
+                            be a str or an object with the buffer interface.
+            dim_x (int): the attribute x length. Default value is 1
+            dim_y (int): the attribute y length. Default value is 0
+            time_stamp (double): the time stamp
+            quality (AttrQuality): the attribute quality factor
 
         Raises:
             DevFailed: If the attribute data type is not coherent.
@@ -1047,9 +1046,9 @@ def __doc_DeviceImpl():
         The method needs only the attribue name and an optional
         "counter" which will be passed unchanged within the event
 
-        Parameters :
-            - attr_name : (str) attribute name
-            - counter : (int) the user counter
+        Parameters:
+            attr_name (str): attribute name
+            counter (int): the user counter
 
         Raises:
             DevFailed: If the attribute name is unknown.
@@ -1062,9 +1061,9 @@ def __doc_DeviceImpl():
 
         Push a pipe event for the given blob.
 
-        Parameters :
-            - pipe_name : (str) pipe name
-            - blob  : (DevicePipeBlob) the blob data
+        Parameters:
+            pipe_name (str): pipe name
+            blob (DevicePipeBlob): the blob data
 
         Raises:
             DevFailed: If the pipe name is unknown.
@@ -1176,8 +1175,8 @@ def __doc_DeviceImpl():
         Stop all polling for a device. if the device is polled, call this
         method before deleting it.
 
-        Parameters :
-            - with_db_upd : (bool)  Is it necessary to update db?
+        Parameters:
+            with_db_upd (bool): Is it necessary to update db?
 
         New in PyTango 7.1.2
     """)
@@ -1188,8 +1187,8 @@ def __doc_DeviceImpl():
         Returns the attribute polling period (ms) or 0 if the attribute
         is not polled.
 
-        Parameters :
-            - attr_name : (str) attribute name
+        Parameters:
+            attr_name (str): attribute name
 
         Return:
             int: attribute polling period (ms) or 0 if it is not polled
@@ -1203,8 +1202,8 @@ def __doc_DeviceImpl():
         Returns the command polling period (ms) or 0 if the command
         is not polled.
 
-        Parameters :
-            - cmd_name : (str) command name
+        Parameters:
+            cmd_name (str): command name
 
         Return:
             int: command polling period (ms) or 0 if it is not polled
@@ -1221,8 +1220,8 @@ def __doc_DeviceImpl():
         The method throws an exception if the
         command is not defined or needs an input value.
 
-        Parameters :
-            - cmd_name: (str) the command name
+        Parameters:
+            cmd_name (str): the command name
 
         Raises:
             DevFailed
@@ -1248,8 +1247,8 @@ def __doc_DeviceImpl():
 
         Returns the command poll ring depth.
 
-        Parameters :
-            - cmd_name: (str) the command name
+        Parameters:
+            cmd_name (str): the command name
 
         Return:
             int: the command poll ring depth
@@ -1262,8 +1261,8 @@ def __doc_DeviceImpl():
 
         Returns the attribute poll ring depth.
 
-        Parameters :
-            - attr_name: (str) the attribute name
+        Parameters:
+            attr_name (str): the attribute name
 
         Return:
             int: the attribute poll ring depth
@@ -1320,9 +1319,10 @@ def __doc_DeviceImpl():
 
         Push an attribute configuration event.
 
-        Parameters : (Attribute) the attribute for which the configuration event
-                     will be sent.
-        New in PyTango 7.2.1
+        Parameters:
+            attr (Attribute): the attribute for which the configuration event
+                              will be sent.
+      New in PyTango 7.2.1
     """)
 
     document_method("push_pipe_event", """
@@ -1330,7 +1330,8 @@ def __doc_DeviceImpl():
 
         Push an pipe event.
 
-        Parameters :  the blob which pipe event will be send.
+        Parameters:
+            blob: the blob which pipe event will be send.
 
         New in PyTango 9.2.2
     """)
@@ -1348,9 +1349,9 @@ def __doc_DeviceImpl():
 
         The device interface change event is not supported by this method.
 
-        Parameters :
-            - att_name: (str) the attribute name
-            - event_type (EventType): the event type
+        Parameters:
+            att_name (str): the attribute name
+            event_type (EventType): the event type
 
         Return:
             bool: True if there is at least one listener or False otherwise
@@ -1389,9 +1390,9 @@ def __doc_extra_DeviceImpl(cls):
         the hardware involved in a a read attribute CORBA call. This method
         must be redefined in sub-classes in order to support attribute reading
 
-        Parameters :
-            attr_list : (sequence<int>) list of indices in the device object attribute vector
-                        of an attribute to be read.
+        Parameters:
+            attr_list (sequence<int>): list of indices in the device object attribute vector
+                                       of an attribute to be read.
 
         Raises:
             DevFailed: This method does not throw exception but a redefined method can.
@@ -1406,9 +1407,9 @@ def __doc_extra_DeviceImpl(cls):
         the hardware involved in a a write attribute. This method must be
         redefined in sub-classes in order to support writable attribute
 
-        Parameters :
-            attr_list : (sequence<int>) list of indices in the device object attribute vector
-                        of an attribute to be written.
+        Parameters:
+            attr_list (sequence<int>): list of indices in the device object attribute vector
+                                       of an attribute to be written.
 
         Raises:
             DevFailed: This method does not throw exception but a redefined method can.
@@ -1423,8 +1424,8 @@ def __doc_extra_DeviceImpl(cls):
         This method is defined as virtual and then, can be redefined following
         device needs.
 
-        Parameters :
-            - signo : (int) the signal number
+        Parameters:
+            signo (int): the signal number
 
         Raises:
             DevFailed: This method does not throw exception but a redefined method can.
@@ -1576,8 +1577,8 @@ def __doc_Attribute():
 
         Set index of the associated writable attribute.
 
-        Parameters :
-            - index : (int) The new index in the main attribute vector of the associated writable attribute
+        Parameters:
+            index (int): The new index in the main attribute vector of the associated writable attribute
     """)
 
     document_method("get_date", """
@@ -1594,8 +1595,8 @@ def __doc_Attribute():
 
         Set attribute date.
 
-        Parameters :
-            - new_date : (TimeVal) the attribute date
+        Parameters:
+            new_date (TimeVal): the attribute date
     """)
 
     document_method("get_label", """
@@ -1621,9 +1622,9 @@ def __doc_Attribute():
 
         Set attribute data quality.
 
-        Parameters :
-            - quality : (AttrQuality) the new attribute data quality
-            - send_event : (bool) true if a change event should be sent. Default is false.
+        Parameters:
+            quality (AttrQuality): the new attribute data quality
+            send_event (bool): true if a change event should be sent. Default is false.
     """)
 
     document_method("get_data_size", """
@@ -1687,10 +1688,10 @@ def __doc_Attribute():
 
         This method allows the user to choose the attribute serialization model.
 
-        Parameters :
-            - ser_model : (AttrSerialModel) The new serialisation model. The
-                          serialization model must be one of ATTR_BY_KERNEL,
-                          ATTR_BY_USER or ATTR_NO_SYNC
+        Parameters:
+            ser_model (AttrSerialModel): The new serialisation model. The
+                        serialization model must be one of ATTR_BY_KERNEL,
+                        ATTR_BY_USER or ATTR_NO_SYNC
 
         New in PyTango 7.1.0
     """)
@@ -1717,20 +1718,20 @@ def __doc_Attribute():
         This method also stores the date when it is called and initializes the
         attribute quality factor.
 
-        Parameters :
-            - data : the data to be set. Data must be compatible with the attribute type and format.
-                     In the DEPRECATED form for SPECTRUM and IMAGE attributes, data
-                     can be any type of FLAT sequence of elements compatible with the
-                     attribute type.
-                     In the new form (without dim_x or dim_y) data should be any
-                     sequence for SPECTRUM and a SEQUENCE of equal-length SEQUENCES
-                     for IMAGE attributes.
-                     The recommended sequence is a C continuous and aligned numpy
-                     array, as it can be optimized.
-            - str_data : (str) special variation for DevEncoded data type. In this case 'data' must
-                         be a str or an object with the buffer interface.
-            - dim_x : (int) [DEPRECATED] the attribute x length. Default value is 1
-            - dim_y : (int) [DEPRECATED] the attribute y length. Default value is 0
+        Parameters:
+            data: the data to be set. Data must be compatible with the attribute type and format.
+                  In the DEPRECATED form for SPECTRUM and IMAGE attributes, data
+                  can be any type of FLAT sequence of elements compatible with the
+                  attribute type.
+                  In the new form (without dim_x or dim_y) data should be any
+                  sequence for SPECTRUM and a SEQUENCE of equal-length SEQUENCES
+                  for IMAGE attributes.
+                  The recommended sequence is a C continuous and aligned numpy
+                  array, as it can be optimized.
+            str_data (str): special variation for DevEncoded data type. In this case 'data' must
+                            be a str or an object with the buffer interface.
+            dim_x (int): [DEPRECATED] the attribute x length. Default value is 1
+            dim_y (int): [DEPRECATED] the attribute y length. Default value is 0
     """)
 
     document_method("set_value_date_quality", """
@@ -1743,22 +1744,22 @@ def __doc_Attribute():
         This method stores the attribute read value, the date and the attribute quality
         factor inside the object.
 
-        Parameters :
-            - data : the data to be set. Data must be compatible with the attribute type and format.
-                     In the DEPRECATED form for SPECTRUM and IMAGE attributes, data
-                     can be any type of FLAT sequence of elements compatible with the
-                     attribute type.
-                     In the new form (without dim_x or dim_y) data should be any
-                     sequence for SPECTRUM and a SEQUENCE of equal-length SEQUENCES
-                     for IMAGE attributes.
-                     The recommended sequence is a C continuous and aligned numpy
-                     array, as it can be optimized.
-            - str_data : (str) special variation for DevEncoded data type. In this case 'data' must
-                         be a str or an object with the buffer interface.
-            - dim_x : (int) [DEPRECATED] the attribute x length. Default value is 1
-            - dim_y : (int) [DEPRECATED] the attribute y length. Default value is 0
-            - time_stamp : (double) the time stamp
-            - quality : (AttrQuality) the attribute quality factor
+        Parameters:
+            data: the data to be set. Data must be compatible with the attribute type and format.
+                  In the DEPRECATED form for SPECTRUM and IMAGE attributes, data
+                  can be any type of FLAT sequence of elements compatible with the
+                  attribute type.
+                  In the new form (without dim_x or dim_y) data should be any
+                  sequence for SPECTRUM and a SEQUENCE of equal-length SEQUENCES
+                  for IMAGE attributes.
+                  The recommended sequence is a C continuous and aligned numpy
+                  array, as it can be optimized.
+            str_data (str): special variation for DevEncoded data type. In this case 'data' must
+                            be a str or an object with the buffer interface.
+            dim_x (int): [DEPRECATED] the attribute x length. Default value is 1
+            dim_y (int): [DEPRECATED] the attribute y length. Default value is 0
+            time_stamp (double): the time stamp
+            quality (AttrQuality): the attribute quality factor
     """)
 
     document_method("set_change_event", """
@@ -1772,10 +1773,10 @@ def __doc_Attribute():
         are fullfilled. If detect is set to false the event is fired without
         any value checking!
 
-        Parameters :
-            - implemented : (bool) True when the server fires change events manually.
-            - detect : (bool) (optional, default is True) Triggers the verification of
-                       the change event properties when set to true.
+        Parameters:
+            implemented (bool): True when the server fires change events manually.
+            detect (bool): (optional, default is True) Triggers the verification of
+                           the change event properties when set to true.
 
         New in PyTango 7.1.0
     """)
@@ -1790,10 +1791,10 @@ def __doc_Attribute():
         is set to true, the criteria specified for the archive event are verified
         and the event is only pushed if they are fullfilled.
 
-        Parameters :
-            - implemented : (bool) True when the server fires archive events manually.
-            - detect : (bool) (optional, default is True) Triggers the verification of
-                       the archive event properties when set to true.
+        Parameters:
+            implemented (bool): True when the server fires archive events manually.
+            detect (bool): (optional, default is True) Triggers the verification of
+                           the archive event properties when set to true.
 
         New in PyTango 7.1.0
     """)
@@ -1849,8 +1850,8 @@ def __doc_Attribute():
 
         Set a flag to indicate that the server fires data ready events.
 
-        Parameters :
-            - implemented : (bool) True when the server fires data ready events manually.
+        Parameters:
+            implemented (bool): True when the server fires data ready events manually.
 
         New in PyTango 7.2.0
     """)
@@ -1916,9 +1917,9 @@ def __doc_WAttribute():
 
         Set attribute minimum value.
 
-        Parameters :
-            - data : the attribute minimum value. python data type must be compatible
-                     with the attribute data format and type.
+        Parameters:
+            data: the attribute minimum value. python data type must be compatible
+                  with the attribute data format and type.
     """)
 
     document_method("set_max_value", """
@@ -1926,9 +1927,9 @@ def __doc_WAttribute():
 
         Set attribute maximum value.
 
-        Parameters :
-            - data : the attribute maximum value. python data type must be compatible
-                     with the attribute data format and type.
+        Parameters:
+            data: the attribute maximum value. python data type must be compatible
+                  with the attribute data format and type.
     """)
 
     document_method("is_min_value", """
@@ -1963,12 +1964,12 @@ def __doc_WAttribute():
     #
     #        Set the writable attribute value.
     #
-    #        Parameters :
-    #            - data : the data to be set. Data must be compatible with the attribute type and format.
-    #                     for SPECTRUM and IMAGE attributes, data can be any type of sequence of elements
-    #                     compatible with the attribute type
-    #            - dim_x : (int) the attribute set value x length. Default value is 1
-    #            - dim_y : (int) the attribute set value y length. Default value is 0
+    #        Parameters:
+    #            data: the data to be set. Data must be compatible with the attribute type and format.
+    #                  for SPECTRUM and IMAGE attributes, data can be any type of sequence of elements
+    #                  compatible with the attribute type
+    #            dim_x (int): the attribute set value x length. Default value is 1
+    #            dim_y (int): the attribute set value y length. Default value is 0
     #    """)
 
     document_method("get_write_value", """
@@ -1977,9 +1978,9 @@ def __doc_WAttribute():
 
         Retrieve the new value for writable attribute.
 
-        Parameters :
-            - extract_as: (ExtractAs)
-            - lst : [out] (list) a list object that will be filled with the attribute write value (DEPRECATED)
+        Parameters:
+            extract_as (ExtractAs): 
+            lst (list): [out] a list object that will be filled with the attribute write value (DEPRECATED)
 
         Return:
             obj: the attribute write value.
@@ -2004,8 +2005,8 @@ def __doc_MultiClassAttribute():
         Get the :class:`~tango.Attr` object for the attribute with
         name passed as parameter.
 
-        Parameters :
-            - attr_name : (str) attribute name
+        Parameters:
+            attr_name (str): attribute name
 
         Return:
             Attr: the attribute object
@@ -2024,9 +2025,9 @@ def __doc_MultiClassAttribute():
 
         Does nothing if the attribute does not exist.
 
-        Parameters :
-            - attr_name : (str) attribute name
-            - cl_name : (str) the attribute class name
+        Parameters:
+            attr_name (str): attribute name
+            cl_name (str): the attribute class name
 
         New in PyTango 7.2.1
     """)
@@ -2062,8 +2063,8 @@ def __doc_MultiAttribute():
         name passed as parameter. The equality on attribute name is case
         independant.
 
-        Parameters :
-            - attr_name : (str) attribute name
+        Parameters:
+            attr_name (str): attribute name
 
         Return:
             Attribute: the attribute object
@@ -2080,8 +2081,8 @@ def __doc_MultiAttribute():
         This method returns an :class:`~tango.Attribute` object from the
         index in the main attribute vector.
 
-        Parameters :
-            - ind : (int) the attribute index
+        Parameters:
+            ind (int): the attribute index
 
         Return:
             Attribute: the attribute object
@@ -2096,8 +2097,8 @@ def __doc_MultiAttribute():
         name passed as parameter. The equality on attribute name is case
         independant.
 
-        Parameters :
-            - attr_name : (str) attribute name
+        Parameters:
+            attr_name (str): attribute name
 
         Return:
             WAttribute: the attribute object
@@ -2114,8 +2115,8 @@ def __doc_MultiAttribute():
         This method returns an :class:`~tango.WAttribute` object from the
         index in the main attribute vector.
 
-        Parameters :
-            - ind : (int) the attribute index
+        Parameters:
+            ind (int): the attribute index
 
         Return:
             WAttribute: the attribute object
@@ -2130,8 +2131,8 @@ def __doc_MultiAttribute():
         :class:`~tango.MultiAttribute` object) of an attribute with a
         given name. The name equality is case independant.
 
-        Parameters :
-            - attr_name : (str) attribute name
+        Parameters:
+            attr_name (str): attribute name
 
         Return:
             int: the attribute index
@@ -2164,9 +2165,9 @@ def __doc_MultiAttribute():
         - The 2nd version of the method checks alarm for one attribute with a given name.
         - The 3rd version of the method checks alarm for one attribute from its index in the main attributes vector.
 
-        Parameters :
-            - attr_name : (str) attribute name
-            - ind : (int) the attribute index
+        Parameters:
+            attr_name (str): attribute name
+            ind (int): the attribute index
 
         Return:
             bool: True if at least one attribute is in alarm condition
@@ -2185,8 +2186,8 @@ def __doc_MultiAttribute():
         This method add alarm mesage to the string passed as parameter.
         A message is added for each attribute which is in alarm condition
 
-        Parameters :
-            - status : (str) a string (should be the device status)
+        Parameters:
+            status (str): a string (should be the device status)
 
         New in PyTango 7.0.0
     """)
@@ -2216,8 +2217,8 @@ def __doc_Attr():
 
         Set default attribute properties.
 
-        Parameters :
-            - attr_prop : (UserDefaultAttrProp) the user default property class
+        Parameters:
+            attr_prop (UserDefaultAttrProp): the user default property class
     """)
 
     document_method("set_disp_level", """
@@ -2225,8 +2226,8 @@ def __doc_Attr():
 
         Set the attribute display level.
 
-        Parameters :
-            - disp_level : (DispLevel) the new display level
+        Parameters:
+            disp_level (DispLevel): the new display level
     """)
 
     document_method("set_polling_period", """
@@ -2234,8 +2235,8 @@ def __doc_Attr():
 
         Set the attribute polling update period.
 
-        Parameters :
-            - period : (int) the attribute polling period (in mS)
+        Parameters:
+            period (int): the attribute polling period (in mS)
     """)
 
     document_method("set_memorized", """
@@ -2258,9 +2259,9 @@ def __doc_Attr():
 
         No action is taken on the attribute
 
-        Parameters :
-            - write_on_init : (bool) if true the setpoint value will be written
-                              to the attribute on initialisation    """)
+        Parameters:
+            write_on_init (bool): if true the setpoint value will be written
+                            to the attribute on initialisation    """)
 
     document_method("set_change_event", """
     set_change_event(self, implemented, detect)
@@ -2274,10 +2275,10 @@ def __doc_Attr():
 
         If detect is set to false the event is fired without checking!
 
-        Parameters :
-            - implemented : (bool) True when the server fires change events manually.
-            - detect : (bool) Triggers the verification of the change event properties
-                       when set to true.
+        Parameters:
+            implemented (bool): True when the server fires change events manually.
+            detect (bool): Triggers the verification of the change event properties
+                           when set to true.
     """)
 
     document_method("is_change_event", """
@@ -2310,10 +2311,10 @@ def __doc_Attr():
 
         If detect is set to false the event is fired without checking!
 
-        Parameters :
-            - implemented : (bool) True when the server fires change events manually.
-            - detect : (bool) Triggers the verification of the archive event properties
-                       when set to true.
+        Parameters:
+            implemented (bool): True when the server fires change events manually.
+            detect (bool): Triggers the verification of the archive event properties
+                           when set to true.
     """)
 
     document_method("is_archive_event", """
@@ -2339,8 +2340,8 @@ def __doc_Attr():
 
         Set a flag to indicate that the server fires data ready events.
 
-        Parameters :
-            - implemented : (bool) True when the server fires data ready events
+        Parameters:
+            implemented (bool): True when the server fires data ready events
 
         New in PyTango 7.2.0
     """)
@@ -2463,8 +2464,8 @@ def __doc_Attr():
 
         Sets the class name.
 
-        Parameters :
-            - cl : (str) new class name
+        Parameters:
+            cl (str): new class name
 
         New in PyTango 7.2.0
     """)
@@ -2492,8 +2493,8 @@ def __doc_Attr():
 
         Set the class level attribute properties.
 
-        Parameters :
-            - props : (StdAttrPropertyVector) new class level attribute properties
+        Parameters:
+            props (StdAttrPropertyVector): new class level attribute properties
     """)
 
 
@@ -2516,8 +2517,8 @@ def __doc_UserDefaultAttrProp():
 
         Set default label property.
 
-        Parameters :
-            - def_label : (str) the user default label property
+        Parameters:
+            def_label (str): the user default label property
     """)
 
     document_method("set_description", """
@@ -2525,8 +2526,8 @@ def __doc_UserDefaultAttrProp():
 
         Set default description property.
 
-        Parameters :
-            - def_description : (str) the user default description property
+        Parameters:
+            def_description (str): the user default description property
     """)
 
     document_method("set_format", """
@@ -2534,8 +2535,8 @@ def __doc_UserDefaultAttrProp():
 
         Set default format property.
 
-        Parameters :
-            - def_format : (str) the user default format property
+        Parameters:
+            def_format (str): the user default format property
     """)
 
     document_method("set_unit", """
@@ -2543,8 +2544,8 @@ def __doc_UserDefaultAttrProp():
 
         Set default unit property.
 
-        Parameters :
-            - def_unit : (str) te user default unit property
+        Parameters:
+            def_unit (str): te user default unit property
     """)
 
     document_method("set_standard_unit", """
@@ -2552,8 +2553,8 @@ def __doc_UserDefaultAttrProp():
 
         Set default standard unit property.
 
-        Parameters :
-            - def_standard_unit : (str) the user default standard unit property
+        Parameters:
+            def_standard_unit (str): the user default standard unit property
     """)
 
     document_method("set_display_unit", """
@@ -2561,8 +2562,8 @@ def __doc_UserDefaultAttrProp():
 
         Set default display unit property.
 
-        Parameters :
-            - def_display_unit : (str) the user default display unit property
+        Parameters:
+            def_display_unit (str): the user default display unit property
     """)
 
     document_method("set_min_value", """
@@ -2570,8 +2571,8 @@ def __doc_UserDefaultAttrProp():
 
         Set default min_value property.
 
-        Parameters :
-            - def_min_value : (str) the user default min_value property
+        Parameters:
+            def_min_value (str): the user default min_value property
     """)
 
     document_method("set_max_value", """
@@ -2579,8 +2580,8 @@ def __doc_UserDefaultAttrProp():
 
         Set default max_value property.
 
-        Parameters :
-            - def_max_value : (str) the user default max_value property
+        Parameters:
+            def_max_value (str): the user default max_value property
     """)
 
     document_method("set_min_alarm", """
@@ -2588,8 +2589,8 @@ def __doc_UserDefaultAttrProp():
 
         Set default min_alarm property.
 
-        Parameters :
-            - def_min_alarm : (str) the user default min_alarm property
+        Parameters:
+            def_min_alarm (str): the user default min_alarm property
     """)
 
     document_method("set_max_alarm", """
@@ -2597,8 +2598,8 @@ def __doc_UserDefaultAttrProp():
 
         Set default max_alarm property.
 
-        Parameters :
-            - def_max_alarm : (str) the user default max_alarm property
+        Parameters:
+            def_max_alarm (str): the user default max_alarm property
     """)
 
     document_method("set_min_warning", """
@@ -2606,8 +2607,8 @@ def __doc_UserDefaultAttrProp():
 
         Set default min_warning property.
 
-        Parameters :
-            - def_min_warning : (str) the user default min_warning property
+        Parameters:
+            def_min_warning (str): the user default min_warning property
     """)
 
     document_method("set_max_warning", """
@@ -2615,8 +2616,8 @@ def __doc_UserDefaultAttrProp():
 
         Set default max_warning property.
 
-        Parameters :
-            - def_max_warning : (str) the user default max_warning property
+        Parameters:
+            def_max_warning (str): the user default max_warning property
     """)
 
     document_method("set_delta_t", """
@@ -2624,8 +2625,8 @@ def __doc_UserDefaultAttrProp():
 
         Set default RDS alarm delta_t property.
 
-        Parameters :
-            - def_delta_t : (str) the user default RDS alarm delta_t property
+        Parameters:
+            def_delta_t (str): the user default RDS alarm delta_t property
     """)
 
     document_method("set_delta_val", """
@@ -2633,8 +2634,8 @@ def __doc_UserDefaultAttrProp():
 
         Set default RDS alarm delta_val property.
 
-        Parameters :
-            - def_delta_val : (str) the user default RDS alarm delta_val property
+        Parameters:
+            def_delta_val (str): the user default RDS alarm delta_val property
     """)
 
     document_method("set_abs_change", """
@@ -2642,8 +2643,8 @@ def __doc_UserDefaultAttrProp():
 
         Set default change event abs_change property.
 
-        Parameters :
-            - def_abs_change : (str) the user default change event abs_change property
+        Parameters:
+            def_abs_change (str): the user default change event abs_change property
 
         Deprecated since PyTango 8.0. Please use set_event_abs_change instead.
     """)
@@ -2653,8 +2654,8 @@ def __doc_UserDefaultAttrProp():
 
         Set default change event abs_change property.
 
-        Parameters :
-            - def_abs_change : (str) the user default change event abs_change property
+        Parameters:
+            def_abs_change (str): the user default change event abs_change property
 
         New in PyTango 8.0
     """)
@@ -2664,8 +2665,8 @@ def __doc_UserDefaultAttrProp():
 
         Set default change event rel_change property.
 
-        Parameters :
-            - def_rel_change : (str) the user default change event rel_change property
+        Parameters:
+            def_rel_change (str): the user default change event rel_change property
 
         Deprecated since PyTango 8.0. Please use set_event_rel_change instead.
     """)
@@ -2675,8 +2676,8 @@ def __doc_UserDefaultAttrProp():
 
         Set default change event rel_change property.
 
-        Parameters :
-            - def_rel_change : (str) the user default change event rel_change property
+        Parameters:
+            def_rel_change (str): the user default change event rel_change property
 
         New in PyTango 8.0
     """)
@@ -2686,8 +2687,8 @@ def __doc_UserDefaultAttrProp():
 
         Set default periodic event period property.
 
-        Parameters :
-            - def_period : (str) the user default periodic event period property
+        Parameters:
+            def_period (str): the user default periodic event period property
 
         Deprecated since PyTango 8.0. Please use set_event_period instead.
     """)
@@ -2697,8 +2698,8 @@ def __doc_UserDefaultAttrProp():
 
         Set default periodic event period property.
 
-        Parameters :
-            - def_period : (str) the user default periodic event period property
+        Parameters:
+            def_period (str): the user default periodic event period property
 
         New in PyTango 8.0
     """)
@@ -2708,8 +2709,8 @@ def __doc_UserDefaultAttrProp():
 
         Set default archive event abs_change property.
 
-        Parameters :
-            - def_archive_abs_change : (str) the user default archive event abs_change property
+        Parameters:
+            def_archive_abs_change (str): the user default archive event abs_change property
 
         Deprecated since PyTango 8.0. Please use set_archive_event_abs_change instead.
     """)
@@ -2719,8 +2720,8 @@ def __doc_UserDefaultAttrProp():
 
         Set default archive event abs_change property.
 
-        Parameters :
-            - def_archive_abs_change : (str) the user default archive event abs_change property
+        Parameters:
+            def_archive_abs_change (str): the user default archive event abs_change property
 
         New in PyTango 8.0
     """)
@@ -2730,8 +2731,8 @@ def __doc_UserDefaultAttrProp():
 
         Set default archive event rel_change property.
 
-        Parameters :
-            - def_archive_rel_change : (str) the user default archive event rel_change property
+        Parameters:
+            def_archive_rel_change (str): the user default archive event rel_change property
 
         Deprecated since PyTango 8.0. Please use set_archive_event_rel_change instead.
     """)
@@ -2741,8 +2742,8 @@ def __doc_UserDefaultAttrProp():
 
         Set default archive event rel_change property.
 
-        Parameters :
-            - def_archive_rel_change : (str) the user default archive event rel_change property
+        Parameters:
+            def_archive_rel_change (str): the user default archive event rel_change property
 
         New in PyTango 8.0
     """)
@@ -2752,8 +2753,8 @@ def __doc_UserDefaultAttrProp():
 
         Set default archive event period property.
 
-        Parameters :
-            - def_archive_period : (str) t
+        Parameters:
+            def_archive_period (str): t
 
         Deprecated since PyTango 8.0. Please use set_archive_event_period instead.
     """)
@@ -2763,8 +2764,8 @@ def __doc_UserDefaultAttrProp():
 
         Set default archive event period property.
 
-        Parameters :
-            - def_archive_period : (str) t
+        Parameters:
+            def_archive_period (str): t
 
         New in PyTango 8.0
     """)

--- a/tango/device_server.py
+++ b/tango/device_server.py
@@ -958,11 +958,13 @@ def __doc_DeviceImpl():
 
     document_method("push_change_event", """
     push_change_event(self, attr_name)
-    push_change_event(self, attr_name, except)
-    push_change_event(self, attr_name, data, dim_x = 1, dim_y = 0)
-    push_change_event(self, attr_name, str_data, data)
-    push_change_event(self, attr_name, data, time_stamp, quality, dim_x = 1, dim_y = 0)
-    push_change_event(self, attr_name, str_data, data, time_stamp, quality)
+
+        .. function:: push_change_event(self, attr_name, except)
+                      push_change_event(self, attr_name, data, dim_x = 1, dim_y = 0)
+                      push_change_event(self, attr_name, str_data, data)
+                      push_change_event(self, attr_name, data, time_stamp, quality, dim_x = 1, dim_y = 0)
+                      push_change_event(self, attr_name, str_data, data, time_stamp, quality)
+            :noindex:
 
         Push a change event for the given attribute name.
 
@@ -993,11 +995,13 @@ def __doc_DeviceImpl():
 
     document_method("push_archive_event", """
     push_archive_event(self, attr_name)
-    push_archive_event(self, attr_name, except)
-    push_archive_event(self, attr_name, data, dim_x = 1, dim_y = 0)
-    push_archive_event(self, attr_name, str_data, data)
-    push_archive_event(self, attr_name, data, time_stamp, quality, dim_x = 1, dim_y = 0)
-    push_archive_event(self, attr_name, str_data, data, time_stamp, quality)
+
+        .. function:: push_archive_event(self, attr_name, except)
+                      push_archive_event(self, attr_name, data, dim_x = 1, dim_y = 0)
+                      push_archive_event(self, attr_name, str_data, data)
+                      push_archive_event(self, attr_name, data, time_stamp, quality, dim_x = 1, dim_y = 0)
+                      push_archive_event(self, attr_name, str_data, data, time_stamp, quality)
+            :noindex:
 
         Push an archive event for the given attribute name.
 
@@ -1028,10 +1032,12 @@ def __doc_DeviceImpl():
 
     document_method("push_event", """
     push_event(self, attr_name, filt_names, filt_vals)
-    push_event(self, attr_name, filt_names, filt_vals, data, dim_x = 1, dim_y = 0)
-    push_event(self, attr_name, filt_names, filt_vals, str_data, data)
-    push_event(self, attr_name, filt_names, filt_vals, data, time_stamp, quality, dim_x = 1, dim_y = 0)
-    push_event(self, attr_name, filt_names, filt_vals, str_data, data, time_stamp, quality)
+
+        .. function:: push_event(self, attr_name, filt_names, filt_vals, data, dim_x = 1, dim_y = 0)
+                      push_event(self, attr_name, filt_names, filt_vals, str_data, data)
+                      push_event(self, attr_name, filt_names, filt_vals, data, time_stamp, quality, dim_x = 1, dim_y = 0)
+                      push_event(self, attr_name, filt_names, filt_vals, str_data, data, time_stamp, quality)
+            :noindex:
 
         Push a user event for the given attribute name.
 
@@ -1082,8 +1088,10 @@ def __doc_DeviceImpl():
 
     document_method("push_pipe_event", """
     push_pipe_event(self, pipe_name, except)
-    push_pipe_event(self, pipe_name, blob, reuse_it)
-    push_pipe_event(self, pipe_name, blob, timeval, reuse_it)
+
+        .. function:: push_pipe_event(self, pipe_name, blob, reuse_it)
+                      push_pipe_event(self, pipe_name, blob, timeval, reuse_it)
+            :noindex:
 
         Push a pipe event for the given blob.
 
@@ -1196,7 +1204,9 @@ def __doc_DeviceImpl():
 
     document_method("stop_polling", """
     stop_polling(self)
-    stop_polling(self, with_db_upd)
+
+        .. function:: stop_polling(self, with_db_upd)
+            :noindex:
 
         Stop all polling for a device. if the device is polled, call this
         method before deleting it.
@@ -1731,8 +1741,10 @@ def __doc_Attribute():
 
     document_method("set_value", """
     set_value(self, data, dim_x = 1, dim_y = 0) <= DEPRECATED
-    set_value(self, data)
-    set_value(self, str_data, data)
+
+        .. function:: set_value(self, data)
+                      set_value(self, str_data, data)
+            :noindex:
 
         Set internal attribute value.
 
@@ -1760,8 +1772,10 @@ def __doc_Attribute():
 
     document_method("set_value_date_quality", """
     set_value_date_quality(self, data, time_stamp, quality, dim_x = 1, dim_y = 0) <= DEPRECATED
-    set_value_date_quality(self, data, time_stamp, quality)
-    set_value_date_quality(self, str_data, data, time_stamp, quality)
+
+        .. function:: set_value_date_quality(self, data, time_stamp, quality)
+                      set_value_date_quality(self, str_data, data, time_stamp, quality)
+            :noindex:
 
         Set internal attribute value, date and quality factor.
 
@@ -2003,7 +2017,9 @@ def __doc_WAttribute():
 
     document_method("get_write_value", """
     get_write_value(self, lst)  <= DEPRECATED
-    get_write_value(self, extract_as=ExtractAs.Numpy) -> obj
+
+        .. function:: get_write_value(self, extract_as=ExtractAs.Numpy) -> obj
+            :noindex:
 
         Retrieve the new value for writable attribute.
 
@@ -2183,8 +2199,10 @@ def __doc_MultiAttribute():
 
     document_method("check_alarm", """
     check_alarm(self) -> bool
-    check_alarm(self, attr_name) -> bool
-    check_alarm(self, ind) -> bool
+
+        .. function:: check_alarm(self, attr_name) -> bool
+                      check_alarm(self, ind) -> bool
+            :noindex:
 
         Checks an alarm.
 

--- a/tango/device_server.py
+++ b/tango/device_server.py
@@ -801,8 +801,6 @@ def __doc_DeviceImpl():
 
         Intialize the device.
 
-        Parameters : None
-
         Return     : None
     """)
 
@@ -822,8 +820,6 @@ def __doc_DeviceImpl():
 
         Get a COPY of the device state.
 
-        Parameters : None
-
         Return     : (DevState) Current device state
     """)
 
@@ -831,8 +827,6 @@ def __doc_DeviceImpl():
     get_prev_state(self) -> DevState
 
         Get a COPY of the device's previous state.
-
-        Parameters : None
 
         Return     : (DevState) the device's previous state
 
@@ -843,8 +837,6 @@ def __doc_DeviceImpl():
 
         Get a COPY of the device name.
 
-        Parameters : None
-
         Return     : (str) the device name
 
     """)
@@ -853,8 +845,6 @@ def __doc_DeviceImpl():
     get_device_attr(self) -> MultiAttribute
 
         Get device multi attribute object.
-
-        Parameters : None
 
         Return     : (MultiAttribute) the device's MultiAttribute object
 
@@ -892,8 +882,6 @@ def __doc_DeviceImpl():
     get_status(self, ) -> str
 
         Get a COPY of the device status.
-
-        Parameters : None
 
         Return     : (str) the device status
     """)
@@ -934,8 +922,6 @@ def __doc_DeviceImpl():
         returns the state This method can be redefined in sub-classes in case
         of the default behaviour does not fullfill the needs.
 
-        Parameters : None
-
         Return     : (DevState) the device state
 
         Throws     : DevFailed - If it is necessary to read attribute(s) and a problem occurs during the reading
@@ -950,8 +936,6 @@ def __doc_DeviceImpl():
         dev_status field. If the device state is ALARM, alarm messages are added
         to the device status. This method can be redefined in sub-classes in case
         of the default behaviour does not fullfill the needs.
-
-        Parameters : None
 
         Return     : (str) the device status
 
@@ -1125,8 +1109,6 @@ def __doc_DeviceImpl():
 
         Returns the Logger object for this device
 
-        Parameters : None
-
         Return     : (Logger) the Logger object for this device
     """)
 
@@ -1134,8 +1116,6 @@ def __doc_DeviceImpl():
     get_exported_flag(self) -> bool
 
         Returns the state of the exported flag
-
-        Parameters : None
 
         Return     : (bool) the state of the exported flag
 
@@ -1147,8 +1127,6 @@ def __doc_DeviceImpl():
 
         Returns the poll ring depth
 
-        Parameters : None
-
         Return     : (int) the poll ring depth
 
         New in PyTango 7.1.2
@@ -1158,8 +1136,6 @@ def __doc_DeviceImpl():
     get_poll_old_factor(self) -> int
 
         Returns the poll old factor
-
-        Parameters : None
 
         Return     : (int) the poll old factor
 
@@ -1171,8 +1147,6 @@ def __doc_DeviceImpl():
 
         Returns if it is polled
 
-        Parameters : None
-
         Return     : (bool) True if it is polled or False otherwise
 
         New in PyTango 7.1.2
@@ -1182,8 +1156,6 @@ def __doc_DeviceImpl():
     get_polled_cmd(self) -> sequence<str>
 
         Returns a COPY of the list of polled commands
-
-        Parameters : None
 
         Return     : (sequence<str>) a COPY of the list of polled commands
 
@@ -1195,8 +1167,6 @@ def __doc_DeviceImpl():
 
         Returns a COPY of the list of polled attributes
 
-        Parameters : None
-
         Return     : (sequence<str>) a COPY of the list of polled attributes
 
         New in PyTango 7.1.2
@@ -1207,8 +1177,6 @@ def __doc_DeviceImpl():
 
         Returns a COPY of the list of non automatic polled commands
 
-        Parameters : None
-
         Return     : (sequence<str>) a COPY of the list of non automatic polled commands
 
         New in PyTango 7.1.2
@@ -1218,8 +1186,6 @@ def __doc_DeviceImpl():
     get_non_auto_polled_attr(self) -> sequence<str>
 
         Returns a COPY of the list of non automatic polled attributes
-
-        Parameters : None
 
         Return     : (sequence<str>) a COPY of the list of non automatic polled attributes
 
@@ -1293,8 +1259,6 @@ def __doc_DeviceImpl():
 
         Returns the IDL version.
 
-        Parameters : None
-
         Return     : (int) the IDL version
 
         New in PyTango 7.1.2
@@ -1331,8 +1295,6 @@ def __doc_DeviceImpl():
 
         Returns if this device is locked by a client.
 
-        Parameters : None
-
         Return     : (bool) True if it is locked or False otherwise
 
         New in PyTango 7.1.2
@@ -1342,8 +1304,6 @@ def __doc_DeviceImpl():
     get_min_poll_period(self) -> int
 
         Returns the min poll period.
-
-        Parameters : None
 
         Return     : (int) the min poll period
 
@@ -1355,8 +1315,6 @@ def __doc_DeviceImpl():
 
         Returns the min command poll period.
 
-        Parameters : None
-
         Return     : (seq<str>) the min command poll period
 
         New in PyTango 7.2.0
@@ -1366,8 +1324,6 @@ def __doc_DeviceImpl():
     get_attr_min_poll_period(self) -> seq<str>
 
         Returns the min attribute poll period
-
-        Parameters : None
 
         Return     : (seq<str>) the min attribute poll period
 
@@ -1428,8 +1384,6 @@ def __doc_extra_DeviceImpl(cls):
 
         Delete the device.
 
-        Parameters : None
-
         Return     : None
     """)
 
@@ -1441,8 +1395,6 @@ def __doc_extra_DeviceImpl(cls):
         Default method to implement an action necessary on a device before
         any command is executed. This method can be redefined in sub-classes
         in case of the default behaviour does not fullfill the needs
-
-        Parameters : None
 
         Return     : None
 
@@ -1519,8 +1471,6 @@ def __doc_Attribute():
 
         Check if the attribute has an associated writable attribute.
 
-        Parameters : None
-
         Return     : (bool) True if there is an associated writable attribute
     """)
 
@@ -1528,8 +1478,6 @@ def __doc_Attribute():
     is_min_alarm(self) -> bool
 
         Check if the attribute is in minimum alarm condition.
-
-        Parameters : None
 
         Return     : (bool) true if the attribute is in alarm condition (read value below the min. alarm).
     """)
@@ -1539,8 +1487,6 @@ def __doc_Attribute():
 
         Check if the attribute is in maximum alarm condition.
 
-        Parameters : None
-
         Return     : (bool) true if the attribute is in alarm condition (read value above the max. alarm).
     """)
 
@@ -1548,8 +1494,6 @@ def __doc_Attribute():
     is_min_warning(self) -> bool
 
         Check if the attribute is in minimum warning condition.
-
-        Parameters : None
 
         Return     : (bool) true if the attribute is in warning condition (read value below the min. warning).
     """)
@@ -1559,8 +1503,6 @@ def __doc_Attribute():
 
         Check if the attribute is in maximum warning condition.
 
-        Parameters : None
-
         Return     : (bool) true if the attribute is in warning condition (read value above the max. warning).
     """)
 
@@ -1568,8 +1510,6 @@ def __doc_Attribute():
     is_rds_alarm(self) -> bool
 
         Check if the attribute is in RDS alarm condition.
-
-        Parameters : None
 
         Return     : (bool) true if the attribute is in RDS condition (Read Different than Set).
     """)
@@ -1579,8 +1519,6 @@ def __doc_Attribute():
 
         Check if the attribute is polled.
 
-        Parameters : None
-
         Return     : (bool) true if the attribute is polled.
     """)
 
@@ -1588,8 +1526,6 @@ def __doc_Attribute():
     check_alarm(self) -> bool
 
         Check if the attribute read value is below/above the alarm level.
-
-        Parameters : None
 
         Return     : (bool) true if the attribute is in alarm condition.
 
@@ -1601,8 +1537,6 @@ def __doc_Attribute():
 
         Get the attribute writable type (RO/WO/RW).
 
-        Parameters : None
-
         Return     : (AttrWriteType) The attribute write type.
     """)
 
@@ -1610,8 +1544,6 @@ def __doc_Attribute():
     get_name(self) -> str
 
         Get attribute name.
-
-        Parameters : None
 
         Return     : (str) The attribute name
     """)
@@ -1621,8 +1553,6 @@ def __doc_Attribute():
 
         Get attribute data type.
 
-        Parameters : None
-
         Return     : (int) the attribute data type
     """)
 
@@ -1630,8 +1560,6 @@ def __doc_Attribute():
     get_data_format(self) -> AttrDataFormat
 
         Get attribute data format.
-
-        Parameters : None
 
         Return     : (AttrDataFormat) the attribute data format
     """)
@@ -1641,8 +1569,6 @@ def __doc_Attribute():
 
         Get name of the associated writable attribute.
 
-        Parameters : None
-
         Return     : (str) the associated writable attribute name
     """)
 
@@ -1650,8 +1576,6 @@ def __doc_Attribute():
     get_assoc_ind(self) -> int
 
         Get index of the associated writable attribute.
-
-        Parameters : None
 
         Return     : (int) the index in the main attribute vector of the associated writable attribute
     """)
@@ -1672,8 +1596,6 @@ def __doc_Attribute():
 
         Get a COPY of the attribute date.
 
-        Parameters : None
-
         Return     : (TimeVal) the attribute date
     """)
 
@@ -1693,8 +1615,6 @@ def __doc_Attribute():
 
         Get attribute label property.
 
-        Parameters : None
-
         Return     : (str) he attribute label
     """)
 
@@ -1702,8 +1622,6 @@ def __doc_Attribute():
     get_quality(self) -> AttrQuality
 
         Get a COPY of the attribute data quality.
-
-        Parameters : None
 
         Return     : (AttrQuality) the attribute data quality
     """)
@@ -1725,8 +1643,6 @@ def __doc_Attribute():
 
         Get attribute data size.
 
-        Parameters : None
-
         Return     : (int) the attribute data size
     """)
 
@@ -1734,8 +1650,6 @@ def __doc_Attribute():
     get_x(self) -> int
 
         Get attribute data size in x dimension.
-
-        Parameters : None
 
         Return     : (int) the attribute data size in x dimension. Set to 1 for scalar attribute
     """)
@@ -1745,8 +1659,6 @@ def __doc_Attribute():
 
         Get attribute maximum data size in x dimension.
 
-        Parameters : None
-
         Return     : (int) the attribute maximum data size in x dimension. Set to 1 for scalar attribute
     """)
 
@@ -1754,8 +1666,6 @@ def __doc_Attribute():
     get_y(self) -> int
 
         Get attribute data size in y dimension.
-
-        Parameters : None
 
         Return     : (int) the attribute data size in y dimension. Set to 1 for scalar attribute
     """)
@@ -1765,8 +1675,6 @@ def __doc_Attribute():
 
         Get attribute maximum data size in y dimension.
 
-        Parameters : None
-
         Return     : (int) the attribute maximum data size in y dimension. Set to 0 for scalar attribute
     """)
 
@@ -1774,8 +1682,6 @@ def __doc_Attribute():
     get_polling_period(self) -> int
 
         Get attribute polling period.
-
-        Parameters : None
 
         Return     : (int) The attribute polling period in mS. Set to 0 when the attribute is not polled
     """)
@@ -1801,8 +1707,6 @@ def __doc_Attribute():
     get_attr_serial_model(self) -> AttrSerialModel
 
         Get attribute serialization model.
-
-        Parameters : None
 
         Return     : (AttrSerialModel) The attribute serialization model
 
@@ -1914,8 +1818,6 @@ def __doc_Attribute():
 
         Check if the change event is fired manually (without polling) for this attribute.
 
-        Parameters : None
-
         Return     : (bool) True if a manual fire change event is implemented.
 
         New in PyTango 7.1.0
@@ -1927,8 +1829,6 @@ def __doc_Attribute():
         Check if the change event criteria should be checked when firing the
         event manually.
 
-        Parameters : None
-
         Return     : (bool) True if a change event criteria will be checked.
 
         New in PyTango 7.1.0
@@ -1938,8 +1838,6 @@ def __doc_Attribute():
     is_archive_event(self) -> bool
 
         Check if the archive event is fired manually (without polling) for this attribute.
-
-        Parameters : None
         Return     : (bool) True if a manual fire archive event is implemented.
 
         New in PyTango 7.1.0
@@ -1950,8 +1848,6 @@ def __doc_Attribute():
 
         Check if the archive event criteria should be checked when firing the
         event manually.
-
-        Parameters : None
 
         Return     : (bool) True if a archive event criteria will be checked.
 
@@ -1977,8 +1873,6 @@ def __doc_Attribute():
         Check if the data ready event is fired manually (without polling)
         for this attribute.
 
-        Parameters : None
-
         Return     : (bool) True if a manual fire data ready event is implemented.
 
         New in PyTango 7.2.0
@@ -1995,8 +1889,6 @@ def __doc_Attribute():
 
         The method removes all configured attribute properties and removes
         the attribute from the list of polled attributes.
-
-        Parameters : None
 
         Return     : None
 
@@ -2018,8 +1910,6 @@ def __doc_WAttribute():
         Get attribute minimum value or throws an exception if the
         attribute does not have a minimum value.
 
-        Parameters : None
-
         Return     : (obj) an object with the python minimum value
     """)
 
@@ -2028,8 +1918,6 @@ def __doc_WAttribute():
 
         Get attribute maximum value or throws an exception if the
         attribute does not have a maximum value.
-
-        Parameters : None
 
         Return     : (obj) an object with the python maximum value
     """)
@@ -2063,8 +1951,6 @@ def __doc_WAttribute():
 
         Check if the attribute has a minimum value.
 
-        Parameters : None
-
         Return     : (bool) true if the attribute has a minimum value defined
     """)
 
@@ -2073,8 +1959,6 @@ def __doc_WAttribute():
 
         Check if the attribute has a maximum value.
 
-        Parameters : None
-
         Return     : (bool) true if the attribute has a maximum value defined
     """)
 
@@ -2082,8 +1966,6 @@ def __doc_WAttribute():
     get_write_value_length(self) -> int
 
         Retrieve the new value length (data number) for writable attribute.
-
-        Parameters : None
 
         Return     : (int) the new value data length
     """)
@@ -2267,8 +2149,6 @@ def __doc_MultiAttribute():
 
         Get attribute number.
 
-        Parameters : None
-
         Return     : (int) the number of attributes
 
         New in PyTango 7.0.0
@@ -2373,8 +2253,6 @@ def __doc_Attr():
         With no argument the setpoint will be
         written to the attribute during initialisation!
 
-        Parameters : None
-
         Return     : None
     """)
 
@@ -2419,8 +2297,6 @@ def __doc_Attr():
 
         Check if the change event is fired manually for this attribute.
 
-        Parameters : None
-
         Return     : (bool) true if a manual fire change event is implemented.
     """)
 
@@ -2428,8 +2304,6 @@ def __doc_Attr():
     is_check_change_criteria(self) -> bool
 
         Check if the change event criteria should be checked when firing the event manually.
-
-        Parameters : None
 
         Return     : (bool) true if a change event criteria will be checked.
     """)
@@ -2459,8 +2333,6 @@ def __doc_Attr():
 
         Check if the archive event is fired manually for this attribute.
 
-        Parameters : None
-
         Return     : (bool) true if a manual fire archive event is implemented.
     """)
 
@@ -2468,8 +2340,6 @@ def __doc_Attr():
     is_check_archive_criteria(self) -> bool
 
         Check if the archive event criteria should be checked when firing the event manually.
-
-        Parameters : None
 
         Return     : (bool) true if a archive event criteria will be checked.
     """)
@@ -2492,8 +2362,6 @@ def __doc_Attr():
 
         Check if the data ready event is fired for this attribute.
 
-        Parameters : None
-
         Return     : (bool) true if firing data ready event is implemented.
 
         New in PyTango 7.2.0
@@ -2504,8 +2372,6 @@ def __doc_Attr():
 
         Get the attribute name.
 
-        Parameters : None
-
         Return     : (str) the attribute name
     """)
 
@@ -2513,8 +2379,6 @@ def __doc_Attr():
     get_format(self) -> AttrDataFormat
 
         Get the attribute format.
-
-        Parameters : None
 
         Return     : (AttrDataFormat) the attribute format
     """)
@@ -2524,8 +2388,6 @@ def __doc_Attr():
 
         Get the attribute write type.
 
-        Parameters : None
-
         Return     : (AttrWriteType) the attribute write type
     """)
 
@@ -2533,8 +2395,6 @@ def __doc_Attr():
     get_type(self) -> int
 
         Get the attribute data type.
-
-        Parameters : None
 
         Return     : (int) the attribute data type
     """)
@@ -2544,8 +2404,6 @@ def __doc_Attr():
 
         Get the attribute display level.
 
-        Parameters : None
-
         Return     : (DispLevel) the attribute display level
     """)
 
@@ -2554,8 +2412,6 @@ def __doc_Attr():
 
         Get the polling period (mS).
 
-        Parameters : None
-
         Return     : (int) the polling period (mS)
     """)
 
@@ -2563,8 +2419,6 @@ def __doc_Attr():
     get_memorized(self) -> bool
 
         Determine if the attribute is memorized or not.
-
-        Parameters : None
 
         Return     : (bool) True if the attribute is memorized
     """)
@@ -2575,8 +2429,6 @@ def __doc_Attr():
         Determine if the attribute is written at startup from the memorized
         value if it is memorized.
 
-        Parameters : None
-
         Return     : (bool) True if initialized with memorized value or not
     """)
 
@@ -2584,8 +2436,6 @@ def __doc_Attr():
     get_assoc(self) -> str
 
         Get the associated name.
-
-        Parameters : None
 
         Return     : (bool) the associated name
     """)
@@ -2595,8 +2445,6 @@ def __doc_Attr():
 
         Determine if it is assoc.
 
-        Parameters : None
-
         Return     : (bool) if it is assoc
     """)
 
@@ -2604,8 +2452,6 @@ def __doc_Attr():
     get_cl_name(self) -> str
 
         Returns the class name.
-
-        Parameters : None
 
         Return     : (str) the class name
 
@@ -2630,8 +2476,6 @@ def __doc_Attr():
 
         Get the class level attribute properties.
 
-        Parameters : None
-
         Return     : (sequence<AttrProperty>) the class attribute properties
     """)
 
@@ -2639,8 +2483,6 @@ def __doc_Attr():
     get_user_default_properties(self) -> sequence<AttrProperty>
 
         Get the user default attribute properties.
-
-        Parameters : None
 
         Return     : (sequence<AttrProperty>) the user default attribute properties
     """)

--- a/tango/device_server.py
+++ b/tango/device_server.py
@@ -1412,7 +1412,7 @@ def __doc_extra_DeviceImpl(cls):
         Read the hardware to return attribute value(s).
 
         Default method to implement an action necessary on a device to read
-        the hardware involved in a a read attribute CORBA call. This method
+        the hardware involved in a read attribute CORBA call. This method
         must be redefined in sub-classes in order to support attribute reading
 
         :param attr_list: list of indices in the device object attribute vector
@@ -1428,7 +1428,7 @@ def __doc_extra_DeviceImpl(cls):
         Write the hardware for attributes.
 
         Default method to implement an action necessary on a device to write
-        the hardware involved in a a write attribute. This method must be
+        the hardware involved in a write attribute. This method must be
         redefined in sub-classes in order to support writable attribute
 
         :param attr_list: list of indices in the device object attribute vector
@@ -1625,7 +1625,7 @@ def __doc_Attribute():
 
         Get attribute label property.
 
-        :returns: he attribute label
+        :returns: the attribute label
         :rtype: str
     """)
 
@@ -1681,7 +1681,7 @@ def __doc_Attribute():
 
         Get attribute data size in y dimension.
 
-        :returns: the attribute data size in y dimension. Set to 1 for scalar attribute
+        :returns: the attribute data size in y dimension. Set to 0 for scalar attribute
         :rtype: int
     """)
 

--- a/tango/device_server.py
+++ b/tango/device_server.py
@@ -227,7 +227,7 @@ def __Attribute__get_properties(self, attr_cfg=None):
 
 def __Attribute__set_properties(self, attr_cfg, dev=None):
     """
-    set_properties(self, attr_cfg, dev) -> None
+    set_properties(self, attr_cfg, dev)
 
         Set attribute properties.
 
@@ -268,7 +268,7 @@ def __DeviceImpl__get_device_class(self):
 
 def __DeviceImpl__get_device_properties(self, ds_class=None):
     """
-    get_device_properties(self, ds_class = None) -> None
+    get_device_properties(self, ds_class = None)
 
         Utility method that fetches all the device properties from the database
         and converts them into members of this DeviceImpl.
@@ -371,7 +371,7 @@ def __DeviceImpl__add_attribute(self, attr, r_meth=None, w_meth=None, is_allo_me
 
 def __DeviceImpl__remove_attribute(self, attr_name):
     """
-    remove_attribute(self, attr_name) -> None
+    remove_attribute(self, attr_name)
 
         Remove one attribute from the device attribute list.
 
@@ -459,7 +459,7 @@ def __DeviceImpl__add_command(self, cmd, device_level=True):
 
 def __DeviceImpl__remove_command(self, cmd_name, free_it=False, clean_db=True):
     """
-    remove_command(self, attr_name) -> None
+    remove_command(self, attr_name)
 
         Remove one command from the device command list.
 
@@ -488,7 +488,7 @@ def __DeviceImpl__remove_command(self, cmd_name, free_it=False, clean_db=True):
 
 def __DeviceImpl__debug_stream(self, msg, *args):
     """
-    debug_stream(self, msg, *args) -> None
+    debug_stream(self, msg, *args)
 
         Sends the given message to the tango debug stream.
 
@@ -506,7 +506,7 @@ def __DeviceImpl__debug_stream(self, msg, *args):
 
 def __DeviceImpl__info_stream(self, msg, *args):
     """
-    info_stream(self, msg, *args) -> None
+    info_stream(self, msg, *args)
 
         Sends the given message to the tango info stream.
 
@@ -524,7 +524,7 @@ def __DeviceImpl__info_stream(self, msg, *args):
 
 def __DeviceImpl__warn_stream(self, msg, *args):
     """
-    warn_stream(self, msg, *args) -> None
+    warn_stream(self, msg, *args)
 
         Sends the given message to the tango warn stream.
 
@@ -542,7 +542,7 @@ def __DeviceImpl__warn_stream(self, msg, *args):
 
 def __DeviceImpl__error_stream(self, msg, *args):
     """
-    error_stream(self, msg, *args) -> None
+    error_stream(self, msg, *args)
 
         Sends the given message to the tango error stream.
 
@@ -560,7 +560,7 @@ def __DeviceImpl__error_stream(self, msg, *args):
 
 def __DeviceImpl__fatal_stream(self, msg, *args):
     """
-    fatal_stream(self, msg, *args) -> None
+    fatal_stream(self, msg, *args)
 
         Sends the given message to the tango fatal stream.
 
@@ -640,7 +640,7 @@ def __init_DeviceImpl():
 
 def __Logger__log(self, level, msg, *args):
     """
-    log(self, level, msg, *args) -> None
+    log(self, level, msg, *args)
 
         Sends the given message to the tango the selected stream.
 
@@ -656,7 +656,7 @@ def __Logger__log(self, level, msg, *args):
 
 def __Logger__log_unconditionally(self, level, msg, *args):
     """
-    log_unconditionally(self, level, msg, *args) -> None
+    log_unconditionally(self, level, msg, *args)
 
         Sends the given message to the tango the selected stream,
         without checking the level.
@@ -673,7 +673,7 @@ def __Logger__log_unconditionally(self, level, msg, *args):
 
 def __Logger__debug(self, msg, *args):
     """
-    debug(self, msg, *args) -> None
+    debug(self, msg, *args)
 
         Sends the given message to the tango debug stream.
 
@@ -688,7 +688,7 @@ def __Logger__debug(self, msg, *args):
 
 def __Logger__info(self, msg, *args):
     """
-    info(self, msg, *args) -> None
+    info(self, msg, *args)
 
         Sends the given message to the tango info stream.
 
@@ -703,7 +703,7 @@ def __Logger__info(self, msg, *args):
 
 def __Logger__warn(self, msg, *args):
     """
-    warn(self, msg, *args) -> None
+    warn(self, msg, *args)
 
         Sends the given message to the tango warn stream.
 
@@ -718,7 +718,7 @@ def __Logger__warn(self, msg, *args):
 
 def __Logger__error(self, msg, *args):
     """
-    error(self, msg, *args) -> None
+    error(self, msg, *args)
 
         Sends the given message to the tango error stream.
 
@@ -733,7 +733,7 @@ def __Logger__error(self, msg, *args):
 
 def __Logger__fatal(self, msg, *args):
     """
-    fatal(self, msg, *args) -> None
+    fatal(self, msg, *args)
 
         Sends the given message to the tango fatal stream.
 
@@ -748,7 +748,7 @@ def __Logger__fatal(self, msg, *args):
 
 def __UserDefaultAttrProp_set_enum_labels(self, enum_labels):
     """
-    set_enum_labels(self, enum_labels) -> None
+    set_enum_labels(self, enum_labels)
 
         Set default enumeration labels.
 
@@ -797,7 +797,7 @@ def __doc_DeviceImpl():
     """
 
     document_method("init_device", """
-    init_device(self) -> None
+    init_device(self)
 
         Intialize the device.
 
@@ -805,7 +805,7 @@ def __doc_DeviceImpl():
     """)
 
     document_method("set_state", """
-    set_state(self, new_state) -> None
+    set_state(self, new_state)
 
         Set device state.
 
@@ -851,7 +851,7 @@ def __doc_DeviceImpl():
     """)
 
     document_method("register_signal", """
-    register_signal(self, signo) -> None
+    register_signal(self, signo)
 
         Register a signal.
 
@@ -865,7 +865,7 @@ def __doc_DeviceImpl():
     """)
 
     document_method("unregister_signal", """
-    unregister_signal(self, signo) -> None
+    unregister_signal(self, signo)
 
         Unregister a signal.
 
@@ -887,7 +887,7 @@ def __doc_DeviceImpl():
     """)
 
     document_method("set_status", """
-    set_status(self, new_status) -> None
+    set_status(self, new_status)
 
         Set device status.
 
@@ -898,7 +898,7 @@ def __doc_DeviceImpl():
     """)
 
     document_method("append_status", """
-    append_status(self, status, new_line=False) -> None
+    append_status(self, status, new_line=False)
 
         Appends a string to the device status.
 
@@ -943,7 +943,7 @@ def __doc_DeviceImpl():
     """)
 
     document_method("set_change_event", """
-    set_change_event(self, attr_name, implemented, detect=True) -> None
+    set_change_event(self, attr_name, implemented, detect=True)
 
         Set an implemented flag for the attribute to indicate that the server fires
         change events manually, without the polling to be started.
@@ -962,7 +962,7 @@ def __doc_DeviceImpl():
     """)
 
     document_method("set_archive_event", """
-    set_archive_event(self, attr_name, implemented, detect=True) -> None
+    set_archive_event(self, attr_name, implemented, detect=True)
 
         Set an implemented flag for the attribute to indicate that the server fires
         archive events manually, without the polling to be started.
@@ -981,12 +981,12 @@ def __doc_DeviceImpl():
     """)
 
     document_method("push_change_event", """
-    push_change_event(self, attr_name) -> None
-    push_change_event(self, attr_name, except) -> None
-    push_change_event(self, attr_name, data, dim_x = 1, dim_y = 0) -> None
-    push_change_event(self, attr_name, str_data, data) -> None
-    push_change_event(self, attr_name, data, time_stamp, quality, dim_x = 1, dim_y = 0) -> None
-    push_change_event(self, attr_name, str_data, data, time_stamp, quality) -> None
+    push_change_event(self, attr_name)
+    push_change_event(self, attr_name, except)
+    push_change_event(self, attr_name, data, dim_x = 1, dim_y = 0)
+    push_change_event(self, attr_name, str_data, data)
+    push_change_event(self, attr_name, data, time_stamp, quality, dim_x = 1, dim_y = 0)
+    push_change_event(self, attr_name, str_data, data, time_stamp, quality)
 
         Push a change event for the given attribute name.
 
@@ -1010,12 +1010,12 @@ def __doc_DeviceImpl():
     """)
 
     document_method("push_archive_event", """
-    push_archive_event(self, attr_name) -> None
-    push_archive_event(self, attr_name, except) -> None
-    push_archive_event(self, attr_name, data, dim_x = 1, dim_y = 0) -> None
-    push_archive_event(self, attr_name, str_data, data) -> None
-    push_archive_event(self, attr_name, data, time_stamp, quality, dim_x = 1, dim_y = 0) -> None
-    push_archive_event(self, attr_name, str_data, data, time_stamp, quality) -> None
+    push_archive_event(self, attr_name)
+    push_archive_event(self, attr_name, except)
+    push_archive_event(self, attr_name, data, dim_x = 1, dim_y = 0)
+    push_archive_event(self, attr_name, str_data, data)
+    push_archive_event(self, attr_name, data, time_stamp, quality, dim_x = 1, dim_y = 0)
+    push_archive_event(self, attr_name, str_data, data, time_stamp, quality)
 
         Push an archive event for the given attribute name.
 
@@ -1039,11 +1039,11 @@ def __doc_DeviceImpl():
     """)
 
     document_method("push_event", """
-    push_event(self, attr_name, filt_names, filt_vals) -> None
-    push_event(self, attr_name, filt_names, filt_vals, data, dim_x = 1, dim_y = 0) -> None
-    push_event(self, attr_name, filt_names, filt_vals, str_data, data) -> None
-    push_event(self, attr_name, filt_names, filt_vals, data, time_stamp, quality, dim_x = 1, dim_y = 0) -> None
-    push_event(self, attr_name, filt_names, filt_vals, str_data, data, time_stamp, quality) -> None
+    push_event(self, attr_name, filt_names, filt_vals)
+    push_event(self, attr_name, filt_names, filt_vals, data, dim_x = 1, dim_y = 0)
+    push_event(self, attr_name, filt_names, filt_vals, str_data, data)
+    push_event(self, attr_name, filt_names, filt_vals, data, time_stamp, quality, dim_x = 1, dim_y = 0)
+    push_event(self, attr_name, filt_names, filt_vals, str_data, data, time_stamp, quality)
 
         Push a user event for the given attribute name.
 
@@ -1068,7 +1068,7 @@ def __doc_DeviceImpl():
     """)
 
     document_method("push_data_ready_event", """
-    push_data_ready_event(self, attr_name, counter = 0) -> None
+    push_data_ready_event(self, attr_name, counter = 0)
 
         Push a data ready event for the given attribute name.
 
@@ -1087,9 +1087,9 @@ def __doc_DeviceImpl():
     """)
 
     document_method("push_pipe_event", """
-    push_pipe_event(self, pipe_name, except) -> None
-    push_pipe_event(self, pipe_name, blob, reuse_it) -> None
-    push_pipe_event(self, pipe_name, blob, timeval, reuse_it) -> None
+    push_pipe_event(self, pipe_name, except)
+    push_pipe_event(self, pipe_name, blob, reuse_it)
+    push_pipe_event(self, pipe_name, blob, timeval, reuse_it)
 
         Push a pipe event for the given blob.
 
@@ -1193,8 +1193,8 @@ def __doc_DeviceImpl():
     """)
 
     document_method("stop_polling", """
-    stop_polling(self) -> None
-    stop_polling(self, with_db_upd) -> None
+    stop_polling(self)
+    stop_polling(self, with_db_upd)
 
         Stop all polling for a device. if the device is polled, call this
         method before deleting it.
@@ -1236,7 +1236,7 @@ def __doc_DeviceImpl():
     """)
 
     document_method("check_command_exists", """
-    check_command_exists(self) -> None
+    check_command_exists(self)
 
         Check that a command is supported by the device and
         does not need input value.
@@ -1331,7 +1331,7 @@ def __doc_DeviceImpl():
     """)
 
     document_method("push_att_conf_event", """
-    push_att_conf_event(self, attr) -> None
+    push_att_conf_event(self, attr)
 
         Push an attribute configuration event.
 
@@ -1343,7 +1343,7 @@ def __doc_DeviceImpl():
     """)
 
     document_method("push_pipe_event", """
-    push_pipe_event(self, blob) -> None
+    push_pipe_event(self, blob)
 
         Push an pipe event.
 
@@ -1380,7 +1380,7 @@ def __doc_extra_DeviceImpl(cls):
         return __document_method(cls, method_name, desc, append)
 
     document_method("delete_device", """
-    delete_device(self) -> None
+    delete_device(self)
 
         Delete the device.
 
@@ -1388,7 +1388,7 @@ def __doc_extra_DeviceImpl(cls):
     """)
 
     document_method("always_executed_hook", """
-    always_executed_hook(self) -> None
+    always_executed_hook(self)
 
         Hook method.
 
@@ -1402,7 +1402,7 @@ def __doc_extra_DeviceImpl(cls):
     """)
 
     document_method("read_attr_hardware", """
-    read_attr_hardware(self, attr_list) -> None
+    read_attr_hardware(self, attr_list)
 
         Read the hardware to return attribute value(s).
 
@@ -1420,7 +1420,7 @@ def __doc_extra_DeviceImpl(cls):
     """)
 
     document_method("write_attr_hardware", """
-    write_attr_hardware(self) -> None
+    write_attr_hardware(self)
 
         Write the hardware for attributes.
 
@@ -1438,7 +1438,7 @@ def __doc_extra_DeviceImpl(cls):
     """)
 
     document_method("signal_handler", """
-    signal_handler(self, signo) -> None
+    signal_handler(self, signo)
 
         Signal handler.
 
@@ -1581,7 +1581,7 @@ def __doc_Attribute():
     """)
 
     document_method("set_assoc_ind", """
-    set_assoc_ind(self, index) -> None
+    set_assoc_ind(self, index)
 
         Set index of the associated writable attribute.
 
@@ -1600,7 +1600,7 @@ def __doc_Attribute():
     """)
 
     document_method("set_date", """
-    set_date(self, new_date) -> None
+    set_date(self, new_date)
 
         Set attribute date.
 
@@ -1627,7 +1627,7 @@ def __doc_Attribute():
     """)
 
     document_method("set_quality", """
-    set_quality(self, quality, send_event=False) -> None
+    set_quality(self, quality, send_event=False)
 
         Set attribute data quality.
 
@@ -1639,7 +1639,7 @@ def __doc_Attribute():
     """)
 
     document_method("get_data_size", """
-    get_data_size(self) -> None
+    get_data_size(self)
 
         Get attribute data size.
 
@@ -1714,9 +1714,9 @@ def __doc_Attribute():
     """)
 
     document_method("set_value", """
-    set_value(self, data, dim_x = 1, dim_y = 0) -> None <= DEPRECATED
-    set_value(self, data) -> None
-    set_value(self, str_data, data) -> None
+    set_value(self, data, dim_x = 1, dim_y = 0) <= DEPRECATED
+    set_value(self, data)
+    set_value(self, str_data, data)
 
         Set internal attribute value.
 
@@ -1743,9 +1743,9 @@ def __doc_Attribute():
     """)
 
     document_method("set_value_date_quality", """
-    set_value_date_quality(self, data, time_stamp, quality, dim_x = 1, dim_y = 0) -> None <= DEPRECATED
-    set_value_date_quality(self, data, time_stamp, quality) -> None
-    set_value_date_quality(self, str_data, data, time_stamp, quality) -> None
+    set_value_date_quality(self, data, time_stamp, quality, dim_x = 1, dim_y = 0) <= DEPRECATED
+    set_value_date_quality(self, data, time_stamp, quality)
+    set_value_date_quality(self, str_data, data, time_stamp, quality)
 
         Set internal attribute value, date and quality factor.
 
@@ -1773,7 +1773,7 @@ def __doc_Attribute():
     """)
 
     document_method("set_change_event", """
-    set_change_event(self, implemented, detect = True) -> None
+    set_change_event(self, implemented, detect = True)
 
         Set a flag to indicate that the server fires change events manually,
         without the polling to be started for the attribute.
@@ -1794,7 +1794,7 @@ def __doc_Attribute():
     """)
 
     document_method("set_archive_event", """
-    set_archive_event(self, implemented, detect = True) -> None
+    set_archive_event(self, implemented, detect = True)
 
         Set a flag to indicate that the server fires archive events manually,
         without the polling to be started for the attribute.
@@ -1855,7 +1855,7 @@ def __doc_Attribute():
     """)
 
     document_method("set_data_ready_event", """
-    set_data_ready_event(self, implemented) -> None
+    set_data_ready_event(self, implemented)
 
         Set a flag to indicate that the server fires data ready events.
 
@@ -1879,7 +1879,7 @@ def __doc_Attribute():
     """)
 
     document_method("remove_configuration", """
-    remove_configuration(self) -> None
+    remove_configuration(self)
 
         Remove the attribute configuration from the database.
 
@@ -1923,7 +1923,7 @@ def __doc_WAttribute():
     """)
 
     document_method("set_min_value", """
-    set_min_value(self, data) -> None
+    set_min_value(self, data)
 
         Set attribute minimum value.
 
@@ -1935,7 +1935,7 @@ def __doc_WAttribute():
     """)
 
     document_method("set_max_value", """
-    set_max_value(self, data) -> None
+    set_max_value(self, data)
 
         Set attribute maximum value.
 
@@ -1971,7 +1971,7 @@ def __doc_WAttribute():
     """)
 
     #    document_method("set_write_value", """
-    #    set_write_value(self, data, dim_x = 1, dim_y = 0) -> None
+    #    set_write_value(self, data, dim_x = 1, dim_y = 0)
     #
     #        Set the writable attribute value.
     #
@@ -1986,7 +1986,7 @@ def __doc_WAttribute():
     #    """)
 
     document_method("get_write_value", """
-    get_write_value(self, lst) -> None  <= DEPRECATED
+    get_write_value(self, lst)  <= DEPRECATED
     get_write_value(self, extract_as=ExtractAs.Numpy) -> obj
 
         Retrieve the new value for writable attribute.
@@ -2028,7 +2028,7 @@ def __doc_MultiClassAttribute():
     """)
 
     document_method("remove_attr", """
-    remove_attr(self, attr_name, cl_name) -> None
+    remove_attr(self, attr_name, cl_name)
 
         Remove the :class:`~tango.Attr` object for the attribute with
         name passed as parameter.
@@ -2177,7 +2177,7 @@ def __doc_MultiAttribute():
     """)
 
     document_method("read_alarm", """
-    read_alarm(self, status) -> None
+    read_alarm(self, status)
 
         Add alarm message to device status.
 
@@ -2212,7 +2212,7 @@ def __doc_Attr():
     """
 
     document_method("set_default_properties", """
-    set_default_properties(self) -> None
+    set_default_properties(self)
 
         Set default attribute properties.
 
@@ -2223,7 +2223,7 @@ def __doc_Attr():
     """)
 
     document_method("set_disp_level", """
-    set_disp_level(self, disp_lelel) -> None
+    set_disp_level(self, disp_lelel)
 
         Set the attribute display level.
 
@@ -2234,7 +2234,7 @@ def __doc_Attr():
     """)
 
     document_method("set_polling_period", """
-    set_polling_period(self, period) -> None
+    set_polling_period(self, period)
 
         Set the attribute polling update period.
 
@@ -2245,7 +2245,7 @@ def __doc_Attr():
     """)
 
     document_method("set_memorized", """
-    set_memorized(self) -> None
+    set_memorized(self)
 
         Set the attribute as memorized in database (only for scalar
         and writable attribute).
@@ -2257,7 +2257,7 @@ def __doc_Attr():
     """)
 
     document_method("set_memorized_init", """
-    set_memorized_init(self, write_on_init) -> None
+    set_memorized_init(self, write_on_init)
 
         Set the initialisation flag for memorized attributes.
 
@@ -2273,7 +2273,7 @@ def __doc_Attr():
     """)
 
     document_method("set_change_event", """
-    set_change_event(self, implemented, detect) -> None
+    set_change_event(self, implemented, detect)
 
         Set a flag to indicate that the server fires change events manually
         without the polling to be started for the attribute.
@@ -2309,7 +2309,7 @@ def __doc_Attr():
     """)
 
     document_method("set_archive_event", """
-    set_archive_event(self) -> None
+    set_archive_event(self)
 
         Set a flag to indicate that the server fires archive events manually
         without the polling to be started for the attribute.
@@ -2345,7 +2345,7 @@ def __doc_Attr():
     """)
 
     document_method("set_data_ready_event", """
-    set_data_ready_event(self, implemented) -> None
+    set_data_ready_event(self, implemented)
 
         Set a flag to indicate that the server fires data ready events.
 
@@ -2459,7 +2459,7 @@ def __doc_Attr():
     """)
 
     document_method("set_cl_name", """
-    set_cl_name(self, cl) -> None
+    set_cl_name(self, cl)
 
         Sets the class name.
 
@@ -2488,7 +2488,7 @@ def __doc_Attr():
     """)
 
     document_method("set_class_properties", """
-    set_class_properties(self, props) -> None
+    set_class_properties(self, props)
 
         Set the class level attribute properties.
 
@@ -2514,7 +2514,7 @@ def __doc_UserDefaultAttrProp():
     """
 
     document_method("set_label", """
-    set_label(self, def_label) -> None
+    set_label(self, def_label)
 
         Set default label property.
 
@@ -2525,7 +2525,7 @@ def __doc_UserDefaultAttrProp():
     """)
 
     document_method("set_description", """
-    set_description(self, def_description) -> None
+    set_description(self, def_description)
 
         Set default description property.
 
@@ -2536,7 +2536,7 @@ def __doc_UserDefaultAttrProp():
     """)
 
     document_method("set_format", """
-    set_format(self, def_format) -> None
+    set_format(self, def_format)
 
         Set default format property.
 
@@ -2547,7 +2547,7 @@ def __doc_UserDefaultAttrProp():
     """)
 
     document_method("set_unit", """
-    set_unit(self, def_unit) -> None
+    set_unit(self, def_unit)
 
         Set default unit property.
 
@@ -2558,7 +2558,7 @@ def __doc_UserDefaultAttrProp():
     """)
 
     document_method("set_standard_unit", """
-    set_standard_unit(self, def_standard_unit) -> None
+    set_standard_unit(self, def_standard_unit)
 
         Set default standard unit property.
 
@@ -2569,7 +2569,7 @@ def __doc_UserDefaultAttrProp():
     """)
 
     document_method("set_display_unit", """
-    set_display_unit(self, def_display_unit) -> None
+    set_display_unit(self, def_display_unit)
 
         Set default display unit property.
 
@@ -2580,7 +2580,7 @@ def __doc_UserDefaultAttrProp():
     """)
 
     document_method("set_min_value", """
-    set_min_value(self, def_min_value) -> None
+    set_min_value(self, def_min_value)
 
         Set default min_value property.
 
@@ -2591,7 +2591,7 @@ def __doc_UserDefaultAttrProp():
     """)
 
     document_method("set_max_value", """
-    set_max_value(self, def_max_value) -> None
+    set_max_value(self, def_max_value)
 
         Set default max_value property.
 
@@ -2602,7 +2602,7 @@ def __doc_UserDefaultAttrProp():
     """)
 
     document_method("set_min_alarm", """
-    set_min_alarm(self, def_min_alarm) -> None
+    set_min_alarm(self, def_min_alarm)
 
         Set default min_alarm property.
 
@@ -2613,7 +2613,7 @@ def __doc_UserDefaultAttrProp():
     """)
 
     document_method("set_max_alarm", """
-    set_max_alarm(self, def_max_alarm) -> None
+    set_max_alarm(self, def_max_alarm)
 
         Set default max_alarm property.
 
@@ -2624,7 +2624,7 @@ def __doc_UserDefaultAttrProp():
     """)
 
     document_method("set_min_warning", """
-    set_min_warning(self, def_min_warning) -> None
+    set_min_warning(self, def_min_warning)
 
         Set default min_warning property.
 
@@ -2635,7 +2635,7 @@ def __doc_UserDefaultAttrProp():
     """)
 
     document_method("set_max_warning", """
-    set_max_warning(self, def_max_warning) -> None
+    set_max_warning(self, def_max_warning)
 
         Set default max_warning property.
 
@@ -2646,7 +2646,7 @@ def __doc_UserDefaultAttrProp():
     """)
 
     document_method("set_delta_t", """
-    set_delta_t(self, def_delta_t) -> None
+    set_delta_t(self, def_delta_t)
 
         Set default RDS alarm delta_t property.
 
@@ -2657,7 +2657,7 @@ def __doc_UserDefaultAttrProp():
     """)
 
     document_method("set_delta_val", """
-    set_delta_val(self, def_delta_val) -> None
+    set_delta_val(self, def_delta_val)
 
         Set default RDS alarm delta_val property.
 
@@ -2668,7 +2668,7 @@ def __doc_UserDefaultAttrProp():
     """)
 
     document_method("set_abs_change", """
-    set_abs_change(self, def_abs_change) -> None <= DEPRECATED
+    set_abs_change(self, def_abs_change) <= DEPRECATED
 
         Set default change event abs_change property.
 
@@ -2681,7 +2681,7 @@ def __doc_UserDefaultAttrProp():
     """)
 
     document_method("set_event_abs_change", """
-    set_event_abs_change(self, def_abs_change) -> None
+    set_event_abs_change(self, def_abs_change)
 
         Set default change event abs_change property.
 
@@ -2694,7 +2694,7 @@ def __doc_UserDefaultAttrProp():
     """)
 
     document_method("set_rel_change", """
-    set_rel_change(self, def_rel_change) -> None <= DEPRECATED
+    set_rel_change(self, def_rel_change) <= DEPRECATED
 
         Set default change event rel_change property.
 
@@ -2707,7 +2707,7 @@ def __doc_UserDefaultAttrProp():
     """)
 
     document_method("set_event_rel_change", """
-    set_event_rel_change(self, def_rel_change) -> None
+    set_event_rel_change(self, def_rel_change)
 
         Set default change event rel_change property.
 
@@ -2720,7 +2720,7 @@ def __doc_UserDefaultAttrProp():
     """)
 
     document_method("set_period", """
-    set_period(self, def_period) -> None <= DEPRECATED
+    set_period(self, def_period) <= DEPRECATED
 
         Set default periodic event period property.
 
@@ -2733,7 +2733,7 @@ def __doc_UserDefaultAttrProp():
     """)
 
     document_method("set_event_period", """
-    set_event_period(self, def_period) -> None
+    set_event_period(self, def_period)
 
         Set default periodic event period property.
 
@@ -2746,7 +2746,7 @@ def __doc_UserDefaultAttrProp():
     """)
 
     document_method("set_archive_abs_change", """
-    set_archive_abs_change(self, def_archive_abs_change) -> None <= DEPRECATED
+    set_archive_abs_change(self, def_archive_abs_change) <= DEPRECATED
 
         Set default archive event abs_change property.
 
@@ -2759,7 +2759,7 @@ def __doc_UserDefaultAttrProp():
     """)
 
     document_method("set_archive_event_abs_change", """
-    set_archive_event_abs_change(self, def_archive_abs_change) -> None
+    set_archive_event_abs_change(self, def_archive_abs_change)
 
         Set default archive event abs_change property.
 
@@ -2772,7 +2772,7 @@ def __doc_UserDefaultAttrProp():
     """)
 
     document_method("set_archive_rel_change", """
-    set_archive_rel_change(self, def_archive_rel_change) -> None <= DEPRECATED
+    set_archive_rel_change(self, def_archive_rel_change) <= DEPRECATED
 
         Set default archive event rel_change property.
 
@@ -2785,7 +2785,7 @@ def __doc_UserDefaultAttrProp():
     """)
 
     document_method("set_archive_event_rel_change", """
-    set_archive_event_rel_change(self, def_archive_rel_change) -> None
+    set_archive_event_rel_change(self, def_archive_rel_change)
 
         Set default archive event rel_change property.
 
@@ -2798,7 +2798,7 @@ def __doc_UserDefaultAttrProp():
     """)
 
     document_method("set_archive_period", """
-    set_archive_period(self, def_archive_period) -> None <= DEPRECATED
+    set_archive_period(self, def_archive_period) <= DEPRECATED
 
         Set default archive event period property.
 
@@ -2811,7 +2811,7 @@ def __doc_UserDefaultAttrProp():
     """)
 
     document_method("set_archive_event_period", """
-    set_archive_event_period(self, def_archive_period) -> None
+    set_archive_event_period(self, def_archive_period)
 
         Set default archive event period property.
 

--- a/tango/device_server.py
+++ b/tango/device_server.py
@@ -203,17 +203,16 @@ def __Attribute__get_properties(self, attr_cfg=None):
 
         Get attribute properties.
 
-        Parameters:
-            conf: the config object to be filled with
-                  the attribute configuration. Default is None meaning the
-                  method will create internally a new AttributeConfig_5
-                  and return it.
-                  Can be AttributeConfig, AttributeConfig_2,
-                  AttributeConfig_3, AttributeConfig_5 or
-                  MultiAttrProp
+        :param conf: the config object to be filled with
+                     the attribute configuration. Default is None meaning the
+                     method will create internally a new AttributeConfig_5
+                     and return it.
+                     Can be AttributeConfig, AttributeConfig_2,
+                     AttributeConfig_3, AttributeConfig_5 or
+                     MultiAttrProp
 
-        Return:
-            AttributeConfig: the config object filled with attribute configuration information
+        :returns: the config object filled with attribute configuration information
+        :rtype: AttributeConfig
 
         New in PyTango 7.1.4
     """
@@ -234,10 +233,11 @@ def __Attribute__set_properties(self, attr_cfg, dev=None):
         This method sets the attribute properties value with the content
         of the fileds in the AttributeConfig/ AttributeConfig_3 object
 
-        Parameters:
-            conf (AttributeConfig or AttributeConfig_3): the config object.
-            dev (DeviceImpl): the device (not used, maintained
-                              for backward compatibility)
+        :param conf: the config object.
+        :type conf: AttributeConfig or AttributeConfig_3
+        :param dev: the device (not used, maintained
+                    for backward compatibility)
+        :type dev: DeviceImpl
 
         New in PyTango 7.1.4
     """
@@ -272,13 +272,12 @@ def __DeviceImpl__get_device_properties(self, ds_class=None):
         Utility method that fetches all the device properties from the database
         and converts them into members of this DeviceImpl.
 
-        Parameters:
-            ds_class (DeviceClass): the DeviceClass object. Optional. Default value is
-                None meaning that the corresponding DeviceClass object for this
-                DeviceImpl will be used
+        :param ds_class: the DeviceClass object. Optional. Default value is
+                         None meaning that the corresponding DeviceClass object for this
+                         DeviceImpl will be used
+        :type ds_class: DeviceClass
 
-        Raises:
-            DevFailed:
+        :raises DevFailed:
     """
     if ds_class is None:
         try:
@@ -312,19 +311,21 @@ def __DeviceImpl__add_attribute(self, attr, r_meth=None, w_meth=None, is_allo_me
         to the device class attribute list. Therefore, all devices belonging to the
         same class created after this attribute addition will also have this attribute.
 
-        Parameters:
-            attr (Attr or AttrData): the new attribute to be added to the list.
-            r_meth (callable): the read method to be called on a read request
-            w_meth (callable): the write method to be called on a write request
-                               (if attr is writable)
-            is_allo_meth (callable): the method that is called to check if it
-                               is possible to access the attribute or not
+        :param attr: the new attribute to be added to the list.
+        :type attr: Attr or AttrData
+        :param r_meth: the read method to be called on a read request
+        :type r_meth: callable
+        :param w_meth: the write method to be called on a write request
+                       (if attr is writable)
+        :type w_meth: callable
+        :param is_allo_meth: the method that is called to check if it
+                             is possible to access the attribute or not
+        :type is_allo_meth: callable
 
-        Return:
-            Attr: the newly created attribute.
+        :returns: the newly created attribute.
+        :rtype: Attr
 
-        Raises:
-            DevFailed:
+        :raises DevFailed:
     """
 
     attr_data = None
@@ -375,11 +376,10 @@ def __DeviceImpl__remove_attribute(self, attr_name):
 
         Remove one attribute from the device attribute list.
 
-        Parameters:
-            attr_name (str): attribute name
+        :param attr_name: attribute name
+        :type attr_name: str
 
-        Raises:
-            DevFailed:
+        :raises DevFailed:
     """
     try:
         # Call this method in a try/except in case remove_attribute
@@ -428,16 +428,14 @@ def __DeviceImpl__add_command(self, cmd, device_level=True):
 
         Add a new command to the device command list.
 
-        Parameters:
-            cmd: the new command to be added to the list
-            device_level: Set this flag to true if the command must be added
-                          for only this device
+        :param cmd: the new command to be added to the list
+        :param device_level: Set this flag to true if the command must be added
+                             for only this device
 
-        Return:
-            Command:
+        :returns:
+        :rtype: Command
 
-        Raises:
-            DevFailed:
+        :raises DevFailed:
     """
     add_name_in_list = False      # This flag is always False, what use is it?
     try:
@@ -464,14 +462,14 @@ def __DeviceImpl__remove_command(self, cmd_name, free_it=False, clean_db=True):
 
         Remove one command from the device command list.
 
-        Parameters:
-            cmd_name (str): command name to be removed from the list
-            free_it (bool): set to true if the command object must be freed.
-            clean_db: Clean command related information (included polling info
-                      if the command is polled) from database.
+        :param cmd_name: command name to be removed from the list
+        :type cmd_name: str
+        :param free_it: set to true if the command object must be freed.
+        :type free_it: bool
+        :param clean_db: Clean command related information (included polling info
+                         if the command is polled) from database.
 
-        Raises:
-            DevFailed:
+        :raises DevFailed:
     """
     try:
         # Call this method in a try/except in case remove
@@ -496,8 +494,8 @@ def __DeviceImpl__debug_stream(self, msg, *args):
 
             print(msg, file=self.log_debug)
 
-        Parameters:
-            msg (str): the message to be sent to the debug stream
+        :param msg: the message to be sent to the debug stream
+        :type msg: str
     """
     self.__debug_stream(msg % args)
 
@@ -512,8 +510,8 @@ def __DeviceImpl__info_stream(self, msg, *args):
 
             print(msg, file=self.log_info)
 
-        Parameters:
-            msg (str): the message to be sent to the info stream
+        :param msg: the message to be sent to the info stream
+        :type msg: str
     """
     self.__info_stream(msg % args)
 
@@ -528,8 +526,8 @@ def __DeviceImpl__warn_stream(self, msg, *args):
 
             print(msg, file=self.log_warn)
 
-        Parameters:
-            msg (str): the message to be sent to the warn stream
+        :param msg: the message to be sent to the warn stream
+        :type msg: str
     """
     self.__warn_stream(msg % args)
 
@@ -544,8 +542,8 @@ def __DeviceImpl__error_stream(self, msg, *args):
 
             print(msg, file=self.log_error)
 
-        Parameters:
-            msg (str): the message to be sent to the error stream
+        :param msg: the message to be sent to the error stream
+        :type msg: str
     """
     self.__error_stream(msg % args)
 
@@ -560,8 +558,8 @@ def __DeviceImpl__fatal_stream(self, msg, *args):
 
             print(msg, file=self.log_fatal)
 
-        Parameters:
-            msg (str): the message to be sent to the fatal stream
+        :param msg: the message to be sent to the fatal stream
+        :type msg: str
     """
     self.__fatal_stream(msg % args)
 
@@ -634,10 +632,12 @@ def __Logger__log(self, level, msg, *args):
 
         Sends the given message to the tango the selected stream.
 
-        Parameters:
-            level (Level.LevelLevel): Log level
-            msg (str): the message to be sent to the stream
-            args (seq<str>): list of optional message arguments
+        :param level: Log level
+        :type level: Level.LevelLevel
+        :param msg: the message to be sent to the stream
+        :type msg: str
+        :param args: list of optional message arguments
+        :type args: seq<str>
     """
     self.__log(level, msg % args)
 
@@ -649,10 +649,12 @@ def __Logger__log_unconditionally(self, level, msg, *args):
         Sends the given message to the tango the selected stream,
         without checking the level.
 
-        Parameters:
-            level (Level.LevelLevel): Log level
-            msg (str): the message to be sent to the stream
-            args (seq<str>): list of optional message arguments
+        :param level: Log level
+        :type level: Level.LevelLevel
+        :param msg: the message to be sent to the stream
+        :type msg: str
+        :param args: list of optional message arguments
+        :type args: seq<str>
     """
     self.__log_unconditionally(level, msg % args)
 
@@ -663,9 +665,10 @@ def __Logger__debug(self, msg, *args):
 
         Sends the given message to the tango debug stream.
 
-        Parameters:
-            msg (str): the message to be sent to the debug stream
-            args (seq<str>): list of optional message arguments
+        :param msg: the message to be sent to the debug stream
+        :type msg: str
+        :param args: list of optional message arguments
+        :type args: seq<str>
     """
     self.__debug(msg % args)
 
@@ -676,9 +679,10 @@ def __Logger__info(self, msg, *args):
 
         Sends the given message to the tango info stream.
 
-        Parameters:
-            msg (str): the message to be sent to the info stream
-            args (seq<str>): list of optional message arguments
+        :param msg: the message to be sent to the info stream
+        :type msg: str
+        :param args: list of optional message arguments
+        :type args: seq<str>
     """
     self.__info(msg % args)
 
@@ -689,9 +693,10 @@ def __Logger__warn(self, msg, *args):
 
         Sends the given message to the tango warn stream.
 
-        Parameters:
-            msg (str): the message to be sent to the warn stream
-            args (seq<str>): list of optional message arguments
+        :param msg: the message to be sent to the warn stream
+        :type msg: str
+        :param args: list of optional message arguments
+        :type args: seq<str>
     """
     self.__warn(msg % args)
 
@@ -702,9 +707,10 @@ def __Logger__error(self, msg, *args):
 
         Sends the given message to the tango error stream.
 
-        Parameters:
-            msg (str): the message to be sent to the error stream
-            args (seq<str>): list of optional message arguments
+        :param msg: the message to be sent to the error stream
+        :type msg: str
+        :param args: list of optional message arguments
+        :type args: seq<str>
     """
     self.__error(msg % args)
 
@@ -715,9 +721,10 @@ def __Logger__fatal(self, msg, *args):
 
         Sends the given message to the tango fatal stream.
 
-        Parameters:
-            msg (str): the message to be sent to the fatal stream
-            args (seq<str>): list of optional message arguments
+        :param msg: the message to be sent to the fatal stream
+        :type msg: str
+        :param args: list of optional message arguments
+        :type args: seq<str>
     """
     self.__fatal(msg % args)
 
@@ -728,8 +735,8 @@ def __UserDefaultAttrProp_set_enum_labels(self, enum_labels):
 
         Set default enumeration labels.
 
-        Parameters:
-            enum_labels (seq<str>): list of enumeration labels
+        :param enum_labels: list of enumeration labels
+        :type enum_labels: seq<str>
 
         New in PyTango 9.2.0
     """
@@ -783,8 +790,8 @@ def __doc_DeviceImpl():
 
         Set device state.
 
-        Parameters:
-            new_state (DevState): the new device state
+        :param new_state: the new device state
+        :type new_state: DevState
     """)
 
     document_method("get_state", """
@@ -792,8 +799,8 @@ def __doc_DeviceImpl():
 
         Get a COPY of the device state.
 
-        Return:
-            DevState: Current device state
+        :returns: Current device state
+        :rtype: DevState
     """)
 
     document_method("get_prev_state", """
@@ -801,8 +808,8 @@ def __doc_DeviceImpl():
 
         Get a COPY of the device's previous state.
 
-        Return:
-            DevState: the device's previous state
+        :returns: the device's previous state
+        :rtype: DevState
     """)
 
     document_method("get_name", """
@@ -810,8 +817,8 @@ def __doc_DeviceImpl():
 
         Get a COPY of the device name.
 
-        Return:
-            str: the device name
+        :returns: the device name
+        :rtype: str
     """)
 
     document_method("get_device_attr", """
@@ -819,8 +826,8 @@ def __doc_DeviceImpl():
 
         Get device multi attribute object.
 
-        Return:
-            MultiAttribute: the device's MultiAttribute object
+        :returns: the device's MultiAttribute object
+        :rtype: MultiAttribute
     """)
 
     document_method("register_signal", """
@@ -831,8 +838,8 @@ def __doc_DeviceImpl():
         Register this device as device to be informed when signal signo
         is sent to to the device server process
 
-        Parameters:
-            signo (int): signal identifier
+        :param signo: signal identifier
+        :type signo: int
     """)
 
     document_method("unregister_signal", """
@@ -843,8 +850,8 @@ def __doc_DeviceImpl():
         Unregister this device as device to be informed when signal signo
         is sent to to the device server process
 
-        Parameters:
-            signo (int): signal identifier
+        :param signo: signal identifier
+        :type signo: int
     """)
 
     document_method("get_status", """
@@ -852,8 +859,8 @@ def __doc_DeviceImpl():
 
         Get a COPY of the device status.
 
-        Return:
-            str: the device status
+        :returns: the device status
+        :rtype: str
     """)
 
     document_method("set_status", """
@@ -861,8 +868,8 @@ def __doc_DeviceImpl():
 
         Set device status.
 
-        Parameters:
-            new_status (str): the new device status
+        :param new_status: the new device status
+        :type new_status: str
     """)
 
     document_method("append_status", """
@@ -870,9 +877,10 @@ def __doc_DeviceImpl():
 
         Appends a string to the device status.
 
-        Parameters:
-            status (str): the string to be appened to the device status
-            new_line (bool): If true, appends a new line character before the string. Default is False
+        :param status: the string to be appened to the device status
+        :type status: str
+        :param new_line: If true, appends a new line character before the string. Default is False
+        :type new_line: bool
     """)
 
     document_method("dev_state", """
@@ -888,11 +896,10 @@ def __doc_DeviceImpl():
         returns the state This method can be redefined in sub-classes in case
         of the default behaviour does not fullfill the needs.
 
-        Return:
-            DevState: the device state
+        :returns: the device state
+        :rtype: DevState
 
-        Raises:
-            DevFailed: If it is necessary to read attribute(s) and a problem occurs during the reading
+        :raises DevFailed: If it is necessary to read attribute(s) and a problem occurs during the reading
     """)
 
     document_method("dev_status", """
@@ -905,11 +912,10 @@ def __doc_DeviceImpl():
         to the device status. This method can be redefined in sub-classes in case
         of the default behaviour does not fullfill the needs.
 
-        Return:
-            str: the device status
+        :returns: the device status
+        :rtype: str
 
-        Raises:
-            DevFailed: If it is necessary to read attribute(s) and a problem occurs during the reading
+        :raises DevFailed: If it is necessary to read attribute(s) and a problem occurs during the reading
     """)
 
     document_method("set_change_event", """
@@ -922,11 +928,13 @@ def __doc_DeviceImpl():
         change event are verified and the event is only pushed if they are fullfilled.
         If detect is set to false the event is fired without any value checking!
 
-        Parameters:
-            attr_name (str): attribute name
-            implemented (bool): True when the server fires change events manually.
-            detect (bool): Triggers the verification of the change event properties
-                           when set to true. Default value is true.
+        :param attr_name: attribute name
+        :type attr_name: str
+        :param implemented: True when the server fires change events manually.
+        :type implemented: bool
+        :param detect: Triggers the verification of the change event properties
+                       when set to true. Default value is true.
+        :type detect: bool
     """)
 
     document_method("set_archive_event", """
@@ -939,11 +947,13 @@ def __doc_DeviceImpl():
         archive event are verified and the event is only pushed if they are fullfilled.
         If detect is set to false the event is fired without any value checking!
 
-        Parameters:
-            attr_name (str): attribute name
-            implemented (bool): True when the server fires change events manually.
-            detect (bool): Triggers the verification of the change event properties
-                           when set to true. Default value is true.
+        :param attr_name: attribute name
+        :type attr_name: str
+        :param implemented: True when the server fires change events manually.
+        :type implemented: bool
+        :param detect: Triggers the verification of the change event properties
+                       when set to true. Default value is true.
+        :type detect: bool
     """)
 
     document_method("push_change_event", """
@@ -958,22 +968,27 @@ def __doc_DeviceImpl():
 
         The event is pushed to the notification daemon.
 
-        Parameters:
-            attr_name (str): attribute name
-            data: the data to be sent as attribute event data. Data must be compatible with the
-                  attribute type and format.
-                  for SPECTRUM and IMAGE attributes, data can be any type of sequence of elements
-                  compatible with the attribute type
-            str_data (str): special variation for DevEncoded data type. In this case 'data' must
-                            be a str or an object with the buffer interface.
-            except (DevFailed): Instead of data, you may want to send an exception.
-            dim_x (int): the attribute x length. Default value is 1
-            dim_y (int): the attribute y length. Default value is 0
-            time_stamp (double): the time stamp
-            quality (AttrQuality): the attribute quality factor
+        :param attr_name: attribute name
+        :type attr_name: str
+        :param data: the data to be sent as attribute event data. Data must be compatible with the
+                     attribute type and format.
+                     for SPECTRUM and IMAGE attributes, data can be any type of sequence of elements
+                     compatible with the attribute type
+        :param str_data: special variation for DevEncoded data type. In this case 'data' must
+                         be a str or an object with the buffer interface.
+        :type str_data: str
+        :param except: Instead of data, you may want to send an exception.
+        :type except: DevFailed
+        :param dim_x: the attribute x length. Default value is 1
+        :type dim_x: int
+        :param dim_y: the attribute y length. Default value is 0
+        :type dim_y: int
+        :param time_stamp: the time stamp
+        :type time_stamp: double
+        :param quality: the attribute quality factor
+        :type quality: AttrQuality
 
-        Raises:
-            DevFailed: If the attribute data type is not coherent.
+        :raises DevFailed: If the attribute data type is not coherent.
     """)
 
     document_method("push_archive_event", """
@@ -988,22 +1003,27 @@ def __doc_DeviceImpl():
 
         The event is pushed to the notification daemon.
 
-        Parameters:
-            attr_name (str): attribute name
-            data: the data to be sent as attribute event data. Data must be compatible with the
-                  attribute type and format.
-                  for SPECTRUM and IMAGE attributes, data can be any type of sequence of elements
-                  compatible with the attribute type
-            str_data (str): special variation for DevEncoded data type. In this case 'data' must
-                            be a str or an object with the buffer interface.
-            except (DevFailed): Instead of data, you may want to send an exception.
-            dim_x (int): the attribute x length. Default value is 1
-            dim_y (int): the attribute y length. Default value is 0
-            time_stamp (double): the time stamp
-            quality (AttrQuality): the attribute quality factor
+        :param attr_name: attribute name
+        :type attr_name: str
+        :param data: the data to be sent as attribute event data. Data must be compatible with the
+                     attribute type and format.
+                     for SPECTRUM and IMAGE attributes, data can be any type of sequence of elements
+                     compatible with the attribute type
+        :param str_data: special variation for DevEncoded data type. In this case 'data' must
+                         be a str or an object with the buffer interface.
+        :type str_data: str
+        :param except: Instead of data, you may want to send an exception.
+        :type except: DevFailed
+        :param dim_x: the attribute x length. Default value is 1
+        :type dim_x: int
+        :param dim_y: the attribute y length. Default value is 0
+        :type dim_y: int
+        :param time_stamp: the time stamp
+        :type time_stamp: double
+        :param quality: the attribute quality factor
+        :type quality: AttrQuality
 
-        Raises:
-            DevFailed: If the attribute data type is not coherent.
+        :raises DevFailed: If the attribute data type is not coherent.
     """)
 
     document_method("push_event", """
@@ -1017,23 +1037,29 @@ def __doc_DeviceImpl():
 
         The event is pushed to the notification daemon.
 
-        Parameters:
-            attr_name (str): attribute name
-            filt_names (sequence<str>): the filterable fields name
-            filt_vals (sequence<double>): the filterable fields value
-            data: the data to be sent as attribute event data. Data must be compatible with the
-                  attribute type and format.
-                  for SPECTRUM and IMAGE attributes, data can be any type of sequence of elements
-                  compatible with the attribute type
-            str_data (str): special variation for DevEncoded data type. In this case 'data' must
-                            be a str or an object with the buffer interface.
-            dim_x (int): the attribute x length. Default value is 1
-            dim_y (int): the attribute y length. Default value is 0
-            time_stamp (double): the time stamp
-            quality (AttrQuality): the attribute quality factor
+        :param attr_name: attribute name
+        :type attr_name: str
+        :param filt_names: the filterable fields name
+        :type filt_names: sequence<str>
+        :param filt_vals: the filterable fields value
+        :type filt_vals: sequence<double>
+        :param data: the data to be sent as attribute event data. Data must be compatible with the
+                     attribute type and format.
+                     for SPECTRUM and IMAGE attributes, data can be any type of sequence of elements
+                     compatible with the attribute type
+        :param str_data: special variation for DevEncoded data type. In this case 'data' must
+                         be a str or an object with the buffer interface.
+        :type str_data: str
+        :param dim_x: the attribute x length. Default value is 1
+        :type dim_x: int
+        :param dim_y: the attribute y length. Default value is 0
+        :type dim_y: int
+        :param time_stamp: the time stamp
+        :type time_stamp: double
+        :param quality: the attribute quality factor
+        :type quality: AttrQuality
 
-        Raises:
-            DevFailed: If the attribute data type is not coherent.
+        :raises DevFailed: If the attribute data type is not coherent.
     """)
 
     document_method("push_data_ready_event", """
@@ -1046,12 +1072,12 @@ def __doc_DeviceImpl():
         The method needs only the attribue name and an optional
         "counter" which will be passed unchanged within the event
 
-        Parameters:
-            attr_name (str): attribute name
-            counter (int): the user counter
+        :param attr_name: attribute name
+        :type attr_name: str
+        :param counter: the user counter
+        :type counter: int
 
-        Raises:
-            DevFailed: If the attribute name is unknown.
+        :raises DevFailed: If the attribute name is unknown.
     """)
 
     document_method("push_pipe_event", """
@@ -1061,12 +1087,12 @@ def __doc_DeviceImpl():
 
         Push a pipe event for the given blob.
 
-        Parameters:
-            pipe_name (str): pipe name
-            blob (DevicePipeBlob): the blob data
+        :param pipe_name: pipe name
+        :type pipe_name: str
+        :param blob: the blob data
+        :type blob: DevicePipeBlob
 
-        Raises:
-            DevFailed: If the pipe name is unknown.
+        :raises DevFailed: If the pipe name is unknown.
 
         New in PyTango 9.2.2
     """)
@@ -1076,8 +1102,8 @@ def __doc_DeviceImpl():
 
         Returns the Logger object for this device
 
-        Return:
-            Logger: the Logger object for this device
+        :returns: the Logger object for this device
+        :rtype: Logger
     """)
 
     document_method("get_exported_flag", """
@@ -1085,8 +1111,8 @@ def __doc_DeviceImpl():
 
         Returns the state of the exported flag
 
-        Return:
-            bool: the state of the exported flag
+        :returns: the state of the exported flag
+        :rtype: bool
 
         New in PyTango 7.1.2
     """)
@@ -1096,8 +1122,8 @@ def __doc_DeviceImpl():
 
         Returns the poll ring depth
 
-        Return:
-            int: the poll ring depth
+        :returns: the poll ring depth
+        :rtype: int
 
         New in PyTango 7.1.2
     """)
@@ -1107,8 +1133,8 @@ def __doc_DeviceImpl():
 
         Returns the poll old factor
 
-        Return:
-            int: the poll old factor
+        :returns: the poll old factor
+        :rtype: int
 
         New in PyTango 7.1.2
     """)
@@ -1118,8 +1144,8 @@ def __doc_DeviceImpl():
 
         Returns if it is polled
 
-        Return:
-            bool: True if it is polled or False otherwise
+        :returns: True if it is polled or False otherwise
+        :rtype: bool
 
         New in PyTango 7.1.2
     """)
@@ -1129,8 +1155,8 @@ def __doc_DeviceImpl():
 
         Returns a COPY of the list of polled commands
 
-        Return:
-            sequence<str>: a COPY of the list of polled commands
+        :returns: a COPY of the list of polled commands
+        :rtype: sequence<str>
 
         New in PyTango 7.1.2
     """)
@@ -1140,8 +1166,8 @@ def __doc_DeviceImpl():
 
         Returns a COPY of the list of polled attributes
 
-        Return:
-            sequence<str>: a COPY of the list of polled attributes
+        :returns: a COPY of the list of polled attributes
+        :rtype: sequence<str>
 
         New in PyTango 7.1.2
     """)
@@ -1151,8 +1177,8 @@ def __doc_DeviceImpl():
 
         Returns a COPY of the list of non automatic polled commands
 
-        Return:
-            sequence<str>: a COPY of the list of non automatic polled commands
+        :returns: a COPY of the list of non automatic polled commands
+        :rtype: sequence<str>
 
         New in PyTango 7.1.2
     """)
@@ -1162,8 +1188,8 @@ def __doc_DeviceImpl():
 
         Returns a COPY of the list of non automatic polled attributes
 
-        Return:
-            sequence<str>: a COPY of the list of non automatic polled attributes
+        :returns: a COPY of the list of non automatic polled attributes
+        :rtype: sequence<str>
 
         New in PyTango 7.1.2
     """)
@@ -1175,8 +1201,8 @@ def __doc_DeviceImpl():
         Stop all polling for a device. if the device is polled, call this
         method before deleting it.
 
-        Parameters:
-            with_db_upd (bool): Is it necessary to update db?
+        :param with_db_upd: Is it necessary to update db?
+        :type with_db_upd: bool
 
         New in PyTango 7.1.2
     """)
@@ -1187,11 +1213,11 @@ def __doc_DeviceImpl():
         Returns the attribute polling period (ms) or 0 if the attribute
         is not polled.
 
-        Parameters:
-            attr_name (str): attribute name
+        :param attr_name: attribute name
+        :type attr_name: str
 
-        Return:
-            int: attribute polling period (ms) or 0 if it is not polled
+        :returns: attribute polling period (ms) or 0 if it is not polled
+        :rtype: int
 
         New in PyTango 8.0.0
     """)
@@ -1202,11 +1228,11 @@ def __doc_DeviceImpl():
         Returns the command polling period (ms) or 0 if the command
         is not polled.
 
-        Parameters:
-            cmd_name (str): command name
+        :param cmd_name: command name
+        :type cmd_name: str
 
-        Return:
-            int: command polling period (ms) or 0 if it is not polled
+        :returns: command polling period (ms) or 0 if it is not polled
+        :rtype: int
 
         New in PyTango 8.0.0
     """)
@@ -1220,13 +1246,12 @@ def __doc_DeviceImpl():
         The method throws an exception if the
         command is not defined or needs an input value.
 
-        Parameters:
-            cmd_name (str): the command name
+        :param cmd_name: the command name
+        :type cmd_name: str
 
-        Raises:
-            DevFailed
-            API_IncompatibleCmdArgumentType
-            API_CommandNotFound
+        :raises DevFailed:
+        :raises API_IncompatibleCmdArgumentType:
+        :raises API_CommandNotFound:
 
         New in PyTango 7.1.2
     """)
@@ -1236,8 +1261,8 @@ def __doc_DeviceImpl():
 
         Returns the IDL version.
 
-        Return:
-            int: the IDL version
+        :returns: the IDL version
+        :rtype: int
 
         New in PyTango 7.1.2
     """)
@@ -1247,11 +1272,11 @@ def __doc_DeviceImpl():
 
         Returns the command poll ring depth.
 
-        Parameters:
-            cmd_name (str): the command name
+        :param cmd_name: the command name
+        :type cmd_name: str
 
-        Return:
-            int: the command poll ring depth
+        :returns: the command poll ring depth
+        :rtype: int
 
         New in PyTango 7.1.2
     """)
@@ -1261,11 +1286,11 @@ def __doc_DeviceImpl():
 
         Returns the attribute poll ring depth.
 
-        Parameters:
-            attr_name (str): the attribute name
+        :param attr_name: the attribute name
+        :type attr_name: str
 
-        Return:
-            int: the attribute poll ring depth
+        :returns: the attribute poll ring depth
+        :rtype: int
 
         New in PyTango 7.1.2
     """)
@@ -1275,8 +1300,8 @@ def __doc_DeviceImpl():
 
         Returns if this device is locked by a client.
 
-        Return:
-            bool: True if it is locked or False otherwise
+        :returns: True if it is locked or False otherwise
+        :rtype: bool
 
         New in PyTango 7.1.2
     """)
@@ -1286,8 +1311,8 @@ def __doc_DeviceImpl():
 
         Returns the min poll period.
 
-        Return:
-            int: the min poll period
+        :returns: the min poll period
+        :rtype: int
 
         New in PyTango 7.2.0
     """)
@@ -1297,8 +1322,8 @@ def __doc_DeviceImpl():
 
         Returns the min command poll period.
 
-        Return:
-            seq<str>: the min command poll period
+        :returns: the min command poll period
+        :rtype: seq<str>
 
         New in PyTango 7.2.0
     """)
@@ -1308,8 +1333,8 @@ def __doc_DeviceImpl():
 
         Returns the min attribute poll period
 
-        Return:
-            seq<str>: the min attribute poll period
+        :returns: the min attribute poll period
+        :rtype: seq<str>
 
         New in PyTango 7.2.0
     """)
@@ -1319,10 +1344,11 @@ def __doc_DeviceImpl():
 
         Push an attribute configuration event.
 
-        Parameters:
-            attr (Attribute): the attribute for which the configuration event
-                              will be sent.
-      New in PyTango 7.2.1
+        :param attr: the attribute for which the configuration event
+                     will be sent.
+        :type attr: Attribute
+
+        New in PyTango 7.2.1
     """)
 
     document_method("push_pipe_event", """
@@ -1330,8 +1356,7 @@ def __doc_DeviceImpl():
 
         Push an pipe event.
 
-        Parameters:
-            blob: the blob which pipe event will be send.
+        :param blob: the blob which pipe event will be send.
 
         New in PyTango 9.2.2
     """)
@@ -1349,12 +1374,13 @@ def __doc_DeviceImpl():
 
         The device interface change event is not supported by this method.
 
-        Parameters:
-            att_name (str): the attribute name
-            event_type (EventType): the event type
+        :param att_name: the attribute name
+        :type att_name: str
+        :param event_type: the event type
+        :type event_type: EventType
 
-        Return:
-            bool: True if there is at least one listener or False otherwise
+        :returns: True if there is at least one listener or False otherwise
+        :rtype: bool
     """)
 
 
@@ -1377,8 +1403,7 @@ def __doc_extra_DeviceImpl(cls):
         any command is executed. This method can be redefined in sub-classes
         in case of the default behaviour does not fullfill the needs
 
-        Raises:
-            DevFailed: This method does not throw exception but a redefined method can.
+        :raises DevFailed: This method does not throw exception but a redefined method can.
     """)
 
     document_method("read_attr_hardware", """
@@ -1390,12 +1415,11 @@ def __doc_extra_DeviceImpl(cls):
         the hardware involved in a a read attribute CORBA call. This method
         must be redefined in sub-classes in order to support attribute reading
 
-        Parameters:
-            attr_list (sequence<int>): list of indices in the device object attribute vector
-                                       of an attribute to be read.
+        :param attr_list: list of indices in the device object attribute vector
+                          of an attribute to be read.
+        :type attr_list: sequence<int>
 
-        Raises:
-            DevFailed: This method does not throw exception but a redefined method can.
+        :raises DevFailed: This method does not throw exception but a redefined method can.
     """)
 
     document_method("write_attr_hardware", """
@@ -1407,12 +1431,11 @@ def __doc_extra_DeviceImpl(cls):
         the hardware involved in a a write attribute. This method must be
         redefined in sub-classes in order to support writable attribute
 
-        Parameters:
-            attr_list (sequence<int>): list of indices in the device object attribute vector
-                                       of an attribute to be written.
+        :param attr_list: list of indices in the device object attribute vector
+                          of an attribute to be written.
+        :type attr_list: sequence<int>
 
-        Raises:
-            DevFailed: This method does not throw exception but a redefined method can.
+        :raises DevFailed: This method does not throw exception but a redefined method can.
     """)
 
     document_method("signal_handler", """
@@ -1424,11 +1447,10 @@ def __doc_extra_DeviceImpl(cls):
         This method is defined as virtual and then, can be redefined following
         device needs.
 
-        Parameters:
-            signo (int): the signal number
+        :param signo: the signal number
+        :type signo: int
 
-        Raises:
-            DevFailed: This method does not throw exception but a redefined method can.
+        :raises DevFailed: This method does not throw exception but a redefined method can.
     """)
 
     copy_doc(cls, "dev_state")
@@ -1448,8 +1470,8 @@ def __doc_Attribute():
 
         Check if the attribute has an associated writable attribute.
 
-        Return:
-            bool: True if there is an associated writable attribute
+        :returns: True if there is an associated writable attribute
+        :rtype: bool
     """)
 
     document_method("is_min_alarm", """
@@ -1457,8 +1479,8 @@ def __doc_Attribute():
 
         Check if the attribute is in minimum alarm condition.
 
-        Return:
-            bool: true if the attribute is in alarm condition (read value below the min. alarm).
+        :returns: true if the attribute is in alarm condition (read value below the min. alarm).
+        :rtype: bool
     """)
 
     document_method("is_max_alarm", """
@@ -1466,8 +1488,8 @@ def __doc_Attribute():
 
         Check if the attribute is in maximum alarm condition.
 
-        Return:
-            bool: true if the attribute is in alarm condition (read value above the max. alarm).
+        :returns: true if the attribute is in alarm condition (read value above the max. alarm).
+        :rtype: bool
     """)
 
     document_method("is_min_warning", """
@@ -1475,8 +1497,8 @@ def __doc_Attribute():
 
         Check if the attribute is in minimum warning condition.
 
-        Return:
-            bool: true if the attribute is in warning condition (read value below the min. warning).
+        :returns: true if the attribute is in warning condition (read value below the min. warning).
+        :rtype: bool
     """)
 
     document_method("is_max_warning", """
@@ -1484,8 +1506,8 @@ def __doc_Attribute():
 
         Check if the attribute is in maximum warning condition.
 
-        Return:
-            bool: true if the attribute is in warning condition (read value above the max. warning).
+        :returns: true if the attribute is in warning condition (read value above the max. warning).
+        :rtype: bool
     """)
 
     document_method("is_rds_alarm", """
@@ -1493,8 +1515,8 @@ def __doc_Attribute():
 
         Check if the attribute is in RDS alarm condition.
 
-        Return:
-            bool: true if the attribute is in RDS condition (Read Different than Set).
+        :returns: true if the attribute is in RDS condition (Read Different than Set).
+        :rtype: bool
     """)
 
     document_method("is_polled", """
@@ -1502,8 +1524,8 @@ def __doc_Attribute():
 
         Check if the attribute is polled.
 
-        Return:
-            bool: true if the attribute is polled.
+        :returns: true if the attribute is polled.
+        :rtype: bool
     """)
 
     document_method("check_alarm", """
@@ -1511,11 +1533,10 @@ def __doc_Attribute():
 
         Check if the attribute read value is below/above the alarm level.
 
-        Return:
-            bool: true if the attribute is in alarm condition.
+        :returns: true if the attribute is in alarm condition.
+        :rtype: bool
 
-        Raises:
-            DevFailed: If no alarm level is defined.
+        :raises DevFailed: If no alarm level is defined.
     """)
 
     document_method("get_writable", """
@@ -1523,8 +1544,8 @@ def __doc_Attribute():
 
         Get the attribute writable type (RO/WO/RW).
 
-        Return:
-            AttrWriteType: The attribute write type.
+        :returns: The attribute write type.
+        :rtype: AttrWriteType
     """)
 
     document_method("get_name", """
@@ -1532,8 +1553,8 @@ def __doc_Attribute():
 
         Get attribute name.
 
-        Return:
-            str: The attribute name
+        :returns: The attribute name
+        :rtype: str
     """)
 
     document_method("get_data_type", """
@@ -1541,8 +1562,8 @@ def __doc_Attribute():
 
         Get attribute data type.
 
-        Return:
-            int: the attribute data type
+        :returns: the attribute data type
+        :rtype: int
     """)
 
     document_method("get_data_format", """
@@ -1550,8 +1571,8 @@ def __doc_Attribute():
 
         Get attribute data format.
 
-        Return:
-            AttrDataFormat: the attribute data format
+        :returns: the attribute data format
+        :rtype: AttrDataFormat
     """)
 
     document_method("get_assoc_name", """
@@ -1559,8 +1580,8 @@ def __doc_Attribute():
 
         Get name of the associated writable attribute.
 
-        Return:
-            str: the associated writable attribute name
+        :returns: the associated writable attribute name
+        :rtype: str
     """)
 
     document_method("get_assoc_ind", """
@@ -1568,8 +1589,8 @@ def __doc_Attribute():
 
         Get index of the associated writable attribute.
 
-        Return:
-            int: the index in the main attribute vector of the associated writable attribute
+        :returns: the index in the main attribute vector of the associated writable attribute
+        :rtype: int
     """)
 
     document_method("set_assoc_ind", """
@@ -1577,8 +1598,8 @@ def __doc_Attribute():
 
         Set index of the associated writable attribute.
 
-        Parameters:
-            index (int): The new index in the main attribute vector of the associated writable attribute
+        :param index: The new index in the main attribute vector of the associated writable attribute
+        :type index: int
     """)
 
     document_method("get_date", """
@@ -1586,8 +1607,8 @@ def __doc_Attribute():
 
         Get a COPY of the attribute date.
 
-        Return:
-            TimeVal: the attribute date
+        :returns: the attribute date
+        :rtype: TimeVal
     """)
 
     document_method("set_date", """
@@ -1595,8 +1616,8 @@ def __doc_Attribute():
 
         Set attribute date.
 
-        Parameters:
-            new_date (TimeVal): the attribute date
+        :param new_date: the attribute date
+        :type new_date: TimeVal
     """)
 
     document_method("get_label", """
@@ -1604,8 +1625,8 @@ def __doc_Attribute():
 
         Get attribute label property.
 
-        Return:
-            str: he attribute label
+        :returns: he attribute label
+        :rtype: str
     """)
 
     document_method("get_quality", """
@@ -1613,8 +1634,8 @@ def __doc_Attribute():
 
         Get a COPY of the attribute data quality.
 
-        Return:
-            AttrQuality: the attribute data quality
+        :returns: the attribute data quality
+        :rtype: AttrQuality
     """)
 
     document_method("set_quality", """
@@ -1622,9 +1643,10 @@ def __doc_Attribute():
 
         Set attribute data quality.
 
-        Parameters:
-            quality (AttrQuality): the new attribute data quality
-            send_event (bool): true if a change event should be sent. Default is false.
+        :param quality: the new attribute data quality
+        :type quality: AttrQuality
+        :param send_event: true if a change event should be sent. Default is false.
+        :type send_event: bool
     """)
 
     document_method("get_data_size", """
@@ -1632,8 +1654,8 @@ def __doc_Attribute():
 
         Get attribute data size.
 
-        Return:
-            int: the attribute data size
+        :returns: the attribute data size
+        :rtype: int
     """)
 
     document_method("get_x", """
@@ -1641,8 +1663,8 @@ def __doc_Attribute():
 
         Get attribute data size in x dimension.
 
-        Return:
-            int: the attribute data size in x dimension. Set to 1 for scalar attribute
+        :returns: the attribute data size in x dimension. Set to 1 for scalar attribute
+        :rtype: int
     """)
 
     document_method("get_max_dim_x", """
@@ -1650,8 +1672,8 @@ def __doc_Attribute():
 
         Get attribute maximum data size in x dimension.
 
-        Return:
-            int: the attribute maximum data size in x dimension. Set to 1 for scalar attribute
+        :returns: the attribute maximum data size in x dimension. Set to 1 for scalar attribute
+        :rtype: int
     """)
 
     document_method("get_y", """
@@ -1659,8 +1681,8 @@ def __doc_Attribute():
 
         Get attribute data size in y dimension.
 
-        Return:
-            int: the attribute data size in y dimension. Set to 1 for scalar attribute
+        :returns: the attribute data size in y dimension. Set to 1 for scalar attribute
+        :rtype: int
     """)
 
     document_method("get_max_dim_y", """
@@ -1668,8 +1690,8 @@ def __doc_Attribute():
 
         Get attribute maximum data size in y dimension.
 
-        Return:
-            int: the attribute maximum data size in y dimension. Set to 0 for scalar attribute
+        :returns: the attribute maximum data size in y dimension. Set to 0 for scalar attribute
+        :rtype: int
     """)
 
     document_method("get_polling_period", """
@@ -1677,8 +1699,8 @@ def __doc_Attribute():
 
         Get attribute polling period.
 
-        Return:
-            int: The attribute polling period in mS. Set to 0 when the attribute is not polled
+        :returns: The attribute polling period in mS. Set to 0 when the attribute is not polled
+        :rtype: int
     """)
 
     document_method("set_attr_serial_model", """
@@ -1688,10 +1710,10 @@ def __doc_Attribute():
 
         This method allows the user to choose the attribute serialization model.
 
-        Parameters:
-            ser_model (AttrSerialModel): The new serialisation model. The
-                        serialization model must be one of ATTR_BY_KERNEL,
-                        ATTR_BY_USER or ATTR_NO_SYNC
+        :param ser_model: The new serialisation model. The
+                          serialization model must be one of ATTR_BY_KERNEL,
+                          ATTR_BY_USER or ATTR_NO_SYNC
+        :type ser_model: AttrSerialModel
 
         New in PyTango 7.1.0
     """)
@@ -1701,8 +1723,8 @@ def __doc_Attribute():
 
         Get attribute serialization model.
 
-        Return:
-            AttrSerialModel: The attribute serialization model
+        :returns: The attribute serialization model
+        :rtype: AttrSerialModel
 
         New in PyTango 7.1.0
     """)
@@ -1718,20 +1740,22 @@ def __doc_Attribute():
         This method also stores the date when it is called and initializes the
         attribute quality factor.
 
-        Parameters:
-            data: the data to be set. Data must be compatible with the attribute type and format.
-                  In the DEPRECATED form for SPECTRUM and IMAGE attributes, data
-                  can be any type of FLAT sequence of elements compatible with the
-                  attribute type.
-                  In the new form (without dim_x or dim_y) data should be any
-                  sequence for SPECTRUM and a SEQUENCE of equal-length SEQUENCES
-                  for IMAGE attributes.
-                  The recommended sequence is a C continuous and aligned numpy
-                  array, as it can be optimized.
-            str_data (str): special variation for DevEncoded data type. In this case 'data' must
-                            be a str or an object with the buffer interface.
-            dim_x (int): [DEPRECATED] the attribute x length. Default value is 1
-            dim_y (int): [DEPRECATED] the attribute y length. Default value is 0
+        :param data: the data to be set. Data must be compatible with the attribute type and format.
+                     In the DEPRECATED form for SPECTRUM and IMAGE attributes, data
+                     can be any type of FLAT sequence of elements compatible with the
+                     attribute type.
+                     In the new form (without dim_x or dim_y) data should be any
+                     sequence for SPECTRUM and a SEQUENCE of equal-length SEQUENCES
+                     for IMAGE attributes.
+                     The recommended sequence is a C continuous and aligned numpy
+                     array, as it can be optimized.
+        :param str_data: special variation for DevEncoded data type. In this case 'data' must
+                         be a str or an object with the buffer interface.
+        :type str_data: str
+        :param dim_x: [DEPRECATED] the attribute x length. Default value is 1
+        :type dim_x: int
+        :param dim_y: [DEPRECATED] the attribute y length. Default value is 0
+        :type dim_y: int
     """)
 
     document_method("set_value_date_quality", """
@@ -1744,22 +1768,26 @@ def __doc_Attribute():
         This method stores the attribute read value, the date and the attribute quality
         factor inside the object.
 
-        Parameters:
-            data: the data to be set. Data must be compatible with the attribute type and format.
-                  In the DEPRECATED form for SPECTRUM and IMAGE attributes, data
-                  can be any type of FLAT sequence of elements compatible with the
-                  attribute type.
-                  In the new form (without dim_x or dim_y) data should be any
-                  sequence for SPECTRUM and a SEQUENCE of equal-length SEQUENCES
-                  for IMAGE attributes.
-                  The recommended sequence is a C continuous and aligned numpy
-                  array, as it can be optimized.
-            str_data (str): special variation for DevEncoded data type. In this case 'data' must
-                            be a str or an object with the buffer interface.
-            dim_x (int): [DEPRECATED] the attribute x length. Default value is 1
-            dim_y (int): [DEPRECATED] the attribute y length. Default value is 0
-            time_stamp (double): the time stamp
-            quality (AttrQuality): the attribute quality factor
+        :param data: the data to be set. Data must be compatible with the attribute type and format.
+                     In the DEPRECATED form for SPECTRUM and IMAGE attributes, data
+                     can be any type of FLAT sequence of elements compatible with the
+                     attribute type.
+                     In the new form (without dim_x or dim_y) data should be any
+                     sequence for SPECTRUM and a SEQUENCE of equal-length SEQUENCES
+                     for IMAGE attributes.
+                     The recommended sequence is a C continuous and aligned numpy
+                     array, as it can be optimized.
+        :param str_data: special variation for DevEncoded data type. In this case 'data' must
+                         be a str or an object with the buffer interface.
+        :type str_data: str
+        :param dim_x: [DEPRECATED] the attribute x length. Default value is 1
+        :type dim_x: int
+        :param dim_y: [DEPRECATED] the attribute y length. Default value is 0
+        :type dim_y: int
+        :param time_stamp: the time stamp
+        :type time_stamp: double
+        :param quality: the attribute quality factor
+        :type quality: AttrQuality
     """)
 
     document_method("set_change_event", """
@@ -1773,10 +1801,11 @@ def __doc_Attribute():
         are fullfilled. If detect is set to false the event is fired without
         any value checking!
 
-        Parameters:
-            implemented (bool): True when the server fires change events manually.
-            detect (bool): (optional, default is True) Triggers the verification of
-                           the change event properties when set to true.
+        :param implemented: True when the server fires change events manually.
+        :type implemented: bool
+        :param detect: (optional, default is True) Triggers the verification of
+                       the change event properties when set to true.
+        :type detect: bool
 
         New in PyTango 7.1.0
     """)
@@ -1791,10 +1820,11 @@ def __doc_Attribute():
         is set to true, the criteria specified for the archive event are verified
         and the event is only pushed if they are fullfilled.
 
-        Parameters:
-            implemented (bool): True when the server fires archive events manually.
-            detect (bool): (optional, default is True) Triggers the verification of
-                           the archive event properties when set to true.
+        :param implemented: True when the server fires archive events manually.
+        :type implemented: bool
+        :param detect: (optional, default is True) Triggers the verification of
+                       the archive event properties when set to true.
+        :type detect: bool
 
         New in PyTango 7.1.0
     """)
@@ -1804,8 +1834,8 @@ def __doc_Attribute():
 
         Check if the change event is fired manually (without polling) for this attribute.
 
-        Return:
-            bool: True if a manual fire change event is implemented.
+        :returns: True if a manual fire change event is implemented.
+        :rtype: bool
 
         New in PyTango 7.1.0
     """)
@@ -1816,8 +1846,8 @@ def __doc_Attribute():
         Check if the change event criteria should be checked when firing the
         event manually.
 
-        Return:
-            bool: True if a change event criteria will be checked.
+        :returns: True if a change event criteria will be checked.
+        :rtype: bool
 
         New in PyTango 7.1.0
     """)
@@ -1827,8 +1857,8 @@ def __doc_Attribute():
 
         Check if the archive event is fired manually (without polling) for this attribute.
 
-        Return:
-            bool: True if a manual fire archive event is implemented.
+        :returns: True if a manual fire archive event is implemented.
+        :rtype: bool
 
         New in PyTango 7.1.0
     """)
@@ -1839,8 +1869,8 @@ def __doc_Attribute():
         Check if the archive event criteria should be checked when firing the
         event manually.
 
-        Return:
-            bool: True if a archive event criteria will be checked.
+        :returns: True if a archive event criteria will be checked.
+        :rtype: bool
 
         New in PyTango 7.1.0
     """)
@@ -1850,8 +1880,8 @@ def __doc_Attribute():
 
         Set a flag to indicate that the server fires data ready events.
 
-        Parameters:
-            implemented (bool): True when the server fires data ready events manually.
+        :param implemented: True when the server fires data ready events manually.
+        :type implemented: bool
 
         New in PyTango 7.2.0
     """)
@@ -1862,8 +1892,8 @@ def __doc_Attribute():
         Check if the data ready event is fired manually (without polling)
         for this attribute.
 
-        Return:
-            bool: True if a manual fire data ready event is implemented.
+        :returns: True if a manual fire data ready event is implemented.
+        :rtype: bool
 
         New in PyTango 7.2.0
     """)
@@ -1898,8 +1928,8 @@ def __doc_WAttribute():
         Get attribute minimum value or throws an exception if the
         attribute does not have a minimum value.
 
-        Return:
-            obj: an object with the python minimum value
+        :returns: an object with the python minimum value
+        :rtype: obj
     """)
 
     document_method("get_max_value", """
@@ -1908,8 +1938,8 @@ def __doc_WAttribute():
         Get attribute maximum value or throws an exception if the
         attribute does not have a maximum value.
 
-        Return:
-            obj: an object with the python maximum value
+        :returns: an object with the python maximum value
+        :rtype: obj
     """)
 
     document_method("set_min_value", """
@@ -1917,9 +1947,8 @@ def __doc_WAttribute():
 
         Set attribute minimum value.
 
-        Parameters:
-            data: the attribute minimum value. python data type must be compatible
-                  with the attribute data format and type.
+        :param data: the attribute minimum value. python data type must be compatible
+                     with the attribute data format and type.
     """)
 
     document_method("set_max_value", """
@@ -1927,9 +1956,8 @@ def __doc_WAttribute():
 
         Set attribute maximum value.
 
-        Parameters:
-            data: the attribute maximum value. python data type must be compatible
-                  with the attribute data format and type.
+        :param data: the attribute maximum value. python data type must be compatible
+                     with the attribute data format and type.
     """)
 
     document_method("is_min_value", """
@@ -1937,8 +1965,8 @@ def __doc_WAttribute():
 
         Check if the attribute has a minimum value.
 
-        Return:
-            bool: true if the attribute has a minimum value defined
+        :returns: true if the attribute has a minimum value defined
+        :rtype: bool
     """)
 
     document_method("is_max_value", """
@@ -1946,8 +1974,8 @@ def __doc_WAttribute():
 
         Check if the attribute has a maximum value.
 
-        Return:
-            bool: true if the attribute has a maximum value defined
+        :returns: true if the attribute has a maximum value defined
+        :rtype: bool
     """)
 
     document_method("get_write_value_length", """
@@ -1955,8 +1983,8 @@ def __doc_WAttribute():
 
         Retrieve the new value length (data number) for writable attribute.
 
-        Return:
-            int: the new value data length
+        :returns: the new value data length
+        :rtype: int
     """)
 
     #    document_method("set_write_value", """
@@ -1964,12 +1992,13 @@ def __doc_WAttribute():
     #
     #        Set the writable attribute value.
     #
-    #        Parameters:
-    #            data: the data to be set. Data must be compatible with the attribute type and format.
-    #                  for SPECTRUM and IMAGE attributes, data can be any type of sequence of elements
-    #                  compatible with the attribute type
-    #            dim_x (int): the attribute set value x length. Default value is 1
-    #            dim_y (int): the attribute set value y length. Default value is 0
+    #        :param data: the data to be set. Data must be compatible with the attribute type and format.
+    #                     for SPECTRUM and IMAGE attributes, data can be any type of sequence of elements
+    #                     compatible with the attribute type
+    #        :param dim_x: the attribute set value x length. Default value is 1
+    #        :type dim_x: int
+    #        :param dim_y: the attribute set value y length. Default value is 0
+    #        :type dim_y: int
     #    """)
 
     document_method("get_write_value", """
@@ -1978,12 +2007,13 @@ def __doc_WAttribute():
 
         Retrieve the new value for writable attribute.
 
-        Parameters:
-            extract_as (ExtractAs): 
-            lst (list): [out] a list object that will be filled with the attribute write value (DEPRECATED)
+        :param extract_as:
+        :type extract_as: ExtractAs
+        :param lst: [out] a list object that will be filled with the attribute write value (DEPRECATED)
+        :type lst: list
 
-        Return:
-            obj: the attribute write value.
+        :returns: the attribute write value.
+        :rtype: obj
     """)
 
 
@@ -2005,14 +2035,13 @@ def __doc_MultiClassAttribute():
         Get the :class:`~tango.Attr` object for the attribute with
         name passed as parameter.
 
-        Parameters:
-            attr_name (str): attribute name
+        :param attr_name: attribute name
+        :type attr_name: str
 
-        Return:
-            Attr: the attribute object
+        :returns: the attribute object
+        :rtype: Attr
 
-        Raises:
-            DevFailed: If the attribute is not defined.
+        :raises DevFailed: If the attribute is not defined.
 
         New in PyTango 7.2.1
     """)
@@ -2025,9 +2054,10 @@ def __doc_MultiClassAttribute():
 
         Does nothing if the attribute does not exist.
 
-        Parameters:
-            attr_name (str): attribute name
-            cl_name (str): the attribute class name
+        :param attr_name: attribute name
+        :type attr_name: str
+        :param cl_name: the attribute class name
+        :type cl_name: str
 
         New in PyTango 7.2.1
     """)
@@ -2037,8 +2067,8 @@ def __doc_MultiClassAttribute():
 
         Get the list of :class:`~tango.Attr` for this device class.
 
-        Return:
-            seq<Attr>: the list of attribute objects
+        :returns: the list of attribute objects
+        :rtype: seq<Attr>
 
         New in PyTango 7.2.1
     """)
@@ -2063,14 +2093,13 @@ def __doc_MultiAttribute():
         name passed as parameter. The equality on attribute name is case
         independant.
 
-        Parameters:
-            attr_name (str): attribute name
+        :param attr_name: attribute name
+        :type attr_name: str
 
-        Return:
-            Attribute: the attribute object
+        :returns: the attribute object
+        :rtype: Attribute
 
-        Raises:
-            DevFailed: If the attribute is not defined.
+        :raises DevFailed: If the attribute is not defined.
     """)
 
     document_method("get_attr_by_ind", """
@@ -2081,11 +2110,11 @@ def __doc_MultiAttribute():
         This method returns an :class:`~tango.Attribute` object from the
         index in the main attribute vector.
 
-        Parameters:
-            ind (int): the attribute index
+        :param ind: the attribute index
+        :type ind: int
 
-        Return:
-            Attribute: the attribute object
+        :returns: the attribute object
+        :rtype: Attribute
     """)
 
     document_method("get_w_attr_by_name", """
@@ -2097,14 +2126,13 @@ def __doc_MultiAttribute():
         name passed as parameter. The equality on attribute name is case
         independant.
 
-        Parameters:
-            attr_name (str): attribute name
+        :param attr_name: attribute name
+        :type attr_name: str
 
-        Return:
-            WAttribute: the attribute object
+        :returns: the attribute object
+        :rtype: WAttribute
 
-        Raises:
-            DevFailed: If the attribute is not defined.
+        :raises DevFailed: If the attribute is not defined.
     """)
 
     document_method("get_w_attr_by_ind", """
@@ -2115,11 +2143,11 @@ def __doc_MultiAttribute():
         This method returns an :class:`~tango.WAttribute` object from the
         index in the main attribute vector.
 
-        Parameters:
-            ind (int): the attribute index
+        :param ind: the attribute index
+        :type ind: int
 
-        Return:
-            WAttribute: the attribute object
+        :returns: the attribute object
+        :rtype: WAttribute
     """)
 
     document_method("get_attr_ind_by_name", """
@@ -2131,14 +2159,13 @@ def __doc_MultiAttribute():
         :class:`~tango.MultiAttribute` object) of an attribute with a
         given name. The name equality is case independant.
 
-        Parameters:
-            attr_name (str): attribute name
+        :param attr_name: attribute name
+        :type attr_name: str
 
-        Return:
-            int: the attribute index
+        :returns: the attribute index
+        :rtype: int
 
-        Raises:
-            DevFailed: If the attribute is not found in the vector.
+        :raises DevFailed: If the attribute is not found in the vector.
 
         New in PyTango 7.0.0
     """)
@@ -2148,8 +2175,8 @@ def __doc_MultiAttribute():
 
         Get attribute number.
 
-        Return:
-            int: the number of attributes
+        :returns: the number of attributes
+        :rtype: int
 
         New in PyTango 7.0.0
     """)
@@ -2165,15 +2192,15 @@ def __doc_MultiAttribute():
         - The 2nd version of the method checks alarm for one attribute with a given name.
         - The 3rd version of the method checks alarm for one attribute from its index in the main attributes vector.
 
-        Parameters:
-            attr_name (str): attribute name
-            ind (int): the attribute index
+        :param attr_name: attribute name
+        :type attr_name: str
+        :param ind: the attribute index
+        :type ind: int
 
-        Return:
-            bool: True if at least one attribute is in alarm condition
+        :returns: True if at least one attribute is in alarm condition
+        :rtype: bool
 
-        Raises:
-            DevFailed: If at least one attribute does not have any alarm level defined
+        :raises DevFailed: If at least one attribute does not have any alarm level defined
 
         New in PyTango 7.0.0
     """)
@@ -2186,8 +2213,8 @@ def __doc_MultiAttribute():
         This method add alarm mesage to the string passed as parameter.
         A message is added for each attribute which is in alarm condition
 
-        Parameters:
-            status (str): a string (should be the device status)
+        :param status: a string (should be the device status)
+        :type status: str
 
         New in PyTango 7.0.0
     """)
@@ -2197,8 +2224,8 @@ def __doc_MultiAttribute():
 
         Get the list of attribute objects.
 
-        Return:
-            seq<Attribute>: list of attribute objects
+        :returns: list of attribute objects
+        :rtype: seq<Attribute>
 
         New in PyTango 7.2.1
     """)
@@ -2217,8 +2244,8 @@ def __doc_Attr():
 
         Set default attribute properties.
 
-        Parameters:
-            attr_prop (UserDefaultAttrProp): the user default property class
+        :param attr_prop: the user default property class
+        :type attr_prop: UserDefaultAttrProp
     """)
 
     document_method("set_disp_level", """
@@ -2226,8 +2253,8 @@ def __doc_Attr():
 
         Set the attribute display level.
 
-        Parameters:
-            disp_level (DispLevel): the new display level
+        :param disp_level: the new display level
+        :type disp_level: DispLevel
     """)
 
     document_method("set_polling_period", """
@@ -2235,8 +2262,8 @@ def __doc_Attr():
 
         Set the attribute polling update period.
 
-        Parameters:
-            period (int): the attribute polling period (in mS)
+        :param period: the attribute polling period (in mS)
+        :type period: int
     """)
 
     document_method("set_memorized", """
@@ -2259,9 +2286,10 @@ def __doc_Attr():
 
         No action is taken on the attribute
 
-        Parameters:
-            write_on_init (bool): if true the setpoint value will be written
-                            to the attribute on initialisation    """)
+        :param write_on_init: if true the setpoint value will be written
+                              to the attribute on initialisation
+        :type write_on_init: bool
+    """)
 
     document_method("set_change_event", """
     set_change_event(self, implemented, detect)
@@ -2275,10 +2303,11 @@ def __doc_Attr():
 
         If detect is set to false the event is fired without checking!
 
-        Parameters:
-            implemented (bool): True when the server fires change events manually.
-            detect (bool): Triggers the verification of the change event properties
-                           when set to true.
+        :param implemented: True when the server fires change events manually.
+        :type implemented: bool
+        :param detect: Triggers the verification of the change event properties
+                       when set to true.
+        :type detect: bool
     """)
 
     document_method("is_change_event", """
@@ -2286,8 +2315,8 @@ def __doc_Attr():
 
         Check if the change event is fired manually for this attribute.
 
-        Return:
-            bool: true if a manual fire change event is implemented.
+        :returns: true if a manual fire change event is implemented.
+        :rtype: bool
     """)
 
     document_method("is_check_change_criteria", """
@@ -2295,8 +2324,8 @@ def __doc_Attr():
 
         Check if the change event criteria should be checked when firing the event manually.
 
-        Return:
-            bool: true if a change event criteria will be checked.
+        :returns: true if a change event criteria will be checked.
+        :rtype: bool
     """)
 
     document_method("set_archive_event", """
@@ -2311,10 +2340,11 @@ def __doc_Attr():
 
         If detect is set to false the event is fired without checking!
 
-        Parameters:
-            implemented (bool): True when the server fires change events manually.
-            detect (bool): Triggers the verification of the archive event properties
-                           when set to true.
+        :param implemented: True when the server fires change events manually.
+        :type implemented: bool
+        :param detect: Triggers the verification of the archive event properties
+                       when set to true.
+        :type detect: bool
     """)
 
     document_method("is_archive_event", """
@@ -2322,8 +2352,8 @@ def __doc_Attr():
 
         Check if the archive event is fired manually for this attribute.
 
-        Return:
-            bool: true if a manual fire archive event is implemented.
+        :returns: true if a manual fire archive event is implemented.
+        :rtype: bool
     """)
 
     document_method("is_check_archive_criteria", """
@@ -2331,8 +2361,8 @@ def __doc_Attr():
 
         Check if the archive event criteria should be checked when firing the event manually.
 
-        Return:
-            bool: true if a archive event criteria will be checked.
+        :returns: true if a archive event criteria will be checked.
+        :rtype: bool
     """)
 
     document_method("set_data_ready_event", """
@@ -2340,8 +2370,8 @@ def __doc_Attr():
 
         Set a flag to indicate that the server fires data ready events.
 
-        Parameters:
-            implemented (bool): True when the server fires data ready events
+        :param implemented: True when the server fires data ready events
+        :type implemented: bool
 
         New in PyTango 7.2.0
     """)
@@ -2351,8 +2381,8 @@ def __doc_Attr():
 
         Check if the data ready event is fired for this attribute.
 
-        Return:
-            bool: true if firing data ready event is implemented.
+        :returns: true if firing data ready event is implemented.
+        :rtype: bool
 
         New in PyTango 7.2.0
     """)
@@ -2362,8 +2392,8 @@ def __doc_Attr():
 
         Get the attribute name.
 
-        Return:
-            str: the attribute name
+        :returns: the attribute name
+        :rtype: str
     """)
 
     document_method("get_format", """
@@ -2371,8 +2401,8 @@ def __doc_Attr():
 
         Get the attribute format.
 
-        Return:
-            AttrDataFormat: the attribute format
+        :returns: the attribute format
+        :rtype: AttrDataFormat
     """)
 
     document_method("get_writable", """
@@ -2380,8 +2410,8 @@ def __doc_Attr():
 
         Get the attribute write type.
 
-        Return:
-            AttrWriteType: the attribute write type
+        :returns: the attribute write type
+        :rtype: AttrWriteType
     """)
 
     document_method("get_type", """
@@ -2389,8 +2419,8 @@ def __doc_Attr():
 
         Get the attribute data type.
 
-        Return:
-            int: the attribute data type
+        :returns: the attribute data type
+        :rtype: int
     """)
 
     document_method("get_disp_level", """
@@ -2398,8 +2428,8 @@ def __doc_Attr():
 
         Get the attribute display level.
 
-        Return:
-            DispLevel: the attribute display level
+        :returns: the attribute display level
+        :rtype: DispLevel
     """)
 
     document_method("get_polling_period", """
@@ -2407,8 +2437,8 @@ def __doc_Attr():
 
         Get the polling period (mS).
 
-        Return:
-            int: the polling period (mS)
+        :returns: the polling period (mS)
+        :rtype: int
     """)
 
     document_method("get_memorized", """
@@ -2416,8 +2446,8 @@ def __doc_Attr():
 
         Determine if the attribute is memorized or not.
 
-        Return:
-            bool: True if the attribute is memorized
+        :returns: True if the attribute is memorized
+        :rtype: bool
     """)
 
     document_method("get_memorized_init", """
@@ -2426,8 +2456,8 @@ def __doc_Attr():
         Determine if the attribute is written at startup from the memorized
         value if it is memorized.
 
-        Return:
-            bool: True if initialized with memorized value or not
+        :returns: True if initialized with memorized value or not
+        :rtype: bool
     """)
 
     document_method("get_assoc", """
@@ -2435,8 +2465,8 @@ def __doc_Attr():
 
         Get the associated name.
 
-        Return:
-            bool: the associated name
+        :returns: the associated name
+        :rtype: bool
     """)
 
     document_method("is_assoc", """
@@ -2444,8 +2474,8 @@ def __doc_Attr():
 
         Determine if it is assoc.
 
-        Return:
-            bool: if it is assoc
+        :returns: if it is assoc
+        :rtype: bool
     """)
 
     document_method("get_cl_name", """
@@ -2453,8 +2483,8 @@ def __doc_Attr():
 
         Returns the class name.
 
-        Return:
-            str: the class name
+        :returns: the class name
+        :rtype: str
 
         New in PyTango 7.2.0
     """)
@@ -2464,8 +2494,8 @@ def __doc_Attr():
 
         Sets the class name.
 
-        Parameters:
-            cl (str): new class name
+        :param cl: new class name
+        :type cl: str
 
         New in PyTango 7.2.0
     """)
@@ -2475,8 +2505,8 @@ def __doc_Attr():
 
         Get the class level attribute properties.
 
-        Return:
-            sequence<AttrProperty>: the class attribute properties
+        :returns: the class attribute properties
+        :rtype: sequence<AttrProperty>
     """)
 
     document_method("get_user_default_properties", """
@@ -2484,8 +2514,8 @@ def __doc_Attr():
 
         Get the user default attribute properties.
 
-        Return:
-            sequence<AttrProperty>: the user default attribute properties
+        :returns: the user default attribute properties
+        :rtype: sequence<AttrProperty>
     """)
 
     document_method("set_class_properties", """
@@ -2493,8 +2523,8 @@ def __doc_Attr():
 
         Set the class level attribute properties.
 
-        Parameters:
-            props (StdAttrPropertyVector): new class level attribute properties
+        :param props: new class level attribute properties
+        :type props: StdAttrPropertyVector
     """)
 
 
@@ -2517,8 +2547,8 @@ def __doc_UserDefaultAttrProp():
 
         Set default label property.
 
-        Parameters:
-            def_label (str): the user default label property
+        :param def_label: the user default label property
+        :type def_label: str
     """)
 
     document_method("set_description", """
@@ -2526,8 +2556,8 @@ def __doc_UserDefaultAttrProp():
 
         Set default description property.
 
-        Parameters:
-            def_description (str): the user default description property
+        :param def_description: the user default description property
+        :type def_description: str
     """)
 
     document_method("set_format", """
@@ -2535,8 +2565,8 @@ def __doc_UserDefaultAttrProp():
 
         Set default format property.
 
-        Parameters:
-            def_format (str): the user default format property
+        :param def_format: the user default format property
+        :type def_format: str
     """)
 
     document_method("set_unit", """
@@ -2544,8 +2574,8 @@ def __doc_UserDefaultAttrProp():
 
         Set default unit property.
 
-        Parameters:
-            def_unit (str): te user default unit property
+        :param def_unit: te user default unit property
+        :type def_unit: str
     """)
 
     document_method("set_standard_unit", """
@@ -2553,8 +2583,8 @@ def __doc_UserDefaultAttrProp():
 
         Set default standard unit property.
 
-        Parameters:
-            def_standard_unit (str): the user default standard unit property
+        :param def_standard_unit: the user default standard unit property
+        :type def_standard_unit: str
     """)
 
     document_method("set_display_unit", """
@@ -2562,8 +2592,8 @@ def __doc_UserDefaultAttrProp():
 
         Set default display unit property.
 
-        Parameters:
-            def_display_unit (str): the user default display unit property
+        :param def_display_unit: the user default display unit property
+        :type def_display_unit: str
     """)
 
     document_method("set_min_value", """
@@ -2571,8 +2601,8 @@ def __doc_UserDefaultAttrProp():
 
         Set default min_value property.
 
-        Parameters:
-            def_min_value (str): the user default min_value property
+        :param def_min_value: the user default min_value property
+        :type def_min_value: str
     """)
 
     document_method("set_max_value", """
@@ -2580,8 +2610,8 @@ def __doc_UserDefaultAttrProp():
 
         Set default max_value property.
 
-        Parameters:
-            def_max_value (str): the user default max_value property
+        :param def_max_value: the user default max_value property
+        :type def_max_value: str
     """)
 
     document_method("set_min_alarm", """
@@ -2589,8 +2619,8 @@ def __doc_UserDefaultAttrProp():
 
         Set default min_alarm property.
 
-        Parameters:
-            def_min_alarm (str): the user default min_alarm property
+        :param def_min_alarm: the user default min_alarm property
+        :type def_min_alarm: str
     """)
 
     document_method("set_max_alarm", """
@@ -2598,8 +2628,8 @@ def __doc_UserDefaultAttrProp():
 
         Set default max_alarm property.
 
-        Parameters:
-            def_max_alarm (str): the user default max_alarm property
+        :param def_max_alarm: the user default max_alarm property
+        :type def_max_alarm: str
     """)
 
     document_method("set_min_warning", """
@@ -2607,8 +2637,8 @@ def __doc_UserDefaultAttrProp():
 
         Set default min_warning property.
 
-        Parameters:
-            def_min_warning (str): the user default min_warning property
+        :param def_min_warning: the user default min_warning property
+        :type def_min_warning: str
     """)
 
     document_method("set_max_warning", """
@@ -2616,8 +2646,8 @@ def __doc_UserDefaultAttrProp():
 
         Set default max_warning property.
 
-        Parameters:
-            def_max_warning (str): the user default max_warning property
+        :param def_max_warning: the user default max_warning property
+        :type def_max_warning: str
     """)
 
     document_method("set_delta_t", """
@@ -2625,8 +2655,8 @@ def __doc_UserDefaultAttrProp():
 
         Set default RDS alarm delta_t property.
 
-        Parameters:
-            def_delta_t (str): the user default RDS alarm delta_t property
+        :param def_delta_t: the user default RDS alarm delta_t property
+        :type def_delta_t: str
     """)
 
     document_method("set_delta_val", """
@@ -2634,8 +2664,8 @@ def __doc_UserDefaultAttrProp():
 
         Set default RDS alarm delta_val property.
 
-        Parameters:
-            def_delta_val (str): the user default RDS alarm delta_val property
+        :param def_delta_val: the user default RDS alarm delta_val property
+        :type def_delta_val: str
     """)
 
     document_method("set_abs_change", """
@@ -2643,8 +2673,8 @@ def __doc_UserDefaultAttrProp():
 
         Set default change event abs_change property.
 
-        Parameters:
-            def_abs_change (str): the user default change event abs_change property
+        :param def_abs_change: the user default change event abs_change property
+        :type def_abs_change: str
 
         Deprecated since PyTango 8.0. Please use set_event_abs_change instead.
     """)
@@ -2654,8 +2684,8 @@ def __doc_UserDefaultAttrProp():
 
         Set default change event abs_change property.
 
-        Parameters:
-            def_abs_change (str): the user default change event abs_change property
+        :param def_abs_change: the user default change event abs_change property
+        :type def_abs_change: str
 
         New in PyTango 8.0
     """)
@@ -2665,8 +2695,8 @@ def __doc_UserDefaultAttrProp():
 
         Set default change event rel_change property.
 
-        Parameters:
-            def_rel_change (str): the user default change event rel_change property
+        :param def_rel_change: the user default change event rel_change property
+        :type def_rel_change: str
 
         Deprecated since PyTango 8.0. Please use set_event_rel_change instead.
     """)
@@ -2676,8 +2706,8 @@ def __doc_UserDefaultAttrProp():
 
         Set default change event rel_change property.
 
-        Parameters:
-            def_rel_change (str): the user default change event rel_change property
+        :param def_rel_change: the user default change event rel_change property
+        :type def_rel_change: str
 
         New in PyTango 8.0
     """)
@@ -2687,8 +2717,8 @@ def __doc_UserDefaultAttrProp():
 
         Set default periodic event period property.
 
-        Parameters:
-            def_period (str): the user default periodic event period property
+        :param def_period: the user default periodic event period property
+        :type def_period: str
 
         Deprecated since PyTango 8.0. Please use set_event_period instead.
     """)
@@ -2698,8 +2728,8 @@ def __doc_UserDefaultAttrProp():
 
         Set default periodic event period property.
 
-        Parameters:
-            def_period (str): the user default periodic event period property
+        :param def_period: the user default periodic event period property
+        :type def_period: str
 
         New in PyTango 8.0
     """)
@@ -2709,8 +2739,8 @@ def __doc_UserDefaultAttrProp():
 
         Set default archive event abs_change property.
 
-        Parameters:
-            def_archive_abs_change (str): the user default archive event abs_change property
+        :param def_archive_abs_change: the user default archive event abs_change property
+        :type def_archive_abs_change: str
 
         Deprecated since PyTango 8.0. Please use set_archive_event_abs_change instead.
     """)
@@ -2720,8 +2750,8 @@ def __doc_UserDefaultAttrProp():
 
         Set default archive event abs_change property.
 
-        Parameters:
-            def_archive_abs_change (str): the user default archive event abs_change property
+        :param def_archive_abs_change: the user default archive event abs_change property
+        :type def_archive_abs_change: str
 
         New in PyTango 8.0
     """)
@@ -2731,8 +2761,8 @@ def __doc_UserDefaultAttrProp():
 
         Set default archive event rel_change property.
 
-        Parameters:
-            def_archive_rel_change (str): the user default archive event rel_change property
+        :param def_archive_rel_change: the user default archive event rel_change property
+        :type def_archive_rel_change: str
 
         Deprecated since PyTango 8.0. Please use set_archive_event_rel_change instead.
     """)
@@ -2742,8 +2772,8 @@ def __doc_UserDefaultAttrProp():
 
         Set default archive event rel_change property.
 
-        Parameters:
-            def_archive_rel_change (str): the user default archive event rel_change property
+        :param def_archive_rel_change: the user default archive event rel_change property
+        :type def_archive_rel_change: str
 
         New in PyTango 8.0
     """)
@@ -2753,8 +2783,8 @@ def __doc_UserDefaultAttrProp():
 
         Set default archive event period property.
 
-        Parameters:
-            def_archive_period (str): t
+        :param def_archive_period: t
+        :type def_archive_period: str
 
         Deprecated since PyTango 8.0. Please use set_archive_event_period instead.
     """)
@@ -2764,8 +2794,8 @@ def __doc_UserDefaultAttrProp():
 
         Set default archive event period property.
 
-        Parameters:
-            def_archive_period (str): t
+        :param def_archive_period: t
+        :type def_archive_period: str
 
         New in PyTango 8.0
     """)

--- a/tango/device_server.py
+++ b/tango/device_server.py
@@ -424,7 +424,7 @@ def __DeviceImpl___remove_attr_meth(self, attr_name):
 
 def __DeviceImpl__add_command(self, cmd, device_level=True):
     """
-    add_command(self, cmd, level=TANGO::OPERATOR) -> cmd
+    add_command(self, cmd, device_level=True) -> cmd
 
         Add a new command to the device command list.
 
@@ -432,7 +432,7 @@ def __DeviceImpl__add_command(self, cmd, device_level=True):
         :param device_level: Set this flag to true if the command must be added
                              for only this device
 
-        :returns:
+        :returns: The command to add
         :rtype: Command
 
         :raises DevFailed:

--- a/tango/device_server.py
+++ b/tango/device_server.py
@@ -278,8 +278,6 @@ def __DeviceImpl__get_device_properties(self, ds_class=None):
                          None meaning that the corresponding DeviceClass object for this
                          DeviceImpl will be used
 
-        Return     : None
-
         Throws     : DevFailed
     """
     if ds_class is None:
@@ -378,8 +376,6 @@ def __DeviceImpl__remove_attribute(self, attr_name):
         Parameters :
             - attr_name : (str) attribute name
 
-        Return     : None
-
         Throws     : DevFailed
     """
     try:
@@ -469,8 +465,6 @@ def __DeviceImpl__remove_command(self, cmd_name, free_it=False, clean_db=True):
             - clean_db : Clean command related information (included polling info
                          if the command is polled) from database.
 
-        Return     : None
-
         Throws     : DevFailed
     """
     try:
@@ -498,8 +492,6 @@ def __DeviceImpl__debug_stream(self, msg, *args):
 
         Parameters :
             - msg : (str) the message to be sent to the debug stream
-
-        Return     : None
     """
     self.__debug_stream(msg % args)
 
@@ -516,8 +508,6 @@ def __DeviceImpl__info_stream(self, msg, *args):
 
         Parameters :
             - msg : (str) the message to be sent to the info stream
-
-        Return     : None
     """
     self.__info_stream(msg % args)
 
@@ -534,8 +524,6 @@ def __DeviceImpl__warn_stream(self, msg, *args):
 
         Parameters :
             - msg : (str) the message to be sent to the warn stream
-
-        Return     : None
     """
     self.__warn_stream(msg % args)
 
@@ -552,8 +540,6 @@ def __DeviceImpl__error_stream(self, msg, *args):
 
         Parameters :
             - msg : (str) the message to be sent to the error stream
-
-        Return     : None
     """
     self.__error_stream(msg % args)
 
@@ -570,8 +556,6 @@ def __DeviceImpl__fatal_stream(self, msg, *args):
 
         Parameters :
             - msg : (str) the message to be sent to the fatal stream
-
-        Return     : None
     """
     self.__fatal_stream(msg % args)
 
@@ -648,8 +632,6 @@ def __Logger__log(self, level, msg, *args):
             - level: (Level.LevelLevel) Log level
             - msg : (str) the message to be sent to the stream
             - args: (seq<str>) list of optional message arguments
-
-        Return     : None
     """
     self.__log(level, msg % args)
 
@@ -665,8 +647,6 @@ def __Logger__log_unconditionally(self, level, msg, *args):
             - level: (Level.LevelLevel) Log level
             - msg : (str) the message to be sent to the stream
             - args: (seq<str>) list of optional message arguments
-
-        Return     : None
     """
     self.__log_unconditionally(level, msg % args)
 
@@ -680,8 +660,6 @@ def __Logger__debug(self, msg, *args):
         Parameters :
             - msg : (str) the message to be sent to the debug stream
             - args: (seq<str>) list of optional message arguments
-
-        Return     : None
     """
     self.__debug(msg % args)
 
@@ -695,8 +673,6 @@ def __Logger__info(self, msg, *args):
         Parameters :
             - msg : (str) the message to be sent to the info stream
             - args: (seq<str>) list of optional message arguments
-
-        Return     : None
     """
     self.__info(msg % args)
 
@@ -710,8 +686,6 @@ def __Logger__warn(self, msg, *args):
         Parameters :
             - msg : (str) the message to be sent to the warn stream
             - args: (seq<str>) list of optional message arguments
-
-        Return     : None
     """
     self.__warn(msg % args)
 
@@ -725,8 +699,6 @@ def __Logger__error(self, msg, *args):
         Parameters :
             - msg : (str) the message to be sent to the error stream
             - args: (seq<str>) list of optional message arguments
-
-        Return     : None
     """
     self.__error(msg % args)
 
@@ -740,8 +712,6 @@ def __Logger__fatal(self, msg, *args):
         Parameters :
             - msg : (str) the message to be sent to the fatal stream
             - args: (seq<str>) list of optional message arguments
-
-        Return     : None
     """
     self.__fatal(msg % args)
 
@@ -800,8 +770,6 @@ def __doc_DeviceImpl():
     init_device(self)
 
         Intialize the device.
-
-        Return     : None
     """)
 
     document_method("set_state", """
@@ -811,8 +779,6 @@ def __doc_DeviceImpl():
 
         Parameters :
             - new_state : (DevState) the new device state
-
-        Return     : None
     """)
 
     document_method("get_state", """
@@ -860,8 +826,6 @@ def __doc_DeviceImpl():
 
         Parameters :
             - signo : (int) signal identifier
-
-        Return     : None
     """)
 
     document_method("unregister_signal", """
@@ -874,8 +838,6 @@ def __doc_DeviceImpl():
 
         Parameters :
             - signo : (int) signal identifier
-
-        Return     : None
     """)
 
     document_method("get_status", """
@@ -893,8 +855,6 @@ def __doc_DeviceImpl():
 
         Parameters :
             - new_status : (str) the new device status
-
-        Return     : None
     """)
 
     document_method("append_status", """
@@ -905,8 +865,6 @@ def __doc_DeviceImpl():
         Parameters :
             status : (str) the string to be appened to the device status
             new_line : (bool) If true, appends a new line character before the string. Default is False
-
-        Return     : None
     """)
 
     document_method("dev_state", """
@@ -957,8 +915,6 @@ def __doc_DeviceImpl():
             - implemented : (bool) True when the server fires change events manually.
             - detect : (bool) Triggers the verification of the change event properties
                        when set to true. Default value is true.
-
-        Return     : None
     """)
 
     document_method("set_archive_event", """
@@ -976,8 +932,6 @@ def __doc_DeviceImpl():
             - implemented : (bool) True when the server fires change events manually.
             - detect : (bool) Triggers the verification of the change event properties
                        when set to true. Default value is true.
-
-        Return     : None
     """)
 
     document_method("push_change_event", """
@@ -1081,8 +1035,6 @@ def __doc_DeviceImpl():
             - attr_name : (str) attribute name
             - counter : (int) the user counter
 
-        Return     : None
-
         Throws     : DevFailed If the attribute name is unknown.
     """)
 
@@ -1096,8 +1048,6 @@ def __doc_DeviceImpl():
         Parameters :
             - pipe_name : (str) pipe name
             - blob  : (DevicePipeBlob) the blob data
-
-        Return     : None
 
         Throws     : DevFailed If the pipe name is unknown.
 
@@ -1202,8 +1152,6 @@ def __doc_DeviceImpl():
         Parameters :
             - with_db_upd : (bool)  Is it necessary to update db?
 
-        Return     : None
-
         New in PyTango 7.1.2
     """)
 
@@ -1246,8 +1194,6 @@ def __doc_DeviceImpl():
 
         Parameters :
             - cmd_name: (str) the command name
-
-        Return     : None
 
         Throws     : DevFailed API_IncompatibleCmdArgumentType, API_CommandNotFound
 
@@ -1337,8 +1283,6 @@ def __doc_DeviceImpl():
 
         Parameters : (Attribute) the attribute for which the configuration event
                      will be sent.
-        Return     : None
-
         New in PyTango 7.2.1
     """)
 
@@ -1348,8 +1292,6 @@ def __doc_DeviceImpl():
         Push an pipe event.
 
         Parameters :  the blob which pipe event will be send.
-
-        Return     : None
 
         New in PyTango 9.2.2
     """)
@@ -1383,8 +1325,6 @@ def __doc_extra_DeviceImpl(cls):
     delete_device(self)
 
         Delete the device.
-
-        Return     : None
     """)
 
     document_method("always_executed_hook", """
@@ -1395,8 +1335,6 @@ def __doc_extra_DeviceImpl(cls):
         Default method to implement an action necessary on a device before
         any command is executed. This method can be redefined in sub-classes
         in case of the default behaviour does not fullfill the needs
-
-        Return     : None
 
         Throws     : DevFailed This method does not throw exception but a redefined method can.
     """)
@@ -1414,8 +1352,6 @@ def __doc_extra_DeviceImpl(cls):
             attr_list : (sequence<int>) list of indices in the device object attribute vector
                         of an attribute to be read.
 
-        Return     : None
-
         Throws     : DevFailed This method does not throw exception but a redefined method can.
     """)
 
@@ -1432,8 +1368,6 @@ def __doc_extra_DeviceImpl(cls):
             attr_list : (sequence<int>) list of indices in the device object attribute vector
                         of an attribute to be written.
 
-        Return     : None
-
         Throws     : DevFailed This method does not throw exception but a redefined method can.
     """)
 
@@ -1448,8 +1382,6 @@ def __doc_extra_DeviceImpl(cls):
 
         Parameters :
             - signo : (int) the signal number
-
-        Return     : None
 
         Throws     : DevFailed This method does not throw exception but a redefined method can.
     """)
@@ -1587,8 +1519,6 @@ def __doc_Attribute():
 
         Parameters :
             - index : (int) The new index in the main attribute vector of the associated writable attribute
-
-        Return     : None
     """)
 
     document_method("get_date", """
@@ -1606,8 +1536,6 @@ def __doc_Attribute():
 
         Parameters :
             - new_date : (TimeVal) the attribute date
-
-        Return     : None
     """)
 
     document_method("get_label", """
@@ -1634,8 +1562,6 @@ def __doc_Attribute():
         Parameters :
             - quality : (AttrQuality) the new attribute data quality
             - send_event : (bool) true if a change event should be sent. Default is false.
-
-        Return     : None
     """)
 
     document_method("get_data_size", """
@@ -1698,8 +1624,6 @@ def __doc_Attribute():
                           serialization model must be one of ATTR_BY_KERNEL,
                           ATTR_BY_USER or ATTR_NO_SYNC
 
-        Return     : None
-
         New in PyTango 7.1.0
     """)
 
@@ -1738,8 +1662,6 @@ def __doc_Attribute():
                          be a str or an object with the buffer interface.
             - dim_x : (int) [DEPRECATED] the attribute x length. Default value is 1
             - dim_y : (int) [DEPRECATED] the attribute y length. Default value is 0
-
-        Return     : None
     """)
 
     document_method("set_value_date_quality", """
@@ -1768,8 +1690,6 @@ def __doc_Attribute():
             - dim_y : (int) [DEPRECATED] the attribute y length. Default value is 0
             - time_stamp : (double) the time stamp
             - quality : (AttrQuality) the attribute quality factor
-
-        Return     : None
     """)
 
     document_method("set_change_event", """
@@ -1788,8 +1708,6 @@ def __doc_Attribute():
             - detect : (bool) (optional, default is True) Triggers the verification of
                        the change event properties when set to true.
 
-        Return     : None
-
         New in PyTango 7.1.0
     """)
 
@@ -1807,8 +1725,6 @@ def __doc_Attribute():
             - implemented : (bool) True when the server fires archive events manually.
             - detect : (bool) (optional, default is True) Triggers the verification of
                        the archive event properties when set to true.
-
-        Return     : None
 
         New in PyTango 7.1.0
     """)
@@ -1862,8 +1778,6 @@ def __doc_Attribute():
         Parameters :
             - implemented : (bool) True when the server fires data ready events manually.
 
-        Return     : None
-
         New in PyTango 7.2.0
     """)
 
@@ -1889,8 +1803,6 @@ def __doc_Attribute():
 
         The method removes all configured attribute properties and removes
         the attribute from the list of polled attributes.
-
-        Return     : None
 
         New in PyTango 7.1.0
     """)
@@ -1930,8 +1842,6 @@ def __doc_WAttribute():
         Parameters :
             - data : the attribute minimum value. python data type must be compatible
                      with the attribute data format and type.
-
-        Return     : None
     """)
 
     document_method("set_max_value", """
@@ -1942,8 +1852,6 @@ def __doc_WAttribute():
         Parameters :
             - data : the attribute maximum value. python data type must be compatible
                      with the attribute data format and type.
-
-        Return     : None
     """)
 
     document_method("is_min_value", """
@@ -1981,8 +1889,6 @@ def __doc_WAttribute():
     #                     compatible with the attribute type
     #            - dim_x : (int) the attribute set value x length. Default value is 1
     #            - dim_y : (int) the attribute set value y length. Default value is 0
-    #
-    #        Return     : None
     #    """)
 
     document_method("get_write_value", """
@@ -2187,8 +2093,6 @@ def __doc_MultiAttribute():
         Parameters :
             - status : (str) a string (should be the device status)
 
-        Return     : None
-
         New in PyTango 7.0.0
     """)
 
@@ -2218,8 +2122,6 @@ def __doc_Attr():
 
         Parameters :
             - attr_prop : (UserDefaultAttrProp) the user default property class
-
-        Return     : None
     """)
 
     document_method("set_disp_level", """
@@ -2229,8 +2131,6 @@ def __doc_Attr():
 
         Parameters :
             - disp_level : (DispLevel) the new display level
-
-        Return     : None
     """)
 
     document_method("set_polling_period", """
@@ -2240,8 +2140,6 @@ def __doc_Attr():
 
         Parameters :
             - period : (int) the attribute polling period (in mS)
-
-        Return     : None
     """)
 
     document_method("set_memorized", """
@@ -2252,8 +2150,6 @@ def __doc_Attr():
 
         With no argument the setpoint will be
         written to the attribute during initialisation!
-
-        Return     : None
     """)
 
     document_method("set_memorized_init", """
@@ -2268,9 +2164,7 @@ def __doc_Attr():
 
         Parameters :
             - write_on_init : (bool) if true the setpoint value will be written
-                              to the attribute on initialisation
-        Return     : None
-    """)
+                              to the attribute on initialisation    """)
 
     document_method("set_change_event", """
     set_change_event(self, implemented, detect)
@@ -2288,8 +2182,6 @@ def __doc_Attr():
             - implemented : (bool) True when the server fires change events manually.
             - detect : (bool) Triggers the verification of the change event properties
                        when set to true.
-
-        Return     : None
     """)
 
     document_method("is_change_event", """
@@ -2324,8 +2216,6 @@ def __doc_Attr():
             - implemented : (bool) True when the server fires change events manually.
             - detect : (bool) Triggers the verification of the archive event properties
                        when set to true.
-
-        Return     : None
     """)
 
     document_method("is_archive_event", """
@@ -2351,8 +2241,6 @@ def __doc_Attr():
 
         Parameters :
             - implemented : (bool) True when the server fires data ready events
-
-        Return     : None
 
         New in PyTango 7.2.0
     """)
@@ -2466,8 +2354,6 @@ def __doc_Attr():
         Parameters :
             - cl : (str) new class name
 
-        Return     : None
-
         New in PyTango 7.2.0
     """)
 
@@ -2494,8 +2380,6 @@ def __doc_Attr():
 
         Parameters :
             - props : (StdAttrPropertyVector) new class level attribute properties
-
-        Return     : None
     """)
 
 
@@ -2520,8 +2404,6 @@ def __doc_UserDefaultAttrProp():
 
         Parameters :
             - def_label : (str) the user default label property
-
-        Return     : None
     """)
 
     document_method("set_description", """
@@ -2531,8 +2413,6 @@ def __doc_UserDefaultAttrProp():
 
         Parameters :
             - def_description : (str) the user default description property
-
-        Return     : None
     """)
 
     document_method("set_format", """
@@ -2542,8 +2422,6 @@ def __doc_UserDefaultAttrProp():
 
         Parameters :
             - def_format : (str) the user default format property
-
-        Return     : None
     """)
 
     document_method("set_unit", """
@@ -2553,8 +2431,6 @@ def __doc_UserDefaultAttrProp():
 
         Parameters :
             - def_unit : (str) te user default unit property
-
-        Return     : None
     """)
 
     document_method("set_standard_unit", """
@@ -2564,8 +2440,6 @@ def __doc_UserDefaultAttrProp():
 
         Parameters :
             - def_standard_unit : (str) the user default standard unit property
-
-        Return     : None
     """)
 
     document_method("set_display_unit", """
@@ -2575,8 +2449,6 @@ def __doc_UserDefaultAttrProp():
 
         Parameters :
             - def_display_unit : (str) the user default display unit property
-
-        Return     : None
     """)
 
     document_method("set_min_value", """
@@ -2586,8 +2458,6 @@ def __doc_UserDefaultAttrProp():
 
         Parameters :
             - def_min_value : (str) the user default min_value property
-
-        Return     : None
     """)
 
     document_method("set_max_value", """
@@ -2597,8 +2467,6 @@ def __doc_UserDefaultAttrProp():
 
         Parameters :
             - def_max_value : (str) the user default max_value property
-
-        Return     : None
     """)
 
     document_method("set_min_alarm", """
@@ -2608,8 +2476,6 @@ def __doc_UserDefaultAttrProp():
 
         Parameters :
             - def_min_alarm : (str) the user default min_alarm property
-
-        Return     : None
     """)
 
     document_method("set_max_alarm", """
@@ -2619,8 +2485,6 @@ def __doc_UserDefaultAttrProp():
 
         Parameters :
             - def_max_alarm : (str) the user default max_alarm property
-
-        Return     : None
     """)
 
     document_method("set_min_warning", """
@@ -2630,8 +2494,6 @@ def __doc_UserDefaultAttrProp():
 
         Parameters :
             - def_min_warning : (str) the user default min_warning property
-
-        Return     : None
     """)
 
     document_method("set_max_warning", """
@@ -2641,8 +2503,6 @@ def __doc_UserDefaultAttrProp():
 
         Parameters :
             - def_max_warning : (str) the user default max_warning property
-
-        Return     : None
     """)
 
     document_method("set_delta_t", """
@@ -2652,8 +2512,6 @@ def __doc_UserDefaultAttrProp():
 
         Parameters :
             - def_delta_t : (str) the user default RDS alarm delta_t property
-
-        Return     : None
     """)
 
     document_method("set_delta_val", """
@@ -2663,8 +2521,6 @@ def __doc_UserDefaultAttrProp():
 
         Parameters :
             - def_delta_val : (str) the user default RDS alarm delta_val property
-
-        Return     : None
     """)
 
     document_method("set_abs_change", """
@@ -2674,8 +2530,6 @@ def __doc_UserDefaultAttrProp():
 
         Parameters :
             - def_abs_change : (str) the user default change event abs_change property
-
-        Return     : None
 
         Deprecated since PyTango 8.0. Please use set_event_abs_change instead.
     """)
@@ -2688,8 +2542,6 @@ def __doc_UserDefaultAttrProp():
         Parameters :
             - def_abs_change : (str) the user default change event abs_change property
 
-        Return     : None
-
         New in PyTango 8.0
     """)
 
@@ -2700,8 +2552,6 @@ def __doc_UserDefaultAttrProp():
 
         Parameters :
             - def_rel_change : (str) the user default change event rel_change property
-
-        Return     : None
 
         Deprecated since PyTango 8.0. Please use set_event_rel_change instead.
     """)
@@ -2714,8 +2564,6 @@ def __doc_UserDefaultAttrProp():
         Parameters :
             - def_rel_change : (str) the user default change event rel_change property
 
-        Return     : None
-
         New in PyTango 8.0
     """)
 
@@ -2726,8 +2574,6 @@ def __doc_UserDefaultAttrProp():
 
         Parameters :
             - def_period : (str) the user default periodic event period property
-
-        Return     : None
 
         Deprecated since PyTango 8.0. Please use set_event_period instead.
     """)
@@ -2740,8 +2586,6 @@ def __doc_UserDefaultAttrProp():
         Parameters :
             - def_period : (str) the user default periodic event period property
 
-        Return     : None
-
         New in PyTango 8.0
     """)
 
@@ -2752,8 +2596,6 @@ def __doc_UserDefaultAttrProp():
 
         Parameters :
             - def_archive_abs_change : (str) the user default archive event abs_change property
-
-        Return     : None
 
         Deprecated since PyTango 8.0. Please use set_archive_event_abs_change instead.
     """)
@@ -2766,8 +2608,6 @@ def __doc_UserDefaultAttrProp():
         Parameters :
             - def_archive_abs_change : (str) the user default archive event abs_change property
 
-        Return     : None
-
         New in PyTango 8.0
     """)
 
@@ -2778,8 +2618,6 @@ def __doc_UserDefaultAttrProp():
 
         Parameters :
             - def_archive_rel_change : (str) the user default archive event rel_change property
-
-        Return     : None
 
         Deprecated since PyTango 8.0. Please use set_archive_event_rel_change instead.
     """)
@@ -2792,8 +2630,6 @@ def __doc_UserDefaultAttrProp():
         Parameters :
             - def_archive_rel_change : (str) the user default archive event rel_change property
 
-        Return     : None
-
         New in PyTango 8.0
     """)
 
@@ -2805,8 +2641,6 @@ def __doc_UserDefaultAttrProp():
         Parameters :
             - def_archive_period : (str) t
 
-        Return     : None
-
         Deprecated since PyTango 8.0. Please use set_archive_event_period instead.
     """)
 
@@ -2817,8 +2651,6 @@ def __doc_UserDefaultAttrProp():
 
         Parameters :
             - def_archive_period : (str) t
-
-        Return     : None
 
         New in PyTango 8.0
     """)

--- a/tango/device_server.py
+++ b/tango/device_server.py
@@ -637,7 +637,7 @@ def __Logger__log(self, level, msg, *args):
         :param msg: the message to be sent to the stream
         :type msg: str
         :param args: list of optional message arguments
-        :type args: seq<str>
+        :type args: Sequence[str]
     """
     self.__log(level, msg % args)
 
@@ -654,7 +654,7 @@ def __Logger__log_unconditionally(self, level, msg, *args):
         :param msg: the message to be sent to the stream
         :type msg: str
         :param args: list of optional message arguments
-        :type args: seq<str>
+        :type args: Sequence[str]
     """
     self.__log_unconditionally(level, msg % args)
 
@@ -668,7 +668,7 @@ def __Logger__debug(self, msg, *args):
         :param msg: the message to be sent to the debug stream
         :type msg: str
         :param args: list of optional message arguments
-        :type args: seq<str>
+        :type args: Sequence[str]
     """
     self.__debug(msg % args)
 
@@ -682,7 +682,7 @@ def __Logger__info(self, msg, *args):
         :param msg: the message to be sent to the info stream
         :type msg: str
         :param args: list of optional message arguments
-        :type args: seq<str>
+        :type args: Sequence[str]
     """
     self.__info(msg % args)
 
@@ -696,7 +696,7 @@ def __Logger__warn(self, msg, *args):
         :param msg: the message to be sent to the warn stream
         :type msg: str
         :param args: list of optional message arguments
-        :type args: seq<str>
+        :type args: Sequence[str]
     """
     self.__warn(msg % args)
 
@@ -710,7 +710,7 @@ def __Logger__error(self, msg, *args):
         :param msg: the message to be sent to the error stream
         :type msg: str
         :param args: list of optional message arguments
-        :type args: seq<str>
+        :type args: Sequence[str]
     """
     self.__error(msg % args)
 
@@ -724,7 +724,7 @@ def __Logger__fatal(self, msg, *args):
         :param msg: the message to be sent to the fatal stream
         :type msg: str
         :param args: list of optional message arguments
-        :type args: seq<str>
+        :type args: Sequence[str]
     """
     self.__fatal(msg % args)
 
@@ -736,7 +736,7 @@ def __UserDefaultAttrProp_set_enum_labels(self, enum_labels):
         Set default enumeration labels.
 
         :param enum_labels: list of enumeration labels
-        :type enum_labels: seq<str>
+        :type enum_labels: Sequence[str]
 
         New in PyTango 9.2.0
     """
@@ -1040,9 +1040,9 @@ def __doc_DeviceImpl():
         :param attr_name: attribute name
         :type attr_name: str
         :param filt_names: the filterable fields name
-        :type filt_names: sequence<str>
+        :type filt_names: Sequence[str]
         :param filt_vals: the filterable fields value
-        :type filt_vals: sequence<double>
+        :type filt_vals: Sequence[double]
         :param data: the data to be sent as attribute event data. Data must be compatible with the
                      attribute type and format.
                      for SPECTRUM and IMAGE attributes, data can be any type of sequence of elements
@@ -1151,45 +1151,45 @@ def __doc_DeviceImpl():
     """)
 
     document_method("get_polled_cmd", """
-    get_polled_cmd(self) -> sequence<str>
+    get_polled_cmd(self) -> Sequence[str]
 
         Returns a COPY of the list of polled commands
 
         :returns: a COPY of the list of polled commands
-        :rtype: sequence<str>
+        :rtype: Sequence[str]
 
         New in PyTango 7.1.2
     """)
 
     document_method("get_polled_attr", """
-    get_polled_attr(self) -> sequence<str>
+    get_polled_attr(self) -> Sequence[str]
 
         Returns a COPY of the list of polled attributes
 
         :returns: a COPY of the list of polled attributes
-        :rtype: sequence<str>
+        :rtype: Sequence[str]
 
         New in PyTango 7.1.2
     """)
 
     document_method("get_non_auto_polled_cmd", """
-    get_non_auto_polled_cmd(self) -> sequence<str>
+    get_non_auto_polled_cmd(self) -> Sequence[str]
 
         Returns a COPY of the list of non automatic polled commands
 
         :returns: a COPY of the list of non automatic polled commands
-        :rtype: sequence<str>
+        :rtype: Sequence[str]
 
         New in PyTango 7.1.2
     """)
 
     document_method("get_non_auto_polled_attr", """
-    get_non_auto_polled_attr(self) -> sequence<str>
+    get_non_auto_polled_attr(self) -> Sequence[str]
 
         Returns a COPY of the list of non automatic polled attributes
 
         :returns: a COPY of the list of non automatic polled attributes
-        :rtype: sequence<str>
+        :rtype: Sequence[str]
 
         New in PyTango 7.1.2
     """)
@@ -1318,23 +1318,23 @@ def __doc_DeviceImpl():
     """)
 
     document_method("get_cmd_min_poll_period", """
-    get_cmd_min_poll_period(self) -> seq<str>
+    get_cmd_min_poll_period(self) -> Sequence[str]
 
         Returns the min command poll period.
 
         :returns: the min command poll period
-        :rtype: seq<str>
+        :rtype: Sequence[str]
 
         New in PyTango 7.2.0
     """)
 
     document_method("get_attr_min_poll_period", """
-    get_attr_min_poll_period(self) -> seq<str>
+    get_attr_min_poll_period(self) -> Sequence[str]
 
         Returns the min attribute poll period
 
         :returns: the min attribute poll period
-        :rtype: seq<str>
+        :rtype: Sequence[str]
 
         New in PyTango 7.2.0
     """)
@@ -1417,7 +1417,7 @@ def __doc_extra_DeviceImpl(cls):
 
         :param attr_list: list of indices in the device object attribute vector
                           of an attribute to be read.
-        :type attr_list: sequence<int>
+        :type attr_list: Sequence[int]
 
         :raises DevFailed: This method does not throw exception but a redefined method can.
     """)
@@ -1433,7 +1433,7 @@ def __doc_extra_DeviceImpl(cls):
 
         :param attr_list: list of indices in the device object attribute vector
                           of an attribute to be written.
-        :type attr_list: sequence<int>
+        :type attr_list: Sequence[int]
 
         :raises DevFailed: This method does not throw exception but a redefined method can.
     """)
@@ -2063,12 +2063,12 @@ def __doc_MultiClassAttribute():
     """)
 
     document_method("get_attr_list", """
-    get_attr_list(self) -> seq<Attr>
+    get_attr_list(self) -> Sequence[Attr]
 
         Get the list of :class:`~tango.Attr` for this device class.
 
         :returns: the list of attribute objects
-        :rtype: seq<Attr>
+        :rtype: Sequence[Attr]
 
         New in PyTango 7.2.1
     """)
@@ -2220,12 +2220,12 @@ def __doc_MultiAttribute():
     """)
 
     document_method("get_attribute_list", """
-    get_attribute_list(self) -> seq<Attribute>
+    get_attribute_list(self) -> Sequence[Attribute]
 
         Get the list of attribute objects.
 
         :returns: list of attribute objects
-        :rtype: seq<Attribute>
+        :rtype: Sequence[Attribute]
 
         New in PyTango 7.2.1
     """)
@@ -2501,21 +2501,21 @@ def __doc_Attr():
     """)
 
     document_method("get_class_properties", """
-    get_class_properties(self) -> sequence<AttrProperty>
+    get_class_properties(self) -> Sequence[AttrProperty]
 
         Get the class level attribute properties.
 
         :returns: the class attribute properties
-        :rtype: sequence<AttrProperty>
+        :rtype: Sequence[AttrProperty]
     """)
 
     document_method("get_user_default_properties", """
-    get_user_default_properties(self) -> sequence<AttrProperty>
+    get_user_default_properties(self) -> Sequence[AttrProperty]
 
         Get the user default attribute properties.
 
         :returns: the user default attribute properties
-        :rtype: sequence<AttrProperty>
+        :rtype: Sequence[AttrProperty]
     """)
 
     document_method("set_class_properties", """

--- a/tango/device_server.py
+++ b/tango/device_server.py
@@ -212,8 +212,8 @@ def __Attribute__get_properties(self, attr_cfg=None):
                      AttributeConfig_3, AttributeConfig_5 or
                      MultiAttrProp
 
-        Return     : (AttributeConfig) the config object filled with
-                     attribute configuration information
+        Return:
+            AttributeConfig: the config object filled with attribute configuration information
 
         New in PyTango 7.1.4
     """
@@ -321,7 +321,8 @@ def __DeviceImpl__add_attribute(self, attr, r_meth=None, w_meth=None, is_allo_me
             - is_allo_meth: (callable) the method that is called to check if it
                             is possible to access the attribute or not
 
-        Return     : (Attr) the newly created attribute.
+        Return:
+            Attr: the newly created attribute.
 
         Raises:
             DevFailed:
@@ -433,7 +434,8 @@ def __DeviceImpl__add_command(self, cmd, device_level=True):
             - device_level : Set this flag to true if the command must be added
                              for only this device
 
-        Return     : Command
+        Return:
+            Command:
 
         Raises:
             DevFailed:
@@ -791,7 +793,8 @@ def __doc_DeviceImpl():
 
         Get a COPY of the device state.
 
-        Return     : (DevState) Current device state
+        Return:
+            DevState: Current device state
     """)
 
     document_method("get_prev_state", """
@@ -799,8 +802,8 @@ def __doc_DeviceImpl():
 
         Get a COPY of the device's previous state.
 
-        Return     : (DevState) the device's previous state
-
+        Return:
+            DevState: the device's previous state
     """)
 
     document_method("get_name", """
@@ -808,8 +811,8 @@ def __doc_DeviceImpl():
 
         Get a COPY of the device name.
 
-        Return     : (str) the device name
-
+        Return:
+            str: the device name
     """)
 
     document_method("get_device_attr", """
@@ -817,8 +820,8 @@ def __doc_DeviceImpl():
 
         Get device multi attribute object.
 
-        Return     : (MultiAttribute) the device's MultiAttribute object
-
+        Return:
+            MultiAttribute: the device's MultiAttribute object
     """)
 
     document_method("register_signal", """
@@ -850,7 +853,8 @@ def __doc_DeviceImpl():
 
         Get a COPY of the device status.
 
-        Return     : (str) the device status
+        Return:
+            str: the device status
     """)
 
     document_method("set_status", """
@@ -885,7 +889,8 @@ def __doc_DeviceImpl():
         returns the state This method can be redefined in sub-classes in case
         of the default behaviour does not fullfill the needs.
 
-        Return     : (DevState) the device state
+        Return:
+            DevState: the device state
 
         Raises:
             DevFailed: If it is necessary to read attribute(s) and a problem occurs during the reading
@@ -901,7 +906,8 @@ def __doc_DeviceImpl():
         to the device status. This method can be redefined in sub-classes in case
         of the default behaviour does not fullfill the needs.
 
-        Return     : (str) the device status
+        Return:
+            str: the device status
 
         Raises:
             DevFailed: If it is necessary to read attribute(s) and a problem occurs during the reading
@@ -1071,7 +1077,8 @@ def __doc_DeviceImpl():
 
         Returns the Logger object for this device
 
-        Return     : (Logger) the Logger object for this device
+        Return:
+            Logger: the Logger object for this device
     """)
 
     document_method("get_exported_flag", """
@@ -1079,7 +1086,8 @@ def __doc_DeviceImpl():
 
         Returns the state of the exported flag
 
-        Return     : (bool) the state of the exported flag
+        Return:
+            bool: the state of the exported flag
 
         New in PyTango 7.1.2
     """)
@@ -1089,7 +1097,8 @@ def __doc_DeviceImpl():
 
         Returns the poll ring depth
 
-        Return     : (int) the poll ring depth
+        Return:
+            int: the poll ring depth
 
         New in PyTango 7.1.2
     """)
@@ -1099,7 +1108,8 @@ def __doc_DeviceImpl():
 
         Returns the poll old factor
 
-        Return     : (int) the poll old factor
+        Return:
+            int: the poll old factor
 
         New in PyTango 7.1.2
     """)
@@ -1109,7 +1119,8 @@ def __doc_DeviceImpl():
 
         Returns if it is polled
 
-        Return     : (bool) True if it is polled or False otherwise
+        Return:
+            bool: True if it is polled or False otherwise
 
         New in PyTango 7.1.2
     """)
@@ -1119,7 +1130,8 @@ def __doc_DeviceImpl():
 
         Returns a COPY of the list of polled commands
 
-        Return     : (sequence<str>) a COPY of the list of polled commands
+        Return:
+            sequence<str>: a COPY of the list of polled commands
 
         New in PyTango 7.1.2
     """)
@@ -1129,7 +1141,8 @@ def __doc_DeviceImpl():
 
         Returns a COPY of the list of polled attributes
 
-        Return     : (sequence<str>) a COPY of the list of polled attributes
+        Return:
+            sequence<str>: a COPY of the list of polled attributes
 
         New in PyTango 7.1.2
     """)
@@ -1139,7 +1152,8 @@ def __doc_DeviceImpl():
 
         Returns a COPY of the list of non automatic polled commands
 
-        Return     : (sequence<str>) a COPY of the list of non automatic polled commands
+        Return:
+            sequence<str>: a COPY of the list of non automatic polled commands
 
         New in PyTango 7.1.2
     """)
@@ -1149,7 +1163,8 @@ def __doc_DeviceImpl():
 
         Returns a COPY of the list of non automatic polled attributes
 
-        Return     : (sequence<str>) a COPY of the list of non automatic polled attributes
+        Return:
+            sequence<str>: a COPY of the list of non automatic polled attributes
 
         New in PyTango 7.1.2
     """)
@@ -1176,7 +1191,8 @@ def __doc_DeviceImpl():
         Parameters :
             - attr_name : (str) attribute name
 
-        Return     : (int) attribute polling period (ms) or 0 if it is not polled
+        Return:
+            int: attribute polling period (ms) or 0 if it is not polled
 
         New in PyTango 8.0.0
     """)
@@ -1190,7 +1206,8 @@ def __doc_DeviceImpl():
         Parameters :
             - cmd_name : (str) command name
 
-        Return     : (int) command polling period (ms) or 0 if it is not polled
+        Return:
+            int: command polling period (ms) or 0 if it is not polled
 
         New in PyTango 8.0.0
     """)
@@ -1220,7 +1237,8 @@ def __doc_DeviceImpl():
 
         Returns the IDL version.
 
-        Return     : (int) the IDL version
+        Return:
+            int: the IDL version
 
         New in PyTango 7.1.2
     """)
@@ -1233,7 +1251,8 @@ def __doc_DeviceImpl():
         Parameters :
             - cmd_name: (str) the command name
 
-        Return     : (int) the command poll ring depth
+        Return:
+            int: the command poll ring depth
 
         New in PyTango 7.1.2
     """)
@@ -1246,7 +1265,8 @@ def __doc_DeviceImpl():
         Parameters :
             - attr_name: (str) the attribute name
 
-        Return     : (int) the attribute poll ring depth
+        Return:
+            int: the attribute poll ring depth
 
         New in PyTango 7.1.2
     """)
@@ -1256,7 +1276,8 @@ def __doc_DeviceImpl():
 
         Returns if this device is locked by a client.
 
-        Return     : (bool) True if it is locked or False otherwise
+        Return:
+            bool: True if it is locked or False otherwise
 
         New in PyTango 7.1.2
     """)
@@ -1266,7 +1287,8 @@ def __doc_DeviceImpl():
 
         Returns the min poll period.
 
-        Return     : (int) the min poll period
+        Return:
+            int: the min poll period
 
         New in PyTango 7.2.0
     """)
@@ -1276,7 +1298,8 @@ def __doc_DeviceImpl():
 
         Returns the min command poll period.
 
-        Return     : (seq<str>) the min command poll period
+        Return:
+            seq<str>: the min command poll period
 
         New in PyTango 7.2.0
     """)
@@ -1286,7 +1309,8 @@ def __doc_DeviceImpl():
 
         Returns the min attribute poll period
 
-        Return     : (seq<str>) the min attribute poll period
+        Return:
+            seq<str>: the min attribute poll period
 
         New in PyTango 7.2.0
     """)
@@ -1328,7 +1352,8 @@ def __doc_DeviceImpl():
             - att_name: (str) the attribute name
             - event_type (EventType): the event type
 
-        Return     : True if there is at least one listener or False otherwise
+        Return:
+            bool: True if there is at least one listener or False otherwise
     """)
 
 
@@ -1422,7 +1447,8 @@ def __doc_Attribute():
 
         Check if the attribute has an associated writable attribute.
 
-        Return     : (bool) True if there is an associated writable attribute
+        Return:
+            bool: True if there is an associated writable attribute
     """)
 
     document_method("is_min_alarm", """
@@ -1430,7 +1456,8 @@ def __doc_Attribute():
 
         Check if the attribute is in minimum alarm condition.
 
-        Return     : (bool) true if the attribute is in alarm condition (read value below the min. alarm).
+        Return:
+            bool: true if the attribute is in alarm condition (read value below the min. alarm).
     """)
 
     document_method("is_max_alarm", """
@@ -1438,7 +1465,8 @@ def __doc_Attribute():
 
         Check if the attribute is in maximum alarm condition.
 
-        Return     : (bool) true if the attribute is in alarm condition (read value above the max. alarm).
+        Return:
+            bool: true if the attribute is in alarm condition (read value above the max. alarm).
     """)
 
     document_method("is_min_warning", """
@@ -1446,7 +1474,8 @@ def __doc_Attribute():
 
         Check if the attribute is in minimum warning condition.
 
-        Return     : (bool) true if the attribute is in warning condition (read value below the min. warning).
+        Return:
+            bool: true if the attribute is in warning condition (read value below the min. warning).
     """)
 
     document_method("is_max_warning", """
@@ -1454,7 +1483,8 @@ def __doc_Attribute():
 
         Check if the attribute is in maximum warning condition.
 
-        Return     : (bool) true if the attribute is in warning condition (read value above the max. warning).
+        Return:
+            bool: true if the attribute is in warning condition (read value above the max. warning).
     """)
 
     document_method("is_rds_alarm", """
@@ -1462,7 +1492,8 @@ def __doc_Attribute():
 
         Check if the attribute is in RDS alarm condition.
 
-        Return     : (bool) true if the attribute is in RDS condition (Read Different than Set).
+        Return:
+            bool: true if the attribute is in RDS condition (Read Different than Set).
     """)
 
     document_method("is_polled", """
@@ -1470,7 +1501,8 @@ def __doc_Attribute():
 
         Check if the attribute is polled.
 
-        Return     : (bool) true if the attribute is polled.
+        Return:
+            bool: true if the attribute is polled.
     """)
 
     document_method("check_alarm", """
@@ -1478,7 +1510,8 @@ def __doc_Attribute():
 
         Check if the attribute read value is below/above the alarm level.
 
-        Return     : (bool) true if the attribute is in alarm condition.
+        Return:
+            bool: true if the attribute is in alarm condition.
 
         Raises:
             DevFailed: If no alarm level is defined.
@@ -1489,7 +1522,8 @@ def __doc_Attribute():
 
         Get the attribute writable type (RO/WO/RW).
 
-        Return     : (AttrWriteType) The attribute write type.
+        Return:
+            AttrWriteType: The attribute write type.
     """)
 
     document_method("get_name", """
@@ -1497,7 +1531,8 @@ def __doc_Attribute():
 
         Get attribute name.
 
-        Return     : (str) The attribute name
+        Return:
+            str: The attribute name
     """)
 
     document_method("get_data_type", """
@@ -1505,7 +1540,8 @@ def __doc_Attribute():
 
         Get attribute data type.
 
-        Return     : (int) the attribute data type
+        Return:
+            int: the attribute data type
     """)
 
     document_method("get_data_format", """
@@ -1513,7 +1549,8 @@ def __doc_Attribute():
 
         Get attribute data format.
 
-        Return     : (AttrDataFormat) the attribute data format
+        Return:
+            AttrDataFormat: the attribute data format
     """)
 
     document_method("get_assoc_name", """
@@ -1521,7 +1558,8 @@ def __doc_Attribute():
 
         Get name of the associated writable attribute.
 
-        Return     : (str) the associated writable attribute name
+        Return:
+            str: the associated writable attribute name
     """)
 
     document_method("get_assoc_ind", """
@@ -1529,7 +1567,8 @@ def __doc_Attribute():
 
         Get index of the associated writable attribute.
 
-        Return     : (int) the index in the main attribute vector of the associated writable attribute
+        Return:
+            int: the index in the main attribute vector of the associated writable attribute
     """)
 
     document_method("set_assoc_ind", """
@@ -1546,7 +1585,8 @@ def __doc_Attribute():
 
         Get a COPY of the attribute date.
 
-        Return     : (TimeVal) the attribute date
+        Return:
+            TimeVal: the attribute date
     """)
 
     document_method("set_date", """
@@ -1563,7 +1603,8 @@ def __doc_Attribute():
 
         Get attribute label property.
 
-        Return     : (str) he attribute label
+        Return:
+            str: he attribute label
     """)
 
     document_method("get_quality", """
@@ -1571,7 +1612,8 @@ def __doc_Attribute():
 
         Get a COPY of the attribute data quality.
 
-        Return     : (AttrQuality) the attribute data quality
+        Return:
+            AttrQuality: the attribute data quality
     """)
 
     document_method("set_quality", """
@@ -1589,7 +1631,8 @@ def __doc_Attribute():
 
         Get attribute data size.
 
-        Return     : (int) the attribute data size
+        Return:
+            int: the attribute data size
     """)
 
     document_method("get_x", """
@@ -1597,7 +1640,8 @@ def __doc_Attribute():
 
         Get attribute data size in x dimension.
 
-        Return     : (int) the attribute data size in x dimension. Set to 1 for scalar attribute
+        Return:
+            int: the attribute data size in x dimension. Set to 1 for scalar attribute
     """)
 
     document_method("get_max_dim_x", """
@@ -1605,7 +1649,8 @@ def __doc_Attribute():
 
         Get attribute maximum data size in x dimension.
 
-        Return     : (int) the attribute maximum data size in x dimension. Set to 1 for scalar attribute
+        Return:
+            int: the attribute maximum data size in x dimension. Set to 1 for scalar attribute
     """)
 
     document_method("get_y", """
@@ -1613,7 +1658,8 @@ def __doc_Attribute():
 
         Get attribute data size in y dimension.
 
-        Return     : (int) the attribute data size in y dimension. Set to 1 for scalar attribute
+        Return:
+            int: the attribute data size in y dimension. Set to 1 for scalar attribute
     """)
 
     document_method("get_max_dim_y", """
@@ -1621,7 +1667,8 @@ def __doc_Attribute():
 
         Get attribute maximum data size in y dimension.
 
-        Return     : (int) the attribute maximum data size in y dimension. Set to 0 for scalar attribute
+        Return:
+            int: the attribute maximum data size in y dimension. Set to 0 for scalar attribute
     """)
 
     document_method("get_polling_period", """
@@ -1629,7 +1676,8 @@ def __doc_Attribute():
 
         Get attribute polling period.
 
-        Return     : (int) The attribute polling period in mS. Set to 0 when the attribute is not polled
+        Return:
+            int: The attribute polling period in mS. Set to 0 when the attribute is not polled
     """)
 
     document_method("set_attr_serial_model", """
@@ -1652,7 +1700,8 @@ def __doc_Attribute():
 
         Get attribute serialization model.
 
-        Return     : (AttrSerialModel) The attribute serialization model
+        Return:
+            AttrSerialModel: The attribute serialization model
 
         New in PyTango 7.1.0
     """)
@@ -1754,7 +1803,8 @@ def __doc_Attribute():
 
         Check if the change event is fired manually (without polling) for this attribute.
 
-        Return     : (bool) True if a manual fire change event is implemented.
+        Return:
+            bool: True if a manual fire change event is implemented.
 
         New in PyTango 7.1.0
     """)
@@ -1765,7 +1815,8 @@ def __doc_Attribute():
         Check if the change event criteria should be checked when firing the
         event manually.
 
-        Return     : (bool) True if a change event criteria will be checked.
+        Return:
+            bool: True if a change event criteria will be checked.
 
         New in PyTango 7.1.0
     """)
@@ -1774,7 +1825,9 @@ def __doc_Attribute():
     is_archive_event(self) -> bool
 
         Check if the archive event is fired manually (without polling) for this attribute.
-        Return     : (bool) True if a manual fire archive event is implemented.
+
+        Return:
+            bool: True if a manual fire archive event is implemented.
 
         New in PyTango 7.1.0
     """)
@@ -1785,7 +1838,8 @@ def __doc_Attribute():
         Check if the archive event criteria should be checked when firing the
         event manually.
 
-        Return     : (bool) True if a archive event criteria will be checked.
+        Return:
+            bool: True if a archive event criteria will be checked.
 
         New in PyTango 7.1.0
     """)
@@ -1807,7 +1861,8 @@ def __doc_Attribute():
         Check if the data ready event is fired manually (without polling)
         for this attribute.
 
-        Return     : (bool) True if a manual fire data ready event is implemented.
+        Return:
+            bool: True if a manual fire data ready event is implemented.
 
         New in PyTango 7.2.0
     """)
@@ -1842,7 +1897,8 @@ def __doc_WAttribute():
         Get attribute minimum value or throws an exception if the
         attribute does not have a minimum value.
 
-        Return     : (obj) an object with the python minimum value
+        Return:
+            obj: an object with the python minimum value
     """)
 
     document_method("get_max_value", """
@@ -1851,7 +1907,8 @@ def __doc_WAttribute():
         Get attribute maximum value or throws an exception if the
         attribute does not have a maximum value.
 
-        Return     : (obj) an object with the python maximum value
+        Return:
+            obj: an object with the python maximum value
     """)
 
     document_method("set_min_value", """
@@ -1879,7 +1936,8 @@ def __doc_WAttribute():
 
         Check if the attribute has a minimum value.
 
-        Return     : (bool) true if the attribute has a minimum value defined
+        Return:
+            bool: true if the attribute has a minimum value defined
     """)
 
     document_method("is_max_value", """
@@ -1887,7 +1945,8 @@ def __doc_WAttribute():
 
         Check if the attribute has a maximum value.
 
-        Return     : (bool) true if the attribute has a maximum value defined
+        Return:
+            bool: true if the attribute has a maximum value defined
     """)
 
     document_method("get_write_value_length", """
@@ -1895,7 +1954,8 @@ def __doc_WAttribute():
 
         Retrieve the new value length (data number) for writable attribute.
 
-        Return     : (int) the new value data length
+        Return:
+            int: the new value data length
     """)
 
     #    document_method("set_write_value", """
@@ -1921,7 +1981,8 @@ def __doc_WAttribute():
             - extract_as: (ExtractAs)
             - lst : [out] (list) a list object that will be filled with the attribute write value (DEPRECATED)
 
-        Return     : (obj) the attribute write value.
+        Return:
+            obj: the attribute write value.
     """)
 
 
@@ -1946,7 +2007,8 @@ def __doc_MultiClassAttribute():
         Parameters :
             - attr_name : (str) attribute name
 
-        Return     : (Attr) the attribute object
+        Return:
+            Attr: the attribute object
 
         Raises:
             DevFailed: If the attribute is not defined.
@@ -1974,7 +2036,8 @@ def __doc_MultiClassAttribute():
 
         Get the list of :class:`~tango.Attr` for this device class.
 
-        Return     : (seq<Attr>) the list of attribute objects
+        Return:
+            seq<Attr>: the list of attribute objects
 
         New in PyTango 7.2.1
     """)
@@ -2002,7 +2065,8 @@ def __doc_MultiAttribute():
         Parameters :
             - attr_name : (str) attribute name
 
-        Return     : (Attribute) the attribute object
+        Return:
+            Attribute: the attribute object
 
         Raises:
             DevFailed: If the attribute is not defined.
@@ -2019,7 +2083,8 @@ def __doc_MultiAttribute():
         Parameters :
             - ind : (int) the attribute index
 
-        Return     : (Attribute) the attribute object
+        Return:
+            Attribute: the attribute object
     """)
 
     document_method("get_w_attr_by_name", """
@@ -2034,7 +2099,8 @@ def __doc_MultiAttribute():
         Parameters :
             - attr_name : (str) attribute name
 
-        Return     : (WAttribute) the attribute object
+        Return:
+            WAttribute: the attribute object
 
         Raises:
             DevFailed: If the attribute is not defined.
@@ -2051,7 +2117,8 @@ def __doc_MultiAttribute():
         Parameters :
             - ind : (int) the attribute index
 
-        Return     : (WAttribute) the attribute object
+        Return:
+            WAttribute: the attribute object
     """)
 
     document_method("get_attr_ind_by_name", """
@@ -2066,7 +2133,8 @@ def __doc_MultiAttribute():
         Parameters :
             - attr_name : (str) attribute name
 
-        Return     : (int) the attribute index
+        Return:
+            int: the attribute index
 
         Raises:
             DevFailed: If the attribute is not found in the vector.
@@ -2079,7 +2147,8 @@ def __doc_MultiAttribute():
 
         Get attribute number.
 
-        Return     : (int) the number of attributes
+        Return:
+            int: the number of attributes
 
         New in PyTango 7.0.0
     """)
@@ -2099,7 +2168,8 @@ def __doc_MultiAttribute():
             - attr_name : (str) attribute name
             - ind : (int) the attribute index
 
-        Return     : (bool) True if at least one attribute is in alarm condition
+        Return:
+            bool: True if at least one attribute is in alarm condition
 
         Raises:
             DevFailed: If at least one attribute does not have any alarm level defined
@@ -2126,7 +2196,8 @@ def __doc_MultiAttribute():
 
         Get the list of attribute objects.
 
-        Return     : (seq<Attribute>) list of attribute objects
+        Return:
+            seq<Attribute>: list of attribute objects
 
         New in PyTango 7.2.1
     """)
@@ -2214,7 +2285,8 @@ def __doc_Attr():
 
         Check if the change event is fired manually for this attribute.
 
-        Return     : (bool) true if a manual fire change event is implemented.
+        Return:
+            bool: true if a manual fire change event is implemented.
     """)
 
     document_method("is_check_change_criteria", """
@@ -2222,7 +2294,8 @@ def __doc_Attr():
 
         Check if the change event criteria should be checked when firing the event manually.
 
-        Return     : (bool) true if a change event criteria will be checked.
+        Return:
+            bool: true if a change event criteria will be checked.
     """)
 
     document_method("set_archive_event", """
@@ -2248,7 +2321,8 @@ def __doc_Attr():
 
         Check if the archive event is fired manually for this attribute.
 
-        Return     : (bool) true if a manual fire archive event is implemented.
+        Return:
+            bool: true if a manual fire archive event is implemented.
     """)
 
     document_method("is_check_archive_criteria", """
@@ -2256,7 +2330,8 @@ def __doc_Attr():
 
         Check if the archive event criteria should be checked when firing the event manually.
 
-        Return     : (bool) true if a archive event criteria will be checked.
+        Return:
+            bool: true if a archive event criteria will be checked.
     """)
 
     document_method("set_data_ready_event", """
@@ -2275,7 +2350,8 @@ def __doc_Attr():
 
         Check if the data ready event is fired for this attribute.
 
-        Return     : (bool) true if firing data ready event is implemented.
+        Return:
+            bool: true if firing data ready event is implemented.
 
         New in PyTango 7.2.0
     """)
@@ -2285,7 +2361,8 @@ def __doc_Attr():
 
         Get the attribute name.
 
-        Return     : (str) the attribute name
+        Return:
+            str: the attribute name
     """)
 
     document_method("get_format", """
@@ -2293,7 +2370,8 @@ def __doc_Attr():
 
         Get the attribute format.
 
-        Return     : (AttrDataFormat) the attribute format
+        Return:
+            AttrDataFormat: the attribute format
     """)
 
     document_method("get_writable", """
@@ -2301,7 +2379,8 @@ def __doc_Attr():
 
         Get the attribute write type.
 
-        Return     : (AttrWriteType) the attribute write type
+        Return:
+            AttrWriteType: the attribute write type
     """)
 
     document_method("get_type", """
@@ -2309,7 +2388,8 @@ def __doc_Attr():
 
         Get the attribute data type.
 
-        Return     : (int) the attribute data type
+        Return:
+            int: the attribute data type
     """)
 
     document_method("get_disp_level", """
@@ -2317,7 +2397,8 @@ def __doc_Attr():
 
         Get the attribute display level.
 
-        Return     : (DispLevel) the attribute display level
+        Return:
+            DispLevel: the attribute display level
     """)
 
     document_method("get_polling_period", """
@@ -2325,7 +2406,8 @@ def __doc_Attr():
 
         Get the polling period (mS).
 
-        Return     : (int) the polling period (mS)
+        Return:
+            int: the polling period (mS)
     """)
 
     document_method("get_memorized", """
@@ -2333,7 +2415,8 @@ def __doc_Attr():
 
         Determine if the attribute is memorized or not.
 
-        Return     : (bool) True if the attribute is memorized
+        Return:
+            bool: True if the attribute is memorized
     """)
 
     document_method("get_memorized_init", """
@@ -2342,7 +2425,8 @@ def __doc_Attr():
         Determine if the attribute is written at startup from the memorized
         value if it is memorized.
 
-        Return     : (bool) True if initialized with memorized value or not
+        Return:
+            bool: True if initialized with memorized value or not
     """)
 
     document_method("get_assoc", """
@@ -2350,7 +2434,8 @@ def __doc_Attr():
 
         Get the associated name.
 
-        Return     : (bool) the associated name
+        Return:
+            bool: the associated name
     """)
 
     document_method("is_assoc", """
@@ -2358,7 +2443,8 @@ def __doc_Attr():
 
         Determine if it is assoc.
 
-        Return     : (bool) if it is assoc
+        Return:
+            bool: if it is assoc
     """)
 
     document_method("get_cl_name", """
@@ -2366,7 +2452,8 @@ def __doc_Attr():
 
         Returns the class name.
 
-        Return     : (str) the class name
+        Return:
+            str: the class name
 
         New in PyTango 7.2.0
     """)
@@ -2387,7 +2474,8 @@ def __doc_Attr():
 
         Get the class level attribute properties.
 
-        Return     : (sequence<AttrProperty>) the class attribute properties
+        Return:
+            sequence<AttrProperty>: the class attribute properties
     """)
 
     document_method("get_user_default_properties", """
@@ -2395,7 +2483,8 @@ def __doc_Attr():
 
         Get the user default attribute properties.
 
-        Return     : (sequence<AttrProperty>) the user default attribute properties
+        Return:
+            sequence<AttrProperty>: the user default attribute properties
     """)
 
     document_method("set_class_properties", """

--- a/tango/device_server.py
+++ b/tango/device_server.py
@@ -278,7 +278,8 @@ def __DeviceImpl__get_device_properties(self, ds_class=None):
                          None meaning that the corresponding DeviceClass object for this
                          DeviceImpl will be used
 
-        Throws     : DevFailed
+        Raises:
+            DevFailed:
     """
     if ds_class is None:
         try:
@@ -322,7 +323,8 @@ def __DeviceImpl__add_attribute(self, attr, r_meth=None, w_meth=None, is_allo_me
 
         Return     : (Attr) the newly created attribute.
 
-        Throws     : DevFailed
+        Raises:
+            DevFailed:
     """
 
     attr_data = None
@@ -376,7 +378,8 @@ def __DeviceImpl__remove_attribute(self, attr_name):
         Parameters :
             - attr_name : (str) attribute name
 
-        Throws     : DevFailed
+        Raises:
+            DevFailed:
     """
     try:
         # Call this method in a try/except in case remove_attribute
@@ -432,7 +435,8 @@ def __DeviceImpl__add_command(self, cmd, device_level=True):
 
         Return     : Command
 
-        Throws     : DevFailed
+        Raises:
+            DevFailed:
     """
     add_name_in_list = False      # This flag is always False, what use is it?
     try:
@@ -465,7 +469,8 @@ def __DeviceImpl__remove_command(self, cmd_name, free_it=False, clean_db=True):
             - clean_db : Clean command related information (included polling info
                          if the command is polled) from database.
 
-        Throws     : DevFailed
+        Raises:
+            DevFailed:
     """
     try:
         # Call this method in a try/except in case remove
@@ -882,7 +887,8 @@ def __doc_DeviceImpl():
 
         Return     : (DevState) the device state
 
-        Throws     : DevFailed - If it is necessary to read attribute(s) and a problem occurs during the reading
+        Raises:
+            DevFailed: If it is necessary to read attribute(s) and a problem occurs during the reading
     """)
 
     document_method("dev_status", """
@@ -897,7 +903,8 @@ def __doc_DeviceImpl():
 
         Return     : (str) the device status
 
-        Throws     : DevFailed - If it is necessary to read attribute(s) and a problem occurs during the reading
+        Raises:
+            DevFailed: If it is necessary to read attribute(s) and a problem occurs during the reading
     """)
 
     document_method("set_change_event", """
@@ -960,7 +967,8 @@ def __doc_DeviceImpl():
             - time_stamp : (double) the time stamp
             - quality : (AttrQuality) the attribute quality factor
 
-        Throws     : DevFailed If the attribute data type is not coherent.
+        Raises:
+            DevFailed: If the attribute data type is not coherent.
     """)
 
     document_method("push_archive_event", """
@@ -989,7 +997,8 @@ def __doc_DeviceImpl():
             - time_stamp : (double) the time stamp
             - quality : (AttrQuality) the attribute quality factor
 
-        Throws     : DevFailed If the attribute data type is not coherent.
+        Raises:
+            DevFailed: If the attribute data type is not coherent.
     """)
 
     document_method("push_event", """
@@ -1018,7 +1027,8 @@ def __doc_DeviceImpl():
             - time_stamp : (double) the time stamp
             - quality : (AttrQuality) the attribute quality factor
 
-        Throws     : DevFailed If the attribute data type is not coherent.
+        Raises:
+            DevFailed: If the attribute data type is not coherent.
     """)
 
     document_method("push_data_ready_event", """
@@ -1035,7 +1045,8 @@ def __doc_DeviceImpl():
             - attr_name : (str) attribute name
             - counter : (int) the user counter
 
-        Throws     : DevFailed If the attribute name is unknown.
+        Raises:
+            DevFailed: If the attribute name is unknown.
     """)
 
     document_method("push_pipe_event", """
@@ -1049,7 +1060,8 @@ def __doc_DeviceImpl():
             - pipe_name : (str) pipe name
             - blob  : (DevicePipeBlob) the blob data
 
-        Throws     : DevFailed If the pipe name is unknown.
+        Raises:
+            DevFailed: If the pipe name is unknown.
 
         New in PyTango 9.2.2
     """)
@@ -1195,7 +1207,10 @@ def __doc_DeviceImpl():
         Parameters :
             - cmd_name: (str) the command name
 
-        Throws     : DevFailed API_IncompatibleCmdArgumentType, API_CommandNotFound
+        Raises:
+            DevFailed
+            API_IncompatibleCmdArgumentType
+            API_CommandNotFound
 
         New in PyTango 7.1.2
     """)
@@ -1336,7 +1351,8 @@ def __doc_extra_DeviceImpl(cls):
         any command is executed. This method can be redefined in sub-classes
         in case of the default behaviour does not fullfill the needs
 
-        Throws     : DevFailed This method does not throw exception but a redefined method can.
+        Raises:
+            DevFailed: This method does not throw exception but a redefined method can.
     """)
 
     document_method("read_attr_hardware", """
@@ -1352,7 +1368,8 @@ def __doc_extra_DeviceImpl(cls):
             attr_list : (sequence<int>) list of indices in the device object attribute vector
                         of an attribute to be read.
 
-        Throws     : DevFailed This method does not throw exception but a redefined method can.
+        Raises:
+            DevFailed: This method does not throw exception but a redefined method can.
     """)
 
     document_method("write_attr_hardware", """
@@ -1368,7 +1385,8 @@ def __doc_extra_DeviceImpl(cls):
             attr_list : (sequence<int>) list of indices in the device object attribute vector
                         of an attribute to be written.
 
-        Throws     : DevFailed This method does not throw exception but a redefined method can.
+        Raises:
+            DevFailed: This method does not throw exception but a redefined method can.
     """)
 
     document_method("signal_handler", """
@@ -1383,7 +1401,8 @@ def __doc_extra_DeviceImpl(cls):
         Parameters :
             - signo : (int) the signal number
 
-        Throws     : DevFailed This method does not throw exception but a redefined method can.
+        Raises:
+            DevFailed: This method does not throw exception but a redefined method can.
     """)
 
     copy_doc(cls, "dev_state")
@@ -1461,7 +1480,8 @@ def __doc_Attribute():
 
         Return     : (bool) true if the attribute is in alarm condition.
 
-        Throws     : DevFailed If no alarm level is defined.
+        Raises:
+            DevFailed: If no alarm level is defined.
     """)
 
     document_method("get_writable", """
@@ -1928,7 +1948,8 @@ def __doc_MultiClassAttribute():
 
         Return     : (Attr) the attribute object
 
-        Throws     : DevFailed If the attribute is not defined.
+        Raises:
+            DevFailed: If the attribute is not defined.
 
         New in PyTango 7.2.1
     """)
@@ -1983,7 +2004,8 @@ def __doc_MultiAttribute():
 
         Return     : (Attribute) the attribute object
 
-        Throws     : DevFailed If the attribute is not defined.
+        Raises:
+            DevFailed: If the attribute is not defined.
     """)
 
     document_method("get_attr_by_ind", """
@@ -2014,7 +2036,8 @@ def __doc_MultiAttribute():
 
         Return     : (WAttribute) the attribute object
 
-        Throws     : DevFailed If the attribute is not defined.
+        Raises:
+            DevFailed: If the attribute is not defined.
     """)
 
     document_method("get_w_attr_by_ind", """
@@ -2045,7 +2068,8 @@ def __doc_MultiAttribute():
 
         Return     : (int) the attribute index
 
-        Throws     : DevFailed If the attribute is not found in the vector.
+        Raises:
+            DevFailed: If the attribute is not found in the vector.
 
         New in PyTango 7.0.0
     """)
@@ -2077,7 +2101,8 @@ def __doc_MultiAttribute():
 
         Return     : (bool) True if at least one attribute is in alarm condition
 
-        Throws     : DevFailed If at least one attribute does not have any alarm level defined
+        Raises:
+            DevFailed: If at least one attribute does not have any alarm level defined
 
         New in PyTango 7.0.0
     """)
@@ -2673,3 +2698,4 @@ def device_server_init(doc=True):
         __doc_MultiClassAttribute()
         __doc_UserDefaultAttrProp()
         __doc_Attr()
+

--- a/tango/device_server.py
+++ b/tango/device_server.py
@@ -198,23 +198,24 @@ class AttributeConfig_5(object):
 
 
 def __Attribute__get_properties(self, attr_cfg=None):
-    """get_properties(self, attr_cfg = None) -> AttributeConfig
+    """
+    get_properties(self, attr_cfg = None) -> AttributeConfig
 
-                Get attribute properties.
+        Get attribute properties.
 
-            Parameters :
-                - conf : the config object to be filled with
-                         the attribute configuration. Default is None meaning the
-                         method will create internally a new AttributeConfig_5
-                         and return it.
-                         Can be AttributeConfig, AttributeConfig_2,
-                         AttributeConfig_3, AttributeConfig_5 or
-                         MultiAttrProp
+        Parameters :
+            - conf : the config object to be filled with
+                     the attribute configuration. Default is None meaning the
+                     method will create internally a new AttributeConfig_5
+                     and return it.
+                     Can be AttributeConfig, AttributeConfig_2,
+                     AttributeConfig_3, AttributeConfig_5 or
+                     MultiAttrProp
 
-            Return     : (AttributeConfig) the config object filled with
-                         attribute configuration information
+        Return     : (AttributeConfig) the config object filled with
+                     attribute configuration information
 
-            New in PyTango 7.1.4
+        New in PyTango 7.1.4
     """
 
     if attr_cfg is None:
@@ -225,20 +226,21 @@ def __Attribute__get_properties(self, attr_cfg=None):
 
 
 def __Attribute__set_properties(self, attr_cfg, dev=None):
-    """set_properties(self, attr_cfg, dev) -> None
+    """
+    set_properties(self, attr_cfg, dev) -> None
 
-                Set attribute properties.
+        Set attribute properties.
 
-                This method sets the attribute properties value with the content
-                of the fileds in the AttributeConfig/ AttributeConfig_3 object
+        This method sets the attribute properties value with the content
+        of the fileds in the AttributeConfig/ AttributeConfig_3 object
 
-            Parameters :
-                - conf : (AttributeConfig or AttributeConfig_3) the config
-                         object.
-                - dev : (DeviceImpl) the device (not used, maintained
-                        for backward compatibility)
+        Parameters :
+            - conf : (AttributeConfig or AttributeConfig_3) the config
+                     object.
+            - dev : (DeviceImpl) the device (not used, maintained
+                    for backward compatibility)
 
-            New in PyTango 7.1.4
+        New in PyTango 7.1.4
     """
 
     if not isinstance(attr_cfg, MultiAttrProp):
@@ -265,19 +267,20 @@ def __DeviceImpl__get_device_class(self):
 
 
 def __DeviceImpl__get_device_properties(self, ds_class=None):
-    """get_device_properties(self, ds_class = None) -> None
+    """
+    get_device_properties(self, ds_class = None) -> None
 
-                Utility method that fetches all the device properties from the database
-                and converts them into members of this DeviceImpl.
+        Utility method that fetches all the device properties from the database
+        and converts them into members of this DeviceImpl.
 
-            Parameters :
-                - ds_class : (DeviceClass) the DeviceClass object. Optional. Default value is
-                             None meaning that the corresponding DeviceClass object for this
-                             DeviceImpl will be used
+        Parameters :
+            - ds_class : (DeviceClass) the DeviceClass object. Optional. Default value is
+                         None meaning that the corresponding DeviceClass object for this
+                         DeviceImpl will be used
 
-            Return     : None
+        Return     : None
 
-            Throws     : DevFailed
+        Throws     : DevFailed
     """
     if ds_class is None:
         try:
@@ -301,12 +304,15 @@ def __DeviceImpl__get_device_properties(self, ds_class=None):
 
 
 def __DeviceImpl__add_attribute(self, attr, r_meth=None, w_meth=None, is_allo_meth=None):
-    """add_attribute(self, attr, r_meth=None, w_meth=None, is_allo_meth=None) -> Attr
+    """
+    add_attribute(self, attr, r_meth=None, w_meth=None, is_allo_meth=None) -> Attr
 
-            Add a new attribute to the device attribute list. Please, note that if you add
-            an attribute to a device at device creation time, this attribute will be added
-            to the device class attribute list. Therefore, all devices belonging to the
-            same class created after this attribute addition will also have this attribute.
+        Add a new attribute to the device attribute list.
+
+        Please, note that if you add
+        an attribute to a device at device creation time, this attribute will be added
+        to the device class attribute list. Therefore, all devices belonging to the
+        same class created after this attribute addition will also have this attribute.
 
         Parameters :
             - attr : (Attr or AttrData) the new attribute to be added to the list.
@@ -364,9 +370,10 @@ def __DeviceImpl__add_attribute(self, attr, r_meth=None, w_meth=None, is_allo_me
 
 
 def __DeviceImpl__remove_attribute(self, attr_name):
-    """remove_attribute(self, attr_name) -> None
+    """
+    remove_attribute(self, attr_name) -> None
 
-            Remove one attribute from the device attribute list.
+        Remove one attribute from the device attribute list.
 
         Parameters :
             - attr_name : (str) attribute name
@@ -417,7 +424,8 @@ def __DeviceImpl___remove_attr_meth(self, attr_name):
 
 
 def __DeviceImpl__add_command(self, cmd, device_level=True):
-    """add_command(self, cmd, level=TANGO::OPERATOR) -> cmd
+    """
+    add_command(self, cmd, level=TANGO::OPERATOR) -> cmd
 
         Add a new command to the device command list.
 
@@ -453,7 +461,7 @@ def __DeviceImpl__remove_command(self, cmd_name, free_it=False, clean_db=True):
     """
     remove_command(self, attr_name) -> None
 
-            Remove one command from the device command list.
+        Remove one command from the device command list.
 
         Parameters :
             - cmd_name : (str) command name to be removed from the list
@@ -481,11 +489,11 @@ def __DeviceImpl__debug_stream(self, msg, *args):
     """
     debug_stream(self, msg, *args) -> None
 
-            Sends the given message to the tango debug stream.
+        Sends the given message to the tango debug stream.
 
-            Since PyTango 7.1.3, the same can be achieved with::
+        Since PyTango 7.1.3, the same can be achieved with::
 
-                print(msg, file=self.log_debug)
+            print(msg, file=self.log_debug)
 
         Parameters :
             - msg : (str) the message to be sent to the debug stream
@@ -498,11 +506,11 @@ def __DeviceImpl__info_stream(self, msg, *args):
     """
     info_stream(self, msg, *args) -> None
 
-            Sends the given message to the tango info stream.
+        Sends the given message to the tango info stream.
 
-            Since PyTango 7.1.3, the same can be achieved with::
+        Since PyTango 7.1.3, the same can be achieved with::
 
-                print(msg, file=self.log_info)
+            print(msg, file=self.log_info)
 
         Parameters :
             - msg : (str) the message to be sent to the info stream
@@ -515,11 +523,11 @@ def __DeviceImpl__warn_stream(self, msg, *args):
     """
     warn_stream(self, msg, *args) -> None
 
-            Sends the given message to the tango warn stream.
+        Sends the given message to the tango warn stream.
 
-            Since PyTango 7.1.3, the same can be achieved with::
+        Since PyTango 7.1.3, the same can be achieved with::
 
-                print(msg, file=self.log_warn)
+            print(msg, file=self.log_warn)
 
         Parameters :
             - msg : (str) the message to be sent to the warn stream
@@ -532,11 +540,11 @@ def __DeviceImpl__error_stream(self, msg, *args):
     """
     error_stream(self, msg, *args) -> None
 
-            Sends the given message to the tango error stream.
+        Sends the given message to the tango error stream.
 
-            Since PyTango 7.1.3, the same can be achieved with::
+        Since PyTango 7.1.3, the same can be achieved with::
 
-                print(msg, file=self.log_error)
+            print(msg, file=self.log_error)
 
         Parameters :
             - msg : (str) the message to be sent to the error stream
@@ -549,11 +557,11 @@ def __DeviceImpl__fatal_stream(self, msg, *args):
     """
     fatal_stream(self, msg, *args) -> None
 
-            Sends the given message to the tango fatal stream.
+        Sends the given message to the tango fatal stream.
 
-            Since PyTango 7.1.3, the same can be achieved with::
+        Since PyTango 7.1.3, the same can be achieved with::
 
-                print(msg, file=self.log_fatal)
+            print(msg, file=self.log_fatal)
 
         Parameters :
             - msg : (str) the message to be sent to the fatal stream
@@ -628,15 +636,13 @@ def __Logger__log(self, level, msg, *args):
     """
     log(self, level, msg, *args) -> None
 
-            Sends the given message to the tango the selected stream.
+        Sends the given message to the tango the selected stream.
 
         Parameters :
             - level: (Level.LevelLevel) Log level
             - msg : (str) the message to be sent to the stream
             - args: (seq<str>) list of optional message arguments
         Return     : None
-
-    .. versionchanged:
     """
     self.__log(level, msg % args)
 
@@ -645,8 +651,8 @@ def __Logger__log_unconditionally(self, level, msg, *args):
     """
     log_unconditionally(self, level, msg, *args) -> None
 
-            Sends the given message to the tango the selected stream,
-            without checking the level.
+        Sends the given message to the tango the selected stream,
+        without checking the level.
 
         Parameters :
             - level: (Level.LevelLevel) Log level
@@ -661,7 +667,7 @@ def __Logger__debug(self, msg, *args):
     """
     debug(self, msg, *args) -> None
 
-            Sends the given message to the tango debug stream.
+        Sends the given message to the tango debug stream.
 
         Parameters :
             - msg : (str) the message to be sent to the debug stream
@@ -675,7 +681,7 @@ def __Logger__info(self, msg, *args):
     """
     info(self, msg, *args) -> None
 
-            Sends the given message to the tango info stream.
+        Sends the given message to the tango info stream.
 
         Parameters :
             - msg : (str) the message to be sent to the info stream
@@ -689,7 +695,7 @@ def __Logger__warn(self, msg, *args):
     """
     warn(self, msg, *args) -> None
 
-            Sends the given message to the tango warn stream.
+        Sends the given message to the tango warn stream.
 
         Parameters :
             - msg : (str) the message to be sent to the warn stream
@@ -703,7 +709,7 @@ def __Logger__error(self, msg, *args):
     """
     error(self, msg, *args) -> None
 
-            Sends the given message to the tango error stream.
+        Sends the given message to the tango error stream.
 
         Parameters :
             - msg : (str) the message to be sent to the error stream
@@ -717,7 +723,7 @@ def __Logger__fatal(self, msg, *args):
     """
     fatal(self, msg, *args) -> None
 
-            Sends the given message to the tango fatal stream.
+        Sends the given message to the tango fatal stream.
 
         Parameters :
             - msg : (str) the message to be sent to the fatal stream
@@ -731,7 +737,7 @@ def __UserDefaultAttrProp_set_enum_labels(self, enum_labels):
     """
     set_enum_labels(self, enum_labels) -> None
 
-            Set default enumeration labels.
+        Set default enumeration labels.
 
         Parameters :
             - enum_labels : (seq<str>) list of enumeration labels
@@ -773,44 +779,42 @@ def __doc_DeviceImpl():
 
     DeviceImpl.__doc__ = """
     Base class for all TANGO device.
+
     This class inherits from CORBA classes where all the network layer is implemented.
     """
 
     document_method("init_device", """
     init_device(self) -> None
 
-            Intialize the device.
+        Intialize the device.
 
         Parameters : None
         Return     : None
-
     """)
 
     document_method("set_state", """
     set_state(self, new_state) -> None
 
-            Set device state.
+        Set device state.
 
         Parameters :
             - new_state : (DevState) the new device state
         Return     : None
-
     """)
 
     document_method("get_state", """
     get_state(self) -> DevState
 
-            Get a COPY of the device state.
+        Get a COPY of the device state.
 
         Parameters : None
         Return     : (DevState) Current device state
-
     """)
 
     document_method("get_prev_state", """
     get_prev_state(self) -> DevState
 
-            Get a COPY of the device's previous state.
+        Get a COPY of the device's previous state.
 
         Parameters : None
         Return     : (DevState) the device's previous state
@@ -820,7 +824,7 @@ def __doc_DeviceImpl():
     document_method("get_name", """
     get_name(self) -> (str)
 
-            Get a COPY of the device name.
+        Get a COPY of the device name.
 
         Parameters : None
         Return     : (str) the device name
@@ -830,7 +834,7 @@ def __doc_DeviceImpl():
     document_method("get_device_attr", """
     get_device_attr(self) -> MultiAttribute
 
-            Get device multi attribute object.
+        Get device multi attribute object.
 
         Parameters : None
         Return     : (MultiAttribute) the device's MultiAttribute object
@@ -840,9 +844,10 @@ def __doc_DeviceImpl():
     document_method("register_signal", """
     register_signal(self, signo) -> None
 
-            Register a signal.
-            Register this device as device to be informed when signal signo
-            is sent to to the device server process
+        Register a signal.
+
+        Register this device as device to be informed when signal signo
+        is sent to to the device server process
 
         Parameters :
             - signo : (int) signal identifier
@@ -853,9 +858,10 @@ def __doc_DeviceImpl():
     document_method("unregister_signal", """
     unregister_signal(self, signo) -> None
 
-            Unregister a signal.
-            Unregister this device as device to be informed when signal signo
-            is sent to to the device server process
+        Unregister a signal.
+
+        Unregister this device as device to be informed when signal signo
+        is sent to to the device server process
 
         Parameters :
             - signo : (int) signal identifier
@@ -866,7 +872,7 @@ def __doc_DeviceImpl():
     document_method("get_status", """
     get_status(self, ) -> str
 
-            Get a COPY of the device status.
+        Get a COPY of the device status.
 
         Parameters : None
         Return     : (str) the device status
@@ -876,7 +882,7 @@ def __doc_DeviceImpl():
     document_method("set_status", """
     set_status(self, new_status) -> None
 
-            Set device status.
+        Set device status.
 
         Parameters :
             - new_status : (str) the new device status
@@ -887,7 +893,7 @@ def __doc_DeviceImpl():
     document_method("append_status", """
     append_status(self, status, new_line=False) -> None
 
-            Appends a string to the device status.
+        Appends a string to the device status.
 
         Parameters :
             status : (str) the string to be appened to the device status
@@ -899,14 +905,15 @@ def __doc_DeviceImpl():
     document_method("dev_state", """
     dev_state(self) -> DevState
 
-            Get device state.
-            Default method to get device state. The behaviour of this method depends
-            on the device state. If the device state is ON or ALARM, it reads the
-            attribute(s) with an alarm level defined, check if the read value is
-            above/below the alarm and eventually change the state to ALARM, return
-            the device state. For all th other device state, this method simply
-            returns the state This method can be redefined in sub-classes in case
-            of the default behaviour does not fullfill the needs.
+        Get device state.
+
+        Default method to get device state. The behaviour of this method depends
+        on the device state. If the device state is ON or ALARM, it reads the
+        attribute(s) with an alarm level defined, check if the read value is
+        above/below the alarm and eventually change the state to ALARM, return
+        the device state. For all th other device state, this method simply
+        returns the state This method can be redefined in sub-classes in case
+        of the default behaviour does not fullfill the needs.
 
         Parameters : None
         Return     : (DevState) the device state
@@ -917,11 +924,12 @@ def __doc_DeviceImpl():
     document_method("dev_status", """
     dev_status(self) -> str
 
-            Get device status.
-            Default method to get device status. It returns the contents of the device
-            dev_status field. If the device state is ALARM, alarm messages are added
-            to the device status. This method can be redefined in sub-classes in case
-            of the default behaviour does not fullfill the needs.
+        Get device status.
+
+        Default method to get device status. It returns the contents of the device
+        dev_status field. If the device state is ALARM, alarm messages are added
+        to the device status. This method can be redefined in sub-classes in case
+        of the default behaviour does not fullfill the needs.
 
         Parameters : None
         Return     : (str) the device status
@@ -932,11 +940,12 @@ def __doc_DeviceImpl():
     document_method("set_change_event", """
     set_change_event(self, attr_name, implemented, detect=True) -> None
 
-            Set an implemented flag for the attribute to indicate that the server fires
-            change events manually, without the polling to be started.
-            If the detect parameter is set to true, the criteria specified for the
-            change event are verified and the event is only pushed if they are fullfilled.
-            If detect is set to false the event is fired without any value checking!
+        Set an implemented flag for the attribute to indicate that the server fires
+        change events manually, without the polling to be started.
+
+        If the detect parameter is set to true, the criteria specified for the
+        change event are verified and the event is only pushed if they are fullfilled.
+        If detect is set to false the event is fired without any value checking!
 
         Parameters :
             - attr_name : (str) attribute name
@@ -949,11 +958,12 @@ def __doc_DeviceImpl():
     document_method("set_archive_event", """
     set_archive_event(self, attr_name, implemented, detect=True) -> None
 
-            Set an implemented flag for the attribute to indicate that the server fires
-            archive events manually, without the polling to be started.
-            If the detect parameter is set to true, the criteria specified for the
-            archive event are verified and the event is only pushed if they are fullfilled.
-            If detect is set to false the event is fired without any value checking!
+        Set an implemented flag for the attribute to indicate that the server fires
+        archive events manually, without the polling to be started.
+
+        If the detect parameter is set to true, the criteria specified for the
+        archive event are verified and the event is only pushed if they are fullfilled.
+        If detect is set to false the event is fired without any value checking!
 
         Parameters :
             - attr_name : (str) attribute name
@@ -973,6 +983,7 @@ def __doc_DeviceImpl():
     push_change_event(self, attr_name, str_data, data, time_stamp, quality) -> None
 
         Push a change event for the given attribute name.
+
         The event is pushed to the notification daemon.
 
         Parameters:
@@ -1000,8 +1011,9 @@ def __doc_DeviceImpl():
     push_archive_event(self, attr_name, data, time_stamp, quality, dim_x = 1, dim_y = 0) -> None
     push_archive_event(self, attr_name, str_data, data, time_stamp, quality) -> None
 
-            Push an archive event for the given attribute name.
-            The event is pushed to the notification daemon.
+        Push an archive event for the given attribute name.
+
+        The event is pushed to the notification daemon.
 
         Parameters:
             - attr_name : (str) attribute name
@@ -1027,8 +1039,9 @@ def __doc_DeviceImpl():
     push_event(self, attr_name, filt_names, filt_vals, data, time_stamp, quality, dim_x = 1, dim_y = 0) -> None
     push_event(self, attr_name, filt_names, filt_vals, str_data, data, time_stamp, quality) -> None
 
-            Push a user event for the given attribute name.
-            The event is pushed to the notification daemon.
+        Push a user event for the given attribute name.
+
+        The event is pushed to the notification daemon.
 
         Parameters:
             - attr_name : (str) attribute name
@@ -1051,11 +1064,12 @@ def __doc_DeviceImpl():
     document_method("push_data_ready_event", """
     push_data_ready_event(self, attr_name, counter = 0) -> None
 
-            Push a data ready event for the given attribute name.
-            The event is pushed to the notification daemon.
+        Push a data ready event for the given attribute name.
 
-            The method needs only the attribue name and an optional
-            "counter" which will be passed unchanged within the event
+        The event is pushed to the notification daemon.
+
+        The method needs only the attribue name and an optional
+        "counter" which will be passed unchanged within the event
 
         Parameters :
             - attr_name : (str) attribute name
@@ -1070,7 +1084,7 @@ def __doc_DeviceImpl():
     push_pipe_event(self, pipe_name, blob, reuse_it) -> None
     push_pipe_event(self, pipe_name, blob, timeval, reuse_it) -> None
 
-            Push a pipe event for the given blob.
+        Push a pipe event for the given blob.
 
         Parameters :
             - pipe_name : (str) pipe name
@@ -1085,7 +1099,7 @@ def __doc_DeviceImpl():
     document_method("get_logger", """
     get_logger(self) -> Logger
 
-            Returns the Logger object for this device
+        Returns the Logger object for this device
 
         Parameters : None
         Return     : (Logger) the Logger object for this device
@@ -1094,7 +1108,7 @@ def __doc_DeviceImpl():
     document_method("get_exported_flag", """
     get_exported_flag(self) -> bool
 
-            Returns the state of the exported flag
+        Returns the state of the exported flag
 
         Parameters : None
         Return     : (bool) the state of the exported flag
@@ -1105,7 +1119,7 @@ def __doc_DeviceImpl():
     document_method("get_poll_ring_depth", """
     get_poll_ring_depth(self) -> int
 
-            Returns the poll ring depth
+        Returns the poll ring depth
 
         Parameters : None
         Return     : (int) the poll ring depth
@@ -1116,7 +1130,7 @@ def __doc_DeviceImpl():
     document_method("get_poll_old_factor", """
     get_poll_old_factor(self) -> int
 
-            Returns the poll old factor
+        Returns the poll old factor
 
         Parameters : None
         Return     : (int) the poll old factor
@@ -1127,7 +1141,7 @@ def __doc_DeviceImpl():
     document_method("is_polled", """
     is_polled(self) -> bool
 
-            Returns if it is polled
+        Returns if it is polled
 
         Parameters : None
         Return     : (bool) True if it is polled or False otherwise
@@ -1138,7 +1152,7 @@ def __doc_DeviceImpl():
     document_method("get_polled_cmd", """
     get_polled_cmd(self) -> sequence<str>
 
-            Returns a COPY of the list of polled commands
+        Returns a COPY of the list of polled commands
 
         Parameters : None
         Return     : (sequence<str>) a COPY of the list of polled commands
@@ -1149,7 +1163,7 @@ def __doc_DeviceImpl():
     document_method("get_polled_attr", """
     get_polled_attr(self) -> sequence<str>
 
-            Returns a COPY of the list of polled attributes
+        Returns a COPY of the list of polled attributes
 
         Parameters : None
         Return     : (sequence<str>) a COPY of the list of polled attributes
@@ -1160,7 +1174,7 @@ def __doc_DeviceImpl():
     document_method("get_non_auto_polled_cmd", """
     get_non_auto_polled_cmd(self) -> sequence<str>
 
-            Returns a COPY of the list of non automatic polled commands
+        Returns a COPY of the list of non automatic polled commands
 
         Parameters : None
         Return     : (sequence<str>) a COPY of the list of non automatic polled commands
@@ -1171,7 +1185,7 @@ def __doc_DeviceImpl():
     document_method("get_non_auto_polled_attr", """
     get_non_auto_polled_attr(self) -> sequence<str>
 
-            Returns a COPY of the list of non automatic polled attributes
+        Returns a COPY of the list of non automatic polled attributes
 
         Parameters : None
         Return     : (sequence<str>) a COPY of the list of non automatic polled attributes
@@ -1183,8 +1197,8 @@ def __doc_DeviceImpl():
     stop_polling(self) -> None
     stop_polling(self, with_db_upd) -> None
 
-            Stop all polling for a device. if the device is polled, call this
-            method before deleting it.
+        Stop all polling for a device. if the device is polled, call this
+        method before deleting it.
 
         Parameters :
             - with_db_upd : (bool)  Is it necessary to update db ?
@@ -1196,8 +1210,8 @@ def __doc_DeviceImpl():
     document_method("get_attribute_poll_period", """
     get_attribute_poll_period(self, attr_name) -> int
 
-            Returns the attribute polling period (ms) or 0 if the attribute
-            is not polled.
+        Returns the attribute polling period (ms) or 0 if the attribute
+        is not polled.
 
         Parameters :
             - attr_name : (str) attribute name
@@ -1209,8 +1223,8 @@ def __doc_DeviceImpl():
     document_method("get_command_poll_period", """
     get_command_poll_period(self, cmd_name) -> int
 
-            Returns the command polling period (ms) or 0 if the command
-            is not polled.
+        Returns the command polling period (ms) or 0 if the command
+        is not polled.
 
         Parameters :
             - cmd_name : (str) command name
@@ -1222,9 +1236,11 @@ def __doc_DeviceImpl():
     document_method("check_command_exists", """
     check_command_exists(self) -> None
 
-            This method check that a command is supported by the device and
-            does not need input value. The method throws an exception if the
-            command is not defined or needs an input value
+        Check that a command is supported by the device and
+        does not need input value.
+
+        The method throws an exception if the
+        command is not defined or needs an input value.
 
         Parameters :
             - cmd_name: (str) the command name
@@ -1238,7 +1254,7 @@ def __doc_DeviceImpl():
     document_method("get_dev_idl_version", """
     get_dev_idl_version(self) -> int
 
-            Returns the IDL version
+        Returns the IDL version.
 
         Parameters : None
         Return     : (int) the IDL version
@@ -1249,7 +1265,7 @@ def __doc_DeviceImpl():
     document_method("get_cmd_poll_ring_depth", """
     get_cmd_poll_ring_depth(self, cmd_name) -> int
 
-            Returns the command poll ring depth
+        Returns the command poll ring depth.
 
         Parameters :
             - cmd_name: (str) the command name
@@ -1261,7 +1277,7 @@ def __doc_DeviceImpl():
     document_method("get_attr_poll_ring_depth", """
     get_attr_poll_ring_depth(self, attr_name) -> int
 
-            Returns the attribute poll ring depth
+        Returns the attribute poll ring depth.
 
         Parameters :
             - attr_name: (str) the attribute name
@@ -1273,7 +1289,7 @@ def __doc_DeviceImpl():
     document_method("is_device_locked", """
     is_device_locked(self) -> bool
 
-            Returns if this device is locked by a client
+        Returns if this device is locked by a client.
 
         Parameters : None
         Return     : (bool) True if it is locked or False otherwise
@@ -1284,7 +1300,7 @@ def __doc_DeviceImpl():
     document_method("get_min_poll_period", """
     get_min_poll_period(self) -> int
 
-            Returns the min poll period
+        Returns the min poll period.
 
         Parameters : None
         Return     : (int) the min poll period
@@ -1295,7 +1311,7 @@ def __doc_DeviceImpl():
     document_method("get_cmd_min_poll_period", """
     get_cmd_min_poll_period(self) -> seq<str>
 
-            Returns the min command poll period
+        Returns the min command poll period.
 
         Parameters : None
         Return     : (seq<str>) the min command poll period
@@ -1306,7 +1322,7 @@ def __doc_DeviceImpl():
     document_method("get_attr_min_poll_period", """
     get_attr_min_poll_period(self) -> seq<str>
 
-            Returns the min attribute poll period
+        Returns the min attribute poll period
 
         Parameters : None
         Return     : (seq<str>) the min attribute poll period
@@ -1317,7 +1333,7 @@ def __doc_DeviceImpl():
     document_method("push_att_conf_event", """
     push_att_conf_event(self, attr) -> None
 
-            Push an attribute configuration event.
+        Push an attribute configuration event.
 
         Parameters : (Attribute) the attribute for which the configuration event
                      will be sent.
@@ -1329,7 +1345,7 @@ def __doc_DeviceImpl():
     document_method("push_pipe_event", """
     push_pipe_event(self, blob) -> None
 
-            Push an pipe event.
+        Push an pipe event.
 
         Parameters :  the blob which pipe event will be send.
         Return     : None
@@ -1340,15 +1356,15 @@ def __doc_DeviceImpl():
     document_method("is_there_subscriber", """
     is_there_subscriber(self, att_name, event_type) -> bool
 
-            Check if there is subscriber(s) listening for the event.
+        Check if there is subscriber(s) listening for the event.
 
-            This method returns a boolean set to true if there are some
-            subscriber(s) listening on the event specified by the two method
-            arguments. Be aware that there is some delay (up to 600 sec)
-            between this method returning false and the last subscriber
-            unsubscription or crash...
+        This method returns a boolean set to true if there are some
+        subscriber(s) listening on the event specified by the two method
+        arguments. Be aware that there is some delay (up to 600 sec)
+        between this method returning false and the last subscriber
+        unsubscription or crash...
 
-            The device interface change event is not supported by this method.
+        The device interface change event is not supported by this method.
 
         Parameters :
             - att_name: (str) the attribute name
@@ -1364,7 +1380,7 @@ def __doc_extra_DeviceImpl(cls):
     document_method("delete_device", """
     delete_device(self) -> None
 
-            Delete the device.
+        Delete the device.
 
         Parameters : None
         Return     : None
@@ -1374,10 +1390,11 @@ def __doc_extra_DeviceImpl(cls):
     document_method("always_executed_hook", """
     always_executed_hook(self) -> None
 
-            Hook method.
-            Default method to implement an action necessary on a device before
-            any command is executed. This method can be redefined in sub-classes
-            in case of the default behaviour does not fullfill the needs
+        Hook method.
+
+        Default method to implement an action necessary on a device before
+        any command is executed. This method can be redefined in sub-classes
+        in case of the default behaviour does not fullfill the needs
 
         Parameters : None
         Return     : None
@@ -1388,10 +1405,11 @@ def __doc_extra_DeviceImpl(cls):
     document_method("read_attr_hardware", """
     read_attr_hardware(self, attr_list) -> None
 
-            Read the hardware to return attribute value(s).
-            Default method to implement an action necessary on a device to read
-            the hardware involved in a a read attribute CORBA call. This method
-            must be redefined in sub-classes in order to support attribute reading
+        Read the hardware to return attribute value(s).
+
+        Default method to implement an action necessary on a device to read
+        the hardware involved in a a read attribute CORBA call. This method
+        must be redefined in sub-classes in order to support attribute reading
 
         Parameters :
             attr_list : (sequence<int>) list of indices in the device object attribute vector
@@ -1405,10 +1423,11 @@ def __doc_extra_DeviceImpl(cls):
     document_method("write_attr_hardware", """
     write_attr_hardware(self) -> None
 
-            Write the hardware for attributes.
-            Default method to implement an action necessary on a device to write
-            the hardware involved in a a write attribute. This method must be
-            redefined in sub-classes in order to support writable attribute
+        Write the hardware for attributes.
+
+        Default method to implement an action necessary on a device to write
+        the hardware involved in a a write attribute. This method must be
+        redefined in sub-classes in order to support writable attribute
 
         Parameters :
             attr_list : (sequence<int>) list of indices in the device object attribute vector
@@ -1421,10 +1440,11 @@ def __doc_extra_DeviceImpl(cls):
     document_method("signal_handler", """
     signal_handler(self, signo) -> None
 
-            Signal handler.
-            The method executed when the signal arrived in the device server process.
-            This method is defined as virtual and then, can be redefined following
-            device needs.
+        Signal handler.
+
+        The method executed when the signal arrived in the device server process.
+        This method is defined as virtual and then, can be redefined following
+        device needs.
 
         Parameters :
             - signo : (int) the signal number
@@ -1448,7 +1468,7 @@ def __doc_Attribute():
     document_method("is_write_associated", """
     is_write_associated(self) -> bool
 
-            Check if the attribute has an associated writable attribute.
+        Check if the attribute has an associated writable attribute.
 
         Parameters : None
         Return     : (bool) True if there is an associated writable attribute
@@ -1457,7 +1477,7 @@ def __doc_Attribute():
     document_method("is_min_alarm", """
     is_min_alarm(self) -> bool
 
-            Check if the attribute is in minimum alarm condition.
+        Check if the attribute is in minimum alarm condition.
 
         Parameters : None
         Return     : (bool) true if the attribute is in alarm condition (read value below the min. alarm).
@@ -1466,7 +1486,7 @@ def __doc_Attribute():
     document_method("is_max_alarm", """
     is_max_alarm(self) -> bool
 
-            Check if the attribute is in maximum alarm condition.
+        Check if the attribute is in maximum alarm condition.
 
         Parameters : None
         Return     : (bool) true if the attribute is in alarm condition (read value above the max. alarm).
@@ -1475,7 +1495,7 @@ def __doc_Attribute():
     document_method("is_min_warning", """
     is_min_warning(self) -> bool
 
-            Check if the attribute is in minimum warning condition.
+        Check if the attribute is in minimum warning condition.
 
         Parameters : None
         Return     : (bool) true if the attribute is in warning condition (read value below the min. warning).
@@ -1484,7 +1504,7 @@ def __doc_Attribute():
     document_method("is_max_warning", """
     is_max_warning(self) -> bool
 
-            Check if the attribute is in maximum warning condition.
+        Check if the attribute is in maximum warning condition.
 
         Parameters : None
         Return     : (bool) true if the attribute is in warning condition (read value above the max. warning).
@@ -1493,7 +1513,7 @@ def __doc_Attribute():
     document_method("is_rds_alarm", """
     is_rds_alarm(self) -> bool
 
-            Check if the attribute is in RDS alarm condition.
+        Check if the attribute is in RDS alarm condition.
 
         Parameters : None
         Return     : (bool) true if the attribute is in RDS condition (Read Different than Set).
@@ -1502,7 +1522,7 @@ def __doc_Attribute():
     document_method("is_polled", """
     is_polled(self) -> bool
 
-            Check if the attribute is polled.
+        Check if the attribute is polled.
 
         Parameters : None
         Return     : (bool) true if the attribute is polled.
@@ -1511,7 +1531,7 @@ def __doc_Attribute():
     document_method("check_alarm", """
     check_alarm(self) -> bool
 
-            Check if the attribute read value is below/above the alarm level.
+        Check if the attribute read value is below/above the alarm level.
 
         Parameters : None
         Return     : (bool) true if the attribute is in alarm condition.
@@ -1522,7 +1542,7 @@ def __doc_Attribute():
     document_method("get_writable", """
     get_writable(self) -> AttrWriteType
 
-            Get the attribute writable type (RO/WO/RW).
+        Get the attribute writable type (RO/WO/RW).
 
         Parameters : None
         Return     : (AttrWriteType) The attribute write type.
@@ -1531,7 +1551,7 @@ def __doc_Attribute():
     document_method("get_name", """
     get_name(self) -> str
 
-            Get attribute name.
+        Get attribute name.
 
         Parameters : None
         Return     : (str) The attribute name
@@ -1540,7 +1560,7 @@ def __doc_Attribute():
     document_method("get_data_type", """
     get_data_type(self) -> int
 
-            Get attribute data type.
+        Get attribute data type.
 
         Parameters : None
         Return     : (int) the attribute data type
@@ -1549,7 +1569,7 @@ def __doc_Attribute():
     document_method("get_data_format", """
     get_data_format(self) -> AttrDataFormat
 
-            Get attribute data format.
+        Get attribute data format.
 
         Parameters : None
         Return     : (AttrDataFormat) the attribute data format
@@ -1558,7 +1578,7 @@ def __doc_Attribute():
     document_method("get_assoc_name", """
     get_assoc_name(self) -> str
 
-            Get name of the associated writable attribute.
+        Get name of the associated writable attribute.
 
         Parameters : None
         Return     : (str) the associated writable attribute name
@@ -1567,7 +1587,7 @@ def __doc_Attribute():
     document_method("get_assoc_ind", """
     get_assoc_ind(self) -> int
 
-            Get index of the associated writable attribute.
+        Get index of the associated writable attribute.
 
         Parameters : None
         Return     : (int) the index in the main attribute vector of the associated writable attribute
@@ -1576,7 +1596,7 @@ def __doc_Attribute():
     document_method("set_assoc_ind", """
     set_assoc_ind(self, index) -> None
 
-            Set index of the associated writable attribute.
+        Set index of the associated writable attribute.
 
         Parameters :
             - index : (int) The new index in the main attribute vector of the associated writable attribute
@@ -1586,7 +1606,7 @@ def __doc_Attribute():
     document_method("get_date", """
     get_date(self) -> TimeVal
 
-            Get a COPY of the attribute date.
+        Get a COPY of the attribute date.
 
         Parameters : None
         Return     : (TimeVal) the attribute date
@@ -1595,7 +1615,7 @@ def __doc_Attribute():
     document_method("set_date", """
     set_date(self, new_date) -> None
 
-            Set attribute date.
+        Set attribute date.
 
         Parameters :
             - new_date : (TimeVal) the attribute date
@@ -1605,7 +1625,7 @@ def __doc_Attribute():
     document_method("get_label", """
     get_label(self, ) -> str
 
-            Get attribute label property.
+        Get attribute label property.
 
         Parameters : None
         Return     : (str) he attribute label
@@ -1614,7 +1634,7 @@ def __doc_Attribute():
     document_method("get_quality", """
     get_quality(self) -> AttrQuality
 
-            Get a COPY of the attribute data quality.
+        Get a COPY of the attribute data quality.
 
         Parameters : None
         Return     : (AttrQuality) the attribute data quality
@@ -1623,7 +1643,7 @@ def __doc_Attribute():
     document_method("set_quality", """
     set_quality(self, quality, send_event=False) -> None
 
-            Set attribute data quality.
+        Set attribute data quality.
 
         Parameters :
             - quality : (AttrQuality) the new attribute data quality
@@ -1634,7 +1654,7 @@ def __doc_Attribute():
     document_method("get_data_size", """
     get_data_size(self) -> None
 
-            Get attribute data size.
+        Get attribute data size.
 
         Parameters : None
         Return     : (int) the attribute data size
@@ -1643,7 +1663,7 @@ def __doc_Attribute():
     document_method("get_x", """
     get_x(self) -> int
 
-            Get attribute data size in x dimension.
+        Get attribute data size in x dimension.
 
         Parameters : None
         Return     : (int) the attribute data size in x dimension. Set to 1 for scalar attribute
@@ -1652,7 +1672,7 @@ def __doc_Attribute():
     document_method("get_max_dim_x", """
     get_max_dim_x(self) -> int
 
-            Get attribute maximum data size in x dimension.
+        Get attribute maximum data size in x dimension.
 
         Parameters : None
         Return     : (int) the attribute maximum data size in x dimension. Set to 1 for scalar attribute
@@ -1661,7 +1681,7 @@ def __doc_Attribute():
     document_method("get_y", """
     get_y(self) -> int
 
-            Get attribute data size in y dimension.
+        Get attribute data size in y dimension.
 
         Parameters : None
         Return     : (int) the attribute data size in y dimension. Set to 1 for scalar attribute
@@ -1670,7 +1690,7 @@ def __doc_Attribute():
     document_method("get_max_dim_y", """
     get_max_dim_y(self) -> int
 
-            Get attribute maximum data size in y dimension.
+        Get attribute maximum data size in y dimension.
 
         Parameters : None
         Return     : (int) the attribute maximum data size in y dimension. Set to 0 for scalar attribute
@@ -1679,7 +1699,7 @@ def __doc_Attribute():
     document_method("get_polling_period", """
     get_polling_period(self) -> int
 
-            Get attribute polling period.
+        Get attribute polling period.
 
         Parameters : None
         Return     : (int) The attribute polling period in mS. Set to 0 when the attribute is not polled
@@ -1688,8 +1708,9 @@ def __doc_Attribute():
     document_method("set_attr_serial_model", """
     set_attr_serial_model(self, ser_model) -> void
 
-            Set attribute serialization model.
-            This method allows the user to choose the attribute serialization model.
+        Set attribute serialization model.
+
+        This method allows the user to choose the attribute serialization model.
 
         Parameters :
             - ser_model : (AttrSerialModel) The new serialisation model. The
@@ -1703,7 +1724,7 @@ def __doc_Attribute():
     document_method("get_attr_serial_model", """
     get_attr_serial_model(self) -> AttrSerialModel
 
-            Get attribute serialization model.
+        Get attribute serialization model.
 
         Parameters : None
         Return     : (AttrSerialModel) The attribute serialization model
@@ -1716,9 +1737,11 @@ def __doc_Attribute():
     set_value(self, data) -> None
     set_value(self, str_data, data) -> None
 
-            Set internal attribute value.
-            This method stores the attribute read value inside the object.
-            This method also stores the date when it is called and initializes the attribute quality factor.
+        Set internal attribute value.
+
+        This method stores the attribute read value inside the object.
+        This method also stores the date when it is called and initializes the
+        attribute quality factor.
 
         Parameters :
             - data : the data to be set. Data must be compatible with the attribute type and format.
@@ -1742,9 +1765,10 @@ def __doc_Attribute():
     set_value_date_quality(self, data, time_stamp, quality) -> None
     set_value_date_quality(self, str_data, data, time_stamp, quality) -> None
 
-            Set internal attribute value, date and quality factor.
-            This method stores the attribute read value, the date and the attribute quality
-            factor inside the object.
+        Set internal attribute value, date and quality factor.
+
+        This method stores the attribute read value, the date and the attribute quality
+        factor inside the object.
 
         Parameters :
             - data : the data to be set. Data must be compatible with the attribute type and format.
@@ -1768,12 +1792,13 @@ def __doc_Attribute():
     document_method("set_change_event", """
     set_change_event(self, implemented, detect = True) -> None
 
-            Set a flag to indicate that the server fires change events manually,
-            without the polling to be started for the attribute.
-            If the detect parameter is set to true, the criteria specified for
-            the change event are verified and the event is only pushed if they
-            are fullfilled. If detect is set to false the event is fired without
-            any value checking!
+        Set a flag to indicate that the server fires change events manually,
+        without the polling to be started for the attribute.
+
+        If the detect parameter is set to true, the criteria specified for
+        the change event are verified and the event is only pushed if they
+        are fullfilled. If detect is set to false the event is fired without
+        any value checking!
 
         Parameters :
             - implemented : (bool) True when the server fires change events manually.
@@ -1787,10 +1812,12 @@ def __doc_Attribute():
     document_method("set_archive_event", """
     set_archive_event(self, implemented, detect = True) -> None
 
-            Set a flag to indicate that the server fires archive events manually,
-            without the polling to be started for the attribute If the detect parameter
-            is set to true, the criteria specified for the archive event are verified
-            and the event is only pushed if they are fullfilled.
+        Set a flag to indicate that the server fires archive events manually,
+        without the polling to be started for the attribute.
+
+        If the detect parameter
+        is set to true, the criteria specified for the archive event are verified
+        and the event is only pushed if they are fullfilled.
 
         Parameters :
             - implemented : (bool) True when the server fires archive events manually.
@@ -1804,7 +1831,7 @@ def __doc_Attribute():
     document_method("is_change_event", """
     is_change_event(self) -> bool
 
-            Check if the change event is fired manually (without polling) for this attribute.
+        Check if the change event is fired manually (without polling) for this attribute.
 
         Parameters : None
         Return     : (bool) True if a manual fire change event is implemented.
@@ -1815,8 +1842,8 @@ def __doc_Attribute():
     document_method("is_check_change_criteria", """
     is_check_change_criteria(self) -> bool
 
-            Check if the change event criteria should be checked when firing the
-            event manually.
+        Check if the change event criteria should be checked when firing the
+        event manually.
 
         Parameters : None
         Return     : (bool) True if a change event criteria will be checked.
@@ -1827,7 +1854,7 @@ def __doc_Attribute():
     document_method("is_archive_event", """
     is_archive_event(self) -> bool
 
-            Check if the archive event is fired manually (without polling) for this attribute.
+        Check if the archive event is fired manually (without polling) for this attribute.
 
         Parameters : None
         Return     : (bool) True if a manual fire archive event is implemented.
@@ -1838,8 +1865,8 @@ def __doc_Attribute():
     document_method("is_check_archive_criteria", """
     is_check_archive_criteria(self) -> bool
 
-            Check if the archive event criteria should be checked when firing the
-            event manually.
+        Check if the archive event criteria should be checked when firing the
+        event manually.
 
         Parameters : None
         Return     : (bool) True if a archive event criteria will be checked.
@@ -1850,7 +1877,7 @@ def __doc_Attribute():
     document_method("set_data_ready_event", """
     set_data_ready_event(self, implemented) -> None
 
-            Set a flag to indicate that the server fires data ready events.
+        Set a flag to indicate that the server fires data ready events.
 
         Parameters :
             - implemented : (bool) True when the server fires data ready events manually.
@@ -1862,8 +1889,8 @@ def __doc_Attribute():
     document_method("is_data_ready_event", """
     is_data_ready_event(self) -> bool
 
-            Check if the data ready event is fired manually (without polling)
-            for this attribute.
+        Check if the data ready event is fired manually (without polling)
+        for this attribute.
 
         Parameters : None
         Return     : (bool) True if a manual fire data ready event is implemented.
@@ -1874,13 +1901,14 @@ def __doc_Attribute():
     document_method("remove_configuration", """
     remove_configuration(self) -> None
 
-            Remove the attribute configuration from the database.
-            This method can be used to clean-up all the configuration of an
-            attribute to come back to its default values or the remove all
-            configuration of a dynamic attribute before deleting it.
+        Remove the attribute configuration from the database.
 
-            The method removes all configured attribute properties and removes
-            the attribute from the list of polled attributes.
+        This method can be used to clean-up all the configuration of an
+        attribute to come back to its default values or the remove all
+        configuration of a dynamic attribute before deleting it.
+
+        The method removes all configured attribute properties and removes
+        the attribute from the list of polled attributes.
 
         Parameters : None
         Return     : None
@@ -1900,8 +1928,8 @@ def __doc_WAttribute():
     document_method("get_min_value", """
     get_min_value(self) -> obj
 
-            Get attribute minimum value or throws an exception if the
-            attribute does not have a minimum value.
+        Get attribute minimum value or throws an exception if the
+        attribute does not have a minimum value.
 
         Parameters : None
         Return     : (obj) an object with the python minimum value
@@ -1910,8 +1938,8 @@ def __doc_WAttribute():
     document_method("get_max_value", """
     get_max_value(self) -> obj
 
-            Get attribute maximum value or throws an exception if the
-            attribute does not have a maximum value.
+        Get attribute maximum value or throws an exception if the
+        attribute does not have a maximum value.
 
         Parameters : None
         Return     : (obj) an object with the python maximum value
@@ -1920,7 +1948,7 @@ def __doc_WAttribute():
     document_method("set_min_value", """
     set_min_value(self, data) -> None
 
-            Set attribute minimum value.
+        Set attribute minimum value.
 
         Parameters :
             - data : the attribute minimum value. python data type must be compatible
@@ -1931,7 +1959,7 @@ def __doc_WAttribute():
     document_method("set_max_value", """
     set_max_value(self, data) -> None
 
-            Set attribute maximum value.
+        Set attribute maximum value.
 
         Parameters :
             - data : the attribute maximum value. python data type must be compatible
@@ -1942,7 +1970,7 @@ def __doc_WAttribute():
     document_method("is_min_value", """
     is_min_value(self) -> bool
 
-            Check if the attribute has a minimum value.
+        Check if the attribute has a minimum value.
 
         Parameters : None
         Return     : (bool) true if the attribute has a minimum value defined
@@ -1951,8 +1979,7 @@ def __doc_WAttribute():
     document_method("is_max_value", """
     is_max_value(self, ) -> bool
 
-            Check if the attribute has a maximum value.
-
+        Check if the attribute has a maximum value.
 
         Parameters : None
         Return     : (bool) true if the attribute has a maximum value defined
@@ -1961,7 +1988,7 @@ def __doc_WAttribute():
     document_method("get_write_value_length", """
     get_write_value_length(self) -> int
 
-            Retrieve the new value length (data number) for writable attribute.
+        Retrieve the new value length (data number) for writable attribute.
 
         Parameters : None
         Return     : (int) the new value data length
@@ -1970,7 +1997,7 @@ def __doc_WAttribute():
     #    document_method("set_write_value", """
     #    set_write_value(self, data, dim_x = 1, dim_y = 0) -> None
     #
-    #            Set the writable attribute value.
+    #        Set the writable attribute value.
     #
     #        Parameters :
     #            - data : the data to be set. Data must be compatible with the attribute type and format.
@@ -1985,7 +2012,7 @@ def __doc_WAttribute():
     get_write_value(self, lst) -> None  <= DEPRECATED
     get_write_value(self, extract_as=ExtractAs.Numpy) -> obj
 
-            Retrieve the new value for writable attribute.
+        Retrieve the new value for writable attribute.
 
         Parameters :
             - extract_as: (ExtractAs)
@@ -2000,6 +2027,7 @@ def __doc_MultiClassAttribute():
 
     MultiClassAttribute.__doc__ = """
     There is one instance of this class for each device class.
+
     This class is mainly an aggregate of :class:`~tango.Attr` objects.
     It eases management of multiple attributes
 
@@ -2008,8 +2036,8 @@ def __doc_MultiClassAttribute():
     document_method("get_attr", """
     get_attr(self, attr_name) -> Attr
 
-            Get the :class:`~tango.Attr` object for the attribute with
-            name passed as parameter
+        Get the :class:`~tango.Attr` object for the attribute with
+        name passed as parameter.
 
         Parameters :
             - attr_name : (str) attribute name
@@ -2023,9 +2051,10 @@ def __doc_MultiClassAttribute():
     document_method("remove_attr", """
     remove_attr(self, attr_name, cl_name) -> None
 
-            Remove the :class:`~tango.Attr` object for the attribute with
-            name passed as parameter. Does nothing if the attribute does not
-            exist.
+        Remove the :class:`~tango.Attr` object for the attribute with
+        name passed as parameter.
+
+        Does nothing if the attribute does not exist.
 
         Parameters :
             - attr_name : (str) attribute name
@@ -2037,7 +2066,7 @@ def __doc_MultiClassAttribute():
     document_method("get_attr_list", """
     get_attr_list(self) -> seq<Attr>
 
-            Get the list of :class:`~tango.Attr` for this device class.
+        Get the list of :class:`~tango.Attr` for this device class.
 
         Return     : (seq<Attr>) the list of attribute objects
 
@@ -2058,10 +2087,11 @@ def __doc_MultiAttribute():
     document_method("get_attr_by_name", """
     get_attr_by_name(self, attr_name) -> Attribute
 
-            Get :class:`~tango.Attribute` object from its name.
-            This method returns an :class:`~tango.Attribute` object with a
-            name passed as parameter. The equality on attribute name is case
-            independant.
+        Get :class:`~tango.Attribute` object from its name.
+
+        This method returns an :class:`~tango.Attribute` object with a
+        name passed as parameter. The equality on attribute name is case
+        independant.
 
         Parameters :
             - attr_name : (str) attribute name
@@ -2073,9 +2103,10 @@ def __doc_MultiAttribute():
     document_method("get_attr_by_ind", """
     get_attr_by_ind(self, ind) -> Attribute
 
-            Get :class:`~tango.Attribute` object from its index.
-            This method returns an :class:`~tango.Attribute` object from the
-            index in the main attribute vector.
+        Get :class:`~tango.Attribute` object from its index.
+
+        This method returns an :class:`~tango.Attribute` object from the
+        index in the main attribute vector.
 
         Parameters :
             - ind : (int) the attribute index
@@ -2085,10 +2116,11 @@ def __doc_MultiAttribute():
     document_method("get_w_attr_by_name", """
     get_w_attr_by_name(self, attr_name) -> WAttribute
 
-            Get a writable attribute object from its name.
-            This method returns an :class:`~tango.WAttribute` object with a
-            name passed as parameter. The equality on attribute name is case
-            independant.
+        Get a writable attribute object from its name.
+
+        This method returns an :class:`~tango.WAttribute` object with a
+        name passed as parameter. The equality on attribute name is case
+        independant.
 
         Parameters :
             - attr_name : (str) attribute name
@@ -2100,9 +2132,10 @@ def __doc_MultiAttribute():
     document_method("get_w_attr_by_ind", """
     get_w_attr_by_ind(self, ind) -> WAttribute
 
-            Get a writable attribute object from its index.
-            This method returns an :class:`~tango.WAttribute` object from the
-            index in the main attribute vector.
+        Get a writable attribute object from its index.
+
+        This method returns an :class:`~tango.WAttribute` object from the
+        index in the main attribute vector.
 
         Parameters :
             - ind : (int) the attribute index
@@ -2112,10 +2145,11 @@ def __doc_MultiAttribute():
     document_method("get_attr_ind_by_name", """
     get_attr_ind_by_name(self, attr_name) -> int
 
-            Get Attribute index into the main attribute vector from its name.
-            This method returns the index in the Attribute vector (stored in the
-            :class:`~tango.MultiAttribute` object) of an attribute with a
-            given name. The name equality is case independant.
+        Get Attribute index into the main attribute vector from its name.
+
+        This method returns the index in the Attribute vector (stored in the
+        :class:`~tango.MultiAttribute` object) of an attribute with a
+        given name. The name equality is case independant.
 
         Parameters :
             - attr_name : (str) attribute name
@@ -2129,7 +2163,7 @@ def __doc_MultiAttribute():
     document_method("get_attr_nb", """
     get_attr_nb(self) -> int
 
-            Get attribute number.
+        Get attribute number.
 
         Parameters : None
         Return     : (int) the number of attributes
@@ -2142,9 +2176,11 @@ def __doc_MultiAttribute():
     check_alarm(self, attr_name) -> bool
     check_alarm(self, ind) -> bool
 
-            - The 1st version of the method checks alarm on all attribute(s) with an alarm defined.
-            - The 2nd version of the method checks alarm for one attribute with a given name.
-            - The 3rd version of the method checks alarm for one attribute from its index in the main attributes vector.
+        Checks an alarm.
+
+        - The 1st version of the method checks alarm on all attribute(s) with an alarm defined.
+        - The 2nd version of the method checks alarm for one attribute with a given name.
+        - The 3rd version of the method checks alarm for one attribute from its index in the main attributes vector.
 
         Parameters :
             - attr_name : (str) attribute name
@@ -2159,9 +2195,10 @@ def __doc_MultiAttribute():
     document_method("read_alarm", """
     read_alarm(self, status) -> None
 
-            Add alarm message to device status.
-            This method add alarm mesage to the string passed as parameter.
-            A message is added for each attribute which is in alarm condition
+        Add alarm message to device status.
+
+        This method add alarm mesage to the string passed as parameter.
+        A message is added for each attribute which is in alarm condition
 
         Parameters :
             - status : (str) a string (should be the device status)
@@ -2173,7 +2210,7 @@ def __doc_MultiAttribute():
     document_method("get_attribute_list", """
     get_attribute_list(self) -> seq<Attribute>
 
-            Get the list of attribute objects.
+        Get the list of attribute objects.
 
         Return     : (seq<Attribute>) list of attribute objects
 
@@ -2192,7 +2229,7 @@ def __doc_Attr():
     document_method("set_default_properties", """
     set_default_properties(self) -> None
 
-            Set default attribute properties.
+        Set default attribute properties.
 
         Parameters :
             - attr_prop : (UserDefaultAttrProp) the user default property class
@@ -2202,7 +2239,7 @@ def __doc_Attr():
     document_method("set_disp_level", """
     set_disp_level(self, disp_lelel) -> None
 
-            Set the attribute display level.
+        Set the attribute display level.
 
         Parameters :
             - disp_level : (DispLevel) the new display level
@@ -2212,7 +2249,7 @@ def __doc_Attr():
     document_method("set_polling_period", """
     set_polling_period(self, period) -> None
 
-            Set the attribute polling update period.
+        Set the attribute polling update period.
 
         Parameters :
             - period : (int) the attribute polling period (in mS)
@@ -2222,9 +2259,11 @@ def __doc_Attr():
     document_method("set_memorized", """
     set_memorized(self) -> None
 
-            Set the attribute as memorized in database (only for scalar
-            and writable attribute) With no argument the setpoint will be
-            written to the attribute during initialisation!
+        Set the attribute as memorized in database (only for scalar
+        and writable attribute).
+
+        With no argument the setpoint will be
+        written to the attribute during initialisation!
 
         Parameters : None
         Return     : None
@@ -2233,10 +2272,12 @@ def __doc_Attr():
     document_method("set_memorized_init", """
     set_memorized_init(self, write_on_init) -> None
 
-            Set the initialisation flag for memorized attributes
-            true = the setpoint value will be written to the attribute on initialisation
-            false = only the attribute setpoint is initialised.
-            No action is taken on the attribute
+        Set the initialisation flag for memorized attributes.
+
+        - true = the setpoint value will be written to the attribute on initialisation
+        - false = only the attribute setpoint is initialised.
+
+        No action is taken on the attribute
 
         Parameters :
             - write_on_init : (bool) if true the setpoint value will be written
@@ -2247,13 +2288,14 @@ def __doc_Attr():
     document_method("set_change_event", """
     set_change_event(self, implemented, detect) -> None
 
-            Set a flag to indicate that the server fires change events manually
-            without the polling to be started for the attribute.
-            If the detect parameter is set to true, the criteria specified for
-            the change event are verified and the event is only pushed if they
-            are fullfilled.
+        Set a flag to indicate that the server fires change events manually
+        without the polling to be started for the attribute.
 
-            If detect is set to false the event is fired without checking!
+        If the detect parameter is set to true, the criteria specified for
+        the change event are verified and the event is only pushed if they
+        are fullfilled.
+
+        If detect is set to false the event is fired without checking!
 
         Parameters :
             - implemented : (bool) True when the server fires change events manually.
@@ -2265,7 +2307,7 @@ def __doc_Attr():
     document_method("is_change_event", """
     is_change_event(self) -> bool
 
-            Check if the change event is fired manually for this attribute.
+        Check if the change event is fired manually for this attribute.
 
         Parameters : None
         Return     : (bool) true if a manual fire change event is implemented.
@@ -2274,7 +2316,7 @@ def __doc_Attr():
     document_method("is_check_change_criteria", """
     is_check_change_criteria(self) -> bool
 
-            Check if the change event criteria should be checked when firing the event manually.
+        Check if the change event criteria should be checked when firing the event manually.
 
         Parameters : None
         Return     : (bool) true if a change event criteria will be checked.
@@ -2283,12 +2325,14 @@ def __doc_Attr():
     document_method("set_archive_event", """
     set_archive_event(self) -> None
 
-            Set a flag to indicate that the server fires archive events manually
-            without the polling to be started for the attribute If the detect
-            parameter is set to true, the criteria specified for the archive
-            event are verified and the event is only pushed if they are fullfilled.
+        Set a flag to indicate that the server fires archive events manually
+        without the polling to be started for the attribute.
 
-            If detect is set to false the event is fired without checking!
+        If the detect
+        parameter is set to true, the criteria specified for the archive
+        event are verified and the event is only pushed if they are fullfilled.
+
+        If detect is set to false the event is fired without checking!
 
         Parameters :
             - implemented : (bool) True when the server fires change events manually.
@@ -2300,7 +2344,7 @@ def __doc_Attr():
     document_method("is_archive_event", """
     is_archive_event(self) -> bool
 
-            Check if the archive event is fired manually for this attribute.
+        Check if the archive event is fired manually for this attribute.
 
         Parameters : None
         Return     : (bool) true if a manual fire archive event is implemented.
@@ -2309,7 +2353,7 @@ def __doc_Attr():
     document_method("is_check_archive_criteria", """
     is_check_archive_criteria(self) -> bool
 
-            Check if the archive event criteria should be checked when firing the event manually.
+        Check if the archive event criteria should be checked when firing the event manually.
 
         Parameters : None
         Return     : (bool) true if a archive event criteria will be checked.
@@ -2318,7 +2362,7 @@ def __doc_Attr():
     document_method("set_data_ready_event", """
     set_data_ready_event(self, implemented) -> None
 
-            Set a flag to indicate that the server fires data ready events.
+        Set a flag to indicate that the server fires data ready events.
 
         Parameters :
             - implemented : (bool) True when the server fires data ready events
@@ -2330,7 +2374,7 @@ def __doc_Attr():
     document_method("is_data_ready_event", """
     is_data_ready_event(self) -> bool
 
-            Check if the data ready event is fired for this attribute.
+        Check if the data ready event is fired for this attribute.
 
         Parameters : None
         Return     : (bool) true if firing data ready event is implemented.
@@ -2341,7 +2385,7 @@ def __doc_Attr():
     document_method("get_name", """
     get_name(self) -> str
 
-            Get the attribute name.
+        Get the attribute name.
 
         Parameters : None
         Return     : (str) the attribute name
@@ -2350,7 +2394,7 @@ def __doc_Attr():
     document_method("get_format", """
     get_format(self) -> AttrDataFormat
 
-            Get the attribute format
+        Get the attribute format.
 
         Parameters : None
         Return     : (AttrDataFormat) the attribute format
@@ -2359,7 +2403,7 @@ def __doc_Attr():
     document_method("get_writable", """
     get_writable(self) -> AttrWriteType
 
-            Get the attribute write type
+        Get the attribute write type.
 
         Parameters : None
         Return     : (AttrWriteType) the attribute write type
@@ -2368,7 +2412,7 @@ def __doc_Attr():
     document_method("get_type", """
     get_type(self) -> int
 
-            Get the attribute data type
+        Get the attribute data type.
 
         Parameters : None
         Return     : (int) the attribute data type
@@ -2377,7 +2421,7 @@ def __doc_Attr():
     document_method("get_disp_level", """
     get_disp_level(self) -> DispLevel
 
-            Get the attribute display level
+        Get the attribute display level.
 
         Parameters : None
         Return     : (DispLevel) the attribute display level
@@ -2386,7 +2430,7 @@ def __doc_Attr():
     document_method("get_polling_period", """
     get_polling_period(self) -> int
 
-            Get the polling period (mS)
+        Get the polling period (mS).
 
         Parameters : None
         Return     : (int) the polling period (mS)
@@ -2395,7 +2439,7 @@ def __doc_Attr():
     document_method("get_memorized", """
     get_memorized(self) -> bool
 
-            Determine if the attribute is memorized or not.
+        Determine if the attribute is memorized or not.
 
         Parameters : None
         Return     : (bool) True if the attribute is memorized
@@ -2404,8 +2448,8 @@ def __doc_Attr():
     document_method("get_memorized_init", """
     get_memorized_init(self) -> bool
 
-            Determine if the attribute is written at startup from the memorized value if
-            it is memorized
+        Determine if the attribute is written at startup from the memorized
+        value if it is memorized.
 
         Parameters : None
         Return     : (bool) True if initialized with memorized value or not
@@ -2414,7 +2458,7 @@ def __doc_Attr():
     document_method("get_assoc", """
     get_assoc(self) -> str
 
-            Get the associated name.
+        Get the associated name.
 
         Parameters : None
         Return     : (bool) the associated name
@@ -2423,7 +2467,7 @@ def __doc_Attr():
     document_method("is_assoc", """
     is_assoc(self) -> bool
 
-            Determine if it is assoc.
+        Determine if it is assoc.
 
         Parameters : None
         Return     : (bool) if it is assoc
@@ -2432,7 +2476,7 @@ def __doc_Attr():
     document_method("get_cl_name", """
     get_cl_name(self) -> str
 
-            Returns the class name
+        Returns the class name.
 
         Parameters : None
         Return     : (str) the class name
@@ -2443,7 +2487,7 @@ def __doc_Attr():
     document_method("set_cl_name", """
     set_cl_name(self, cl) -> None
 
-            Sets the class name
+        Sets the class name.
 
         Parameters :
             - cl : (str) new class name
@@ -2455,7 +2499,7 @@ def __doc_Attr():
     document_method("get_class_properties", """
     get_class_properties(self) -> sequence<AttrProperty>
 
-            Get the class level attribute properties
+        Get the class level attribute properties.
 
         Parameters : None
         Return     : (sequence<AttrProperty>) the class attribute properties
@@ -2464,7 +2508,7 @@ def __doc_Attr():
     document_method("get_user_default_properties", """
     get_user_default_properties(self) -> sequence<AttrProperty>
 
-            Get the user default attribute properties
+        Get the user default attribute properties.
 
         Parameters : None
         Return     : (sequence<AttrProperty>) the user default attribute properties
@@ -2473,7 +2517,7 @@ def __doc_Attr():
     document_method("set_class_properties", """
     set_class_properties(self, props) -> None
 
-            Set the class level attribute properties
+        Set the class level attribute properties.
 
         Parameters :
             - props : (StdAttrPropertyVector) new class level attribute properties
@@ -2487,17 +2531,18 @@ def __doc_UserDefaultAttrProp():
 
     UserDefaultAttrProp.__doc__ = """
     User class to set attribute default properties.
+
     This class is used to set attribute default properties.
     Three levels of attributes properties setting are implemented within Tango.
     The highest property setting level is the database.
     Then the user default (set using this UserDefaultAttrProp class) and finally
-    a Tango library default value
+    a Tango library default value.
     """
 
     document_method("set_label", """
     set_label(self, def_label) -> None
 
-            Set default label property.
+        Set default label property.
 
         Parameters :
             - def_label : (str) the user default label property
@@ -2507,7 +2552,7 @@ def __doc_UserDefaultAttrProp():
     document_method("set_description", """
     set_description(self, def_description) -> None
 
-            Set default description property.
+        Set default description property.
 
         Parameters :
             - def_description : (str) the user default description property
@@ -2517,7 +2562,7 @@ def __doc_UserDefaultAttrProp():
     document_method("set_format", """
     set_format(self, def_format) -> None
 
-            Set default format property.
+        Set default format property.
 
         Parameters :
             - def_format : (str) the user default format property
@@ -2527,7 +2572,7 @@ def __doc_UserDefaultAttrProp():
     document_method("set_unit", """
     set_unit(self, def_unit) -> None
 
-            Set default unit property.
+        Set default unit property.
 
         Parameters :
             - def_unit : (str) te user default unit property
@@ -2537,7 +2582,7 @@ def __doc_UserDefaultAttrProp():
     document_method("set_standard_unit", """
     set_standard_unit(self, def_standard_unit) -> None
 
-            Set default standard unit property.
+        Set default standard unit property.
 
         Parameters :
             - def_standard_unit : (str) the user default standard unit property
@@ -2547,7 +2592,7 @@ def __doc_UserDefaultAttrProp():
     document_method("set_display_unit", """
     set_display_unit(self, def_display_unit) -> None
 
-            Set default display unit property.
+        Set default display unit property.
 
         Parameters :
             - def_display_unit : (str) the user default display unit property
@@ -2557,7 +2602,7 @@ def __doc_UserDefaultAttrProp():
     document_method("set_min_value", """
     set_min_value(self, def_min_value) -> None
 
-            Set default min_value property.
+        Set default min_value property.
 
         Parameters :
             - def_min_value : (str) the user default min_value property
@@ -2567,7 +2612,7 @@ def __doc_UserDefaultAttrProp():
     document_method("set_max_value", """
     set_max_value(self, def_max_value) -> None
 
-            Set default max_value property.
+        Set default max_value property.
 
         Parameters :
             - def_max_value : (str) the user default max_value property
@@ -2577,7 +2622,7 @@ def __doc_UserDefaultAttrProp():
     document_method("set_min_alarm", """
     set_min_alarm(self, def_min_alarm) -> None
 
-            Set default min_alarm property.
+        Set default min_alarm property.
 
         Parameters :
             - def_min_alarm : (str) the user default min_alarm property
@@ -2587,7 +2632,7 @@ def __doc_UserDefaultAttrProp():
     document_method("set_max_alarm", """
     set_max_alarm(self, def_max_alarm) -> None
 
-            Set default max_alarm property.
+        Set default max_alarm property.
 
         Parameters :
             - def_max_alarm : (str) the user default max_alarm property
@@ -2597,7 +2642,7 @@ def __doc_UserDefaultAttrProp():
     document_method("set_min_warning", """
     set_min_warning(self, def_min_warning) -> None
 
-            Set default min_warning property.
+        Set default min_warning property.
 
         Parameters :
             - def_min_warning : (str) the user default min_warning property
@@ -2607,7 +2652,7 @@ def __doc_UserDefaultAttrProp():
     document_method("set_max_warning", """
     set_max_warning(self, def_max_warning) -> None
 
-            Set default max_warning property.
+        Set default max_warning property.
 
         Parameters :
             - def_max_warning : (str) the user default max_warning property
@@ -2617,7 +2662,7 @@ def __doc_UserDefaultAttrProp():
     document_method("set_delta_t", """
     set_delta_t(self, def_delta_t) -> None
 
-            Set default RDS alarm delta_t property.
+        Set default RDS alarm delta_t property.
 
         Parameters :
             - def_delta_t : (str) the user default RDS alarm delta_t property
@@ -2627,7 +2672,7 @@ def __doc_UserDefaultAttrProp():
     document_method("set_delta_val", """
     set_delta_val(self, def_delta_val) -> None
 
-            Set default RDS alarm delta_val property.
+        Set default RDS alarm delta_val property.
 
         Parameters :
             - def_delta_val : (str) the user default RDS alarm delta_val property
@@ -2637,7 +2682,7 @@ def __doc_UserDefaultAttrProp():
     document_method("set_abs_change", """
     set_abs_change(self, def_abs_change) -> None <= DEPRECATED
 
-            Set default change event abs_change property.
+        Set default change event abs_change property.
 
         Parameters :
             - def_abs_change : (str) the user default change event abs_change property
@@ -2649,7 +2694,7 @@ def __doc_UserDefaultAttrProp():
     document_method("set_event_abs_change", """
     set_event_abs_change(self, def_abs_change) -> None
 
-            Set default change event abs_change property.
+        Set default change event abs_change property.
 
         Parameters :
             - def_abs_change : (str) the user default change event abs_change property
@@ -2661,7 +2706,7 @@ def __doc_UserDefaultAttrProp():
     document_method("set_rel_change", """
     set_rel_change(self, def_rel_change) -> None <= DEPRECATED
 
-            Set default change event rel_change property.
+        Set default change event rel_change property.
 
         Parameters :
             - def_rel_change : (str) the user default change event rel_change property
@@ -2673,7 +2718,7 @@ def __doc_UserDefaultAttrProp():
     document_method("set_event_rel_change", """
     set_event_rel_change(self, def_rel_change) -> None
 
-            Set default change event rel_change property.
+        Set default change event rel_change property.
 
         Parameters :
             - def_rel_change : (str) the user default change event rel_change property
@@ -2685,7 +2730,7 @@ def __doc_UserDefaultAttrProp():
     document_method("set_period", """
     set_period(self, def_period) -> None <= DEPRECATED
 
-            Set default periodic event period property.
+        Set default periodic event period property.
 
         Parameters :
             - def_period : (str) the user default periodic event period property
@@ -2697,7 +2742,7 @@ def __doc_UserDefaultAttrProp():
     document_method("set_event_period", """
     set_event_period(self, def_period) -> None
 
-            Set default periodic event period property.
+        Set default periodic event period property.
 
         Parameters :
             - def_period : (str) the user default periodic event period property
@@ -2709,7 +2754,7 @@ def __doc_UserDefaultAttrProp():
     document_method("set_archive_abs_change", """
     set_archive_abs_change(self, def_archive_abs_change) -> None <= DEPRECATED
 
-            Set default archive event abs_change property.
+        Set default archive event abs_change property.
 
         Parameters :
             - def_archive_abs_change : (str) the user default archive event abs_change property
@@ -2721,7 +2766,7 @@ def __doc_UserDefaultAttrProp():
     document_method("set_archive_event_abs_change", """
     set_archive_event_abs_change(self, def_archive_abs_change) -> None
 
-            Set default archive event abs_change property.
+        Set default archive event abs_change property.
 
         Parameters :
             - def_archive_abs_change : (str) the user default archive event abs_change property
@@ -2733,7 +2778,7 @@ def __doc_UserDefaultAttrProp():
     document_method("set_archive_rel_change", """
     set_archive_rel_change(self, def_archive_rel_change) -> None <= DEPRECATED
 
-            Set default archive event rel_change property.
+        Set default archive event rel_change property.
 
         Parameters :
             - def_archive_rel_change : (str) the user default archive event rel_change property
@@ -2745,7 +2790,7 @@ def __doc_UserDefaultAttrProp():
     document_method("set_archive_event_rel_change", """
     set_archive_event_rel_change(self, def_archive_rel_change) -> None
 
-            Set default archive event rel_change property.
+        Set default archive event rel_change property.
 
         Parameters :
             - def_archive_rel_change : (str) the user default archive event rel_change property
@@ -2757,7 +2802,7 @@ def __doc_UserDefaultAttrProp():
     document_method("set_archive_period", """
     set_archive_period(self, def_archive_period) -> None <= DEPRECATED
 
-            Set default archive event period property.
+        Set default archive event period property.
 
         Parameters :
             - def_archive_period : (str) t
@@ -2769,7 +2814,7 @@ def __doc_UserDefaultAttrProp():
     document_method("set_archive_event_period", """
     set_archive_event_period(self, def_archive_period) -> None
 
-            Set default archive event period property.
+        Set default archive event period property.
 
         Parameters :
             - def_archive_period : (str) t

--- a/tango/device_server.py
+++ b/tango/device_server.py
@@ -468,6 +468,7 @@ def __DeviceImpl__remove_command(self, cmd_name, free_it=False, clean_db=True):
             - free_it  : Boolean set to true if the command object must be freed.
             - clean_db : Clean command related information (included polling info
                          if the command is polled) from database.
+
         Return     : None
 
         Throws     : DevFailed
@@ -497,6 +498,7 @@ def __DeviceImpl__debug_stream(self, msg, *args):
 
         Parameters :
             - msg : (str) the message to be sent to the debug stream
+
         Return     : None
     """
     self.__debug_stream(msg % args)
@@ -514,6 +516,7 @@ def __DeviceImpl__info_stream(self, msg, *args):
 
         Parameters :
             - msg : (str) the message to be sent to the info stream
+
         Return     : None
     """
     self.__info_stream(msg % args)
@@ -531,6 +534,7 @@ def __DeviceImpl__warn_stream(self, msg, *args):
 
         Parameters :
             - msg : (str) the message to be sent to the warn stream
+
         Return     : None
     """
     self.__warn_stream(msg % args)
@@ -548,6 +552,7 @@ def __DeviceImpl__error_stream(self, msg, *args):
 
         Parameters :
             - msg : (str) the message to be sent to the error stream
+
         Return     : None
     """
     self.__error_stream(msg % args)
@@ -565,6 +570,7 @@ def __DeviceImpl__fatal_stream(self, msg, *args):
 
         Parameters :
             - msg : (str) the message to be sent to the fatal stream
+
         Return     : None
     """
     self.__fatal_stream(msg % args)
@@ -642,6 +648,7 @@ def __Logger__log(self, level, msg, *args):
             - level: (Level.LevelLevel) Log level
             - msg : (str) the message to be sent to the stream
             - args: (seq<str>) list of optional message arguments
+
         Return     : None
     """
     self.__log(level, msg % args)
@@ -658,6 +665,7 @@ def __Logger__log_unconditionally(self, level, msg, *args):
             - level: (Level.LevelLevel) Log level
             - msg : (str) the message to be sent to the stream
             - args: (seq<str>) list of optional message arguments
+
         Return     : None
     """
     self.__log_unconditionally(level, msg % args)
@@ -672,6 +680,7 @@ def __Logger__debug(self, msg, *args):
         Parameters :
             - msg : (str) the message to be sent to the debug stream
             - args: (seq<str>) list of optional message arguments
+
         Return     : None
     """
     self.__debug(msg % args)
@@ -686,6 +695,7 @@ def __Logger__info(self, msg, *args):
         Parameters :
             - msg : (str) the message to be sent to the info stream
             - args: (seq<str>) list of optional message arguments
+
         Return     : None
     """
     self.__info(msg % args)
@@ -700,6 +710,7 @@ def __Logger__warn(self, msg, *args):
         Parameters :
             - msg : (str) the message to be sent to the warn stream
             - args: (seq<str>) list of optional message arguments
+
         Return     : None
     """
     self.__warn(msg % args)
@@ -714,6 +725,7 @@ def __Logger__error(self, msg, *args):
         Parameters :
             - msg : (str) the message to be sent to the error stream
             - args: (seq<str>) list of optional message arguments
+
         Return     : None
     """
     self.__error(msg % args)
@@ -728,6 +740,7 @@ def __Logger__fatal(self, msg, *args):
         Parameters :
             - msg : (str) the message to be sent to the fatal stream
             - args: (seq<str>) list of optional message arguments
+
         Return     : None
     """
     self.__fatal(msg % args)
@@ -789,6 +802,7 @@ def __doc_DeviceImpl():
         Intialize the device.
 
         Parameters : None
+
         Return     : None
     """)
 
@@ -799,6 +813,7 @@ def __doc_DeviceImpl():
 
         Parameters :
             - new_state : (DevState) the new device state
+
         Return     : None
     """)
 
@@ -808,6 +823,7 @@ def __doc_DeviceImpl():
         Get a COPY of the device state.
 
         Parameters : None
+
         Return     : (DevState) Current device state
     """)
 
@@ -817,6 +833,7 @@ def __doc_DeviceImpl():
         Get a COPY of the device's previous state.
 
         Parameters : None
+
         Return     : (DevState) the device's previous state
 
     """)
@@ -827,6 +844,7 @@ def __doc_DeviceImpl():
         Get a COPY of the device name.
 
         Parameters : None
+
         Return     : (str) the device name
 
     """)
@@ -837,6 +855,7 @@ def __doc_DeviceImpl():
         Get device multi attribute object.
 
         Parameters : None
+
         Return     : (MultiAttribute) the device's MultiAttribute object
 
     """)
@@ -851,8 +870,8 @@ def __doc_DeviceImpl():
 
         Parameters :
             - signo : (int) signal identifier
-        Return     : None
 
+        Return     : None
     """)
 
     document_method("unregister_signal", """
@@ -865,8 +884,8 @@ def __doc_DeviceImpl():
 
         Parameters :
             - signo : (int) signal identifier
-        Return     : None
 
+        Return     : None
     """)
 
     document_method("get_status", """
@@ -875,8 +894,8 @@ def __doc_DeviceImpl():
         Get a COPY of the device status.
 
         Parameters : None
-        Return     : (str) the device status
 
+        Return     : (str) the device status
     """)
 
     document_method("set_status", """
@@ -886,8 +905,8 @@ def __doc_DeviceImpl():
 
         Parameters :
             - new_status : (str) the new device status
-        Return     : None
 
+        Return     : None
     """)
 
     document_method("append_status", """
@@ -898,8 +917,8 @@ def __doc_DeviceImpl():
         Parameters :
             status : (str) the string to be appened to the device status
             new_line : (bool) If true, appends a new line character before the string. Default is False
-        Return     : None
 
+        Return     : None
     """)
 
     document_method("dev_state", """
@@ -916,6 +935,7 @@ def __doc_DeviceImpl():
         of the default behaviour does not fullfill the needs.
 
         Parameters : None
+
         Return     : (DevState) the device state
 
         Throws     : DevFailed - If it is necessary to read attribute(s) and a problem occurs during the reading
@@ -932,6 +952,7 @@ def __doc_DeviceImpl():
         of the default behaviour does not fullfill the needs.
 
         Parameters : None
+
         Return     : (str) the device status
 
         Throws     : DevFailed - If it is necessary to read attribute(s) and a problem occurs during the reading
@@ -952,6 +973,7 @@ def __doc_DeviceImpl():
             - implemented : (bool) True when the server fires change events manually.
             - detect : (bool) Triggers the verification of the change event properties
                        when set to true. Default value is true.
+
         Return     : None
     """)
 
@@ -970,8 +992,8 @@ def __doc_DeviceImpl():
             - implemented : (bool) True when the server fires change events manually.
             - detect : (bool) Triggers the verification of the change event properties
                        when set to true. Default value is true.
-        Return     : None
 
+        Return     : None
     """)
 
     document_method("push_change_event", """
@@ -1074,6 +1096,7 @@ def __doc_DeviceImpl():
         Parameters :
             - attr_name : (str) attribute name
             - counter : (int) the user counter
+
         Return     : None
 
         Throws     : DevFailed If the attribute name is unknown.
@@ -1089,6 +1112,7 @@ def __doc_DeviceImpl():
         Parameters :
             - pipe_name : (str) pipe name
             - blob  : (DevicePipeBlob) the blob data
+
         Return     : None
 
         Throws     : DevFailed If the pipe name is unknown.
@@ -1102,6 +1126,7 @@ def __doc_DeviceImpl():
         Returns the Logger object for this device
 
         Parameters : None
+
         Return     : (Logger) the Logger object for this device
     """)
 
@@ -1111,6 +1136,7 @@ def __doc_DeviceImpl():
         Returns the state of the exported flag
 
         Parameters : None
+
         Return     : (bool) the state of the exported flag
 
         New in PyTango 7.1.2
@@ -1122,6 +1148,7 @@ def __doc_DeviceImpl():
         Returns the poll ring depth
 
         Parameters : None
+
         Return     : (int) the poll ring depth
 
         New in PyTango 7.1.2
@@ -1133,6 +1160,7 @@ def __doc_DeviceImpl():
         Returns the poll old factor
 
         Parameters : None
+
         Return     : (int) the poll old factor
 
         New in PyTango 7.1.2
@@ -1144,6 +1172,7 @@ def __doc_DeviceImpl():
         Returns if it is polled
 
         Parameters : None
+
         Return     : (bool) True if it is polled or False otherwise
 
         New in PyTango 7.1.2
@@ -1155,6 +1184,7 @@ def __doc_DeviceImpl():
         Returns a COPY of the list of polled commands
 
         Parameters : None
+
         Return     : (sequence<str>) a COPY of the list of polled commands
 
         New in PyTango 7.1.2
@@ -1166,6 +1196,7 @@ def __doc_DeviceImpl():
         Returns a COPY of the list of polled attributes
 
         Parameters : None
+
         Return     : (sequence<str>) a COPY of the list of polled attributes
 
         New in PyTango 7.1.2
@@ -1177,6 +1208,7 @@ def __doc_DeviceImpl():
         Returns a COPY of the list of non automatic polled commands
 
         Parameters : None
+
         Return     : (sequence<str>) a COPY of the list of non automatic polled commands
 
         New in PyTango 7.1.2
@@ -1188,6 +1220,7 @@ def __doc_DeviceImpl():
         Returns a COPY of the list of non automatic polled attributes
 
         Parameters : None
+
         Return     : (sequence<str>) a COPY of the list of non automatic polled attributes
 
         New in PyTango 7.1.2
@@ -1201,7 +1234,8 @@ def __doc_DeviceImpl():
         method before deleting it.
 
         Parameters :
-            - with_db_upd : (bool)  Is it necessary to update db ?
+            - with_db_upd : (bool)  Is it necessary to update db?
+
         Return     : None
 
         New in PyTango 7.1.2
@@ -1215,6 +1249,7 @@ def __doc_DeviceImpl():
 
         Parameters :
             - attr_name : (str) attribute name
+
         Return     : (int) attribute polling period (ms) or 0 if it is not polled
 
         New in PyTango 8.0.0
@@ -1228,6 +1263,7 @@ def __doc_DeviceImpl():
 
         Parameters :
             - cmd_name : (str) command name
+
         Return     : (int) command polling period (ms) or 0 if it is not polled
 
         New in PyTango 8.0.0
@@ -1244,6 +1280,7 @@ def __doc_DeviceImpl():
 
         Parameters :
             - cmd_name: (str) the command name
+
         Return     : None
 
         Throws     : DevFailed API_IncompatibleCmdArgumentType, API_CommandNotFound
@@ -1257,6 +1294,7 @@ def __doc_DeviceImpl():
         Returns the IDL version.
 
         Parameters : None
+
         Return     : (int) the IDL version
 
         New in PyTango 7.1.2
@@ -1269,6 +1307,7 @@ def __doc_DeviceImpl():
 
         Parameters :
             - cmd_name: (str) the command name
+
         Return     : (int) the command poll ring depth
 
         New in PyTango 7.1.2
@@ -1281,6 +1320,7 @@ def __doc_DeviceImpl():
 
         Parameters :
             - attr_name: (str) the attribute name
+
         Return     : (int) the attribute poll ring depth
 
         New in PyTango 7.1.2
@@ -1292,6 +1332,7 @@ def __doc_DeviceImpl():
         Returns if this device is locked by a client.
 
         Parameters : None
+
         Return     : (bool) True if it is locked or False otherwise
 
         New in PyTango 7.1.2
@@ -1303,6 +1344,7 @@ def __doc_DeviceImpl():
         Returns the min poll period.
 
         Parameters : None
+
         Return     : (int) the min poll period
 
         New in PyTango 7.2.0
@@ -1314,6 +1356,7 @@ def __doc_DeviceImpl():
         Returns the min command poll period.
 
         Parameters : None
+
         Return     : (seq<str>) the min command poll period
 
         New in PyTango 7.2.0
@@ -1325,6 +1368,7 @@ def __doc_DeviceImpl():
         Returns the min attribute poll period
 
         Parameters : None
+
         Return     : (seq<str>) the min attribute poll period
 
         New in PyTango 7.2.0
@@ -1348,6 +1392,7 @@ def __doc_DeviceImpl():
         Push an pipe event.
 
         Parameters :  the blob which pipe event will be send.
+
         Return     : None
 
         New in PyTango 9.2.2
@@ -1369,6 +1414,7 @@ def __doc_DeviceImpl():
         Parameters :
             - att_name: (str) the attribute name
             - event_type (EventType): the event type
+
         Return     : True if there is at least one listener or False otherwise
     """)
 
@@ -1383,8 +1429,8 @@ def __doc_extra_DeviceImpl(cls):
         Delete the device.
 
         Parameters : None
-        Return     : None
 
+        Return     : None
     """)
 
     document_method("always_executed_hook", """
@@ -1397,6 +1443,7 @@ def __doc_extra_DeviceImpl(cls):
         in case of the default behaviour does not fullfill the needs
 
         Parameters : None
+
         Return     : None
 
         Throws     : DevFailed This method does not throw exception but a redefined method can.
@@ -1432,6 +1479,7 @@ def __doc_extra_DeviceImpl(cls):
         Parameters :
             attr_list : (sequence<int>) list of indices in the device object attribute vector
                         of an attribute to be written.
+
         Return     : None
 
         Throws     : DevFailed This method does not throw exception but a redefined method can.
@@ -1448,6 +1496,7 @@ def __doc_extra_DeviceImpl(cls):
 
         Parameters :
             - signo : (int) the signal number
+
         Return     : None
 
         Throws     : DevFailed This method does not throw exception but a redefined method can.
@@ -1471,6 +1520,7 @@ def __doc_Attribute():
         Check if the attribute has an associated writable attribute.
 
         Parameters : None
+
         Return     : (bool) True if there is an associated writable attribute
     """)
 
@@ -1480,6 +1530,7 @@ def __doc_Attribute():
         Check if the attribute is in minimum alarm condition.
 
         Parameters : None
+
         Return     : (bool) true if the attribute is in alarm condition (read value below the min. alarm).
     """)
 
@@ -1489,6 +1540,7 @@ def __doc_Attribute():
         Check if the attribute is in maximum alarm condition.
 
         Parameters : None
+
         Return     : (bool) true if the attribute is in alarm condition (read value above the max. alarm).
     """)
 
@@ -1498,6 +1550,7 @@ def __doc_Attribute():
         Check if the attribute is in minimum warning condition.
 
         Parameters : None
+
         Return     : (bool) true if the attribute is in warning condition (read value below the min. warning).
     """)
 
@@ -1507,6 +1560,7 @@ def __doc_Attribute():
         Check if the attribute is in maximum warning condition.
 
         Parameters : None
+
         Return     : (bool) true if the attribute is in warning condition (read value above the max. warning).
     """)
 
@@ -1516,6 +1570,7 @@ def __doc_Attribute():
         Check if the attribute is in RDS alarm condition.
 
         Parameters : None
+
         Return     : (bool) true if the attribute is in RDS condition (Read Different than Set).
     """)
 
@@ -1525,6 +1580,7 @@ def __doc_Attribute():
         Check if the attribute is polled.
 
         Parameters : None
+
         Return     : (bool) true if the attribute is polled.
     """)
 
@@ -1534,6 +1590,7 @@ def __doc_Attribute():
         Check if the attribute read value is below/above the alarm level.
 
         Parameters : None
+
         Return     : (bool) true if the attribute is in alarm condition.
 
         Throws     : DevFailed If no alarm level is defined.
@@ -1545,6 +1602,7 @@ def __doc_Attribute():
         Get the attribute writable type (RO/WO/RW).
 
         Parameters : None
+
         Return     : (AttrWriteType) The attribute write type.
     """)
 
@@ -1554,6 +1612,7 @@ def __doc_Attribute():
         Get attribute name.
 
         Parameters : None
+
         Return     : (str) The attribute name
     """)
 
@@ -1563,6 +1622,7 @@ def __doc_Attribute():
         Get attribute data type.
 
         Parameters : None
+
         Return     : (int) the attribute data type
     """)
 
@@ -1572,6 +1632,7 @@ def __doc_Attribute():
         Get attribute data format.
 
         Parameters : None
+
         Return     : (AttrDataFormat) the attribute data format
     """)
 
@@ -1581,6 +1642,7 @@ def __doc_Attribute():
         Get name of the associated writable attribute.
 
         Parameters : None
+
         Return     : (str) the associated writable attribute name
     """)
 
@@ -1590,6 +1652,7 @@ def __doc_Attribute():
         Get index of the associated writable attribute.
 
         Parameters : None
+
         Return     : (int) the index in the main attribute vector of the associated writable attribute
     """)
 
@@ -1600,6 +1663,7 @@ def __doc_Attribute():
 
         Parameters :
             - index : (int) The new index in the main attribute vector of the associated writable attribute
+
         Return     : None
     """)
 
@@ -1609,6 +1673,7 @@ def __doc_Attribute():
         Get a COPY of the attribute date.
 
         Parameters : None
+
         Return     : (TimeVal) the attribute date
     """)
 
@@ -1619,6 +1684,7 @@ def __doc_Attribute():
 
         Parameters :
             - new_date : (TimeVal) the attribute date
+
         Return     : None
     """)
 
@@ -1628,6 +1694,7 @@ def __doc_Attribute():
         Get attribute label property.
 
         Parameters : None
+
         Return     : (str) he attribute label
     """)
 
@@ -1637,6 +1704,7 @@ def __doc_Attribute():
         Get a COPY of the attribute data quality.
 
         Parameters : None
+
         Return     : (AttrQuality) the attribute data quality
     """)
 
@@ -1648,6 +1716,7 @@ def __doc_Attribute():
         Parameters :
             - quality : (AttrQuality) the new attribute data quality
             - send_event : (bool) true if a change event should be sent. Default is false.
+
         Return     : None
     """)
 
@@ -1657,6 +1726,7 @@ def __doc_Attribute():
         Get attribute data size.
 
         Parameters : None
+
         Return     : (int) the attribute data size
     """)
 
@@ -1666,6 +1736,7 @@ def __doc_Attribute():
         Get attribute data size in x dimension.
 
         Parameters : None
+
         Return     : (int) the attribute data size in x dimension. Set to 1 for scalar attribute
     """)
 
@@ -1675,6 +1746,7 @@ def __doc_Attribute():
         Get attribute maximum data size in x dimension.
 
         Parameters : None
+
         Return     : (int) the attribute maximum data size in x dimension. Set to 1 for scalar attribute
     """)
 
@@ -1684,6 +1756,7 @@ def __doc_Attribute():
         Get attribute data size in y dimension.
 
         Parameters : None
+
         Return     : (int) the attribute data size in y dimension. Set to 1 for scalar attribute
     """)
 
@@ -1693,6 +1766,7 @@ def __doc_Attribute():
         Get attribute maximum data size in y dimension.
 
         Parameters : None
+
         Return     : (int) the attribute maximum data size in y dimension. Set to 0 for scalar attribute
     """)
 
@@ -1702,6 +1776,7 @@ def __doc_Attribute():
         Get attribute polling period.
 
         Parameters : None
+
         Return     : (int) The attribute polling period in mS. Set to 0 when the attribute is not polled
     """)
 
@@ -1716,6 +1791,7 @@ def __doc_Attribute():
             - ser_model : (AttrSerialModel) The new serialisation model. The
                           serialization model must be one of ATTR_BY_KERNEL,
                           ATTR_BY_USER or ATTR_NO_SYNC
+
         Return     : None
 
         New in PyTango 7.1.0
@@ -1727,6 +1803,7 @@ def __doc_Attribute():
         Get attribute serialization model.
 
         Parameters : None
+
         Return     : (AttrSerialModel) The attribute serialization model
 
         New in PyTango 7.1.0
@@ -1757,6 +1834,7 @@ def __doc_Attribute():
                          be a str or an object with the buffer interface.
             - dim_x : (int) [DEPRECATED] the attribute x length. Default value is 1
             - dim_y : (int) [DEPRECATED] the attribute y length. Default value is 0
+
         Return     : None
     """)
 
@@ -1786,6 +1864,7 @@ def __doc_Attribute():
             - dim_y : (int) [DEPRECATED] the attribute y length. Default value is 0
             - time_stamp : (double) the time stamp
             - quality : (AttrQuality) the attribute quality factor
+
         Return     : None
     """)
 
@@ -1804,6 +1883,7 @@ def __doc_Attribute():
             - implemented : (bool) True when the server fires change events manually.
             - detect : (bool) (optional, default is True) Triggers the verification of
                        the change event properties when set to true.
+
         Return     : None
 
         New in PyTango 7.1.0
@@ -1823,6 +1903,7 @@ def __doc_Attribute():
             - implemented : (bool) True when the server fires archive events manually.
             - detect : (bool) (optional, default is True) Triggers the verification of
                        the archive event properties when set to true.
+
         Return     : None
 
         New in PyTango 7.1.0
@@ -1834,6 +1915,7 @@ def __doc_Attribute():
         Check if the change event is fired manually (without polling) for this attribute.
 
         Parameters : None
+
         Return     : (bool) True if a manual fire change event is implemented.
 
         New in PyTango 7.1.0
@@ -1846,6 +1928,7 @@ def __doc_Attribute():
         event manually.
 
         Parameters : None
+
         Return     : (bool) True if a change event criteria will be checked.
 
         New in PyTango 7.1.0
@@ -1869,6 +1952,7 @@ def __doc_Attribute():
         event manually.
 
         Parameters : None
+
         Return     : (bool) True if a archive event criteria will be checked.
 
         New in PyTango 7.1.0
@@ -1881,6 +1965,7 @@ def __doc_Attribute():
 
         Parameters :
             - implemented : (bool) True when the server fires data ready events manually.
+
         Return     : None
 
         New in PyTango 7.2.0
@@ -1893,6 +1978,7 @@ def __doc_Attribute():
         for this attribute.
 
         Parameters : None
+
         Return     : (bool) True if a manual fire data ready event is implemented.
 
         New in PyTango 7.2.0
@@ -1911,6 +1997,7 @@ def __doc_Attribute():
         the attribute from the list of polled attributes.
 
         Parameters : None
+
         Return     : None
 
         New in PyTango 7.1.0
@@ -1932,6 +2019,7 @@ def __doc_WAttribute():
         attribute does not have a minimum value.
 
         Parameters : None
+
         Return     : (obj) an object with the python minimum value
     """)
 
@@ -1942,6 +2030,7 @@ def __doc_WAttribute():
         attribute does not have a maximum value.
 
         Parameters : None
+
         Return     : (obj) an object with the python maximum value
     """)
 
@@ -1953,6 +2042,7 @@ def __doc_WAttribute():
         Parameters :
             - data : the attribute minimum value. python data type must be compatible
                      with the attribute data format and type.
+
         Return     : None
     """)
 
@@ -1964,6 +2054,7 @@ def __doc_WAttribute():
         Parameters :
             - data : the attribute maximum value. python data type must be compatible
                      with the attribute data format and type.
+
         Return     : None
     """)
 
@@ -1973,6 +2064,7 @@ def __doc_WAttribute():
         Check if the attribute has a minimum value.
 
         Parameters : None
+
         Return     : (bool) true if the attribute has a minimum value defined
     """)
 
@@ -1982,6 +2074,7 @@ def __doc_WAttribute():
         Check if the attribute has a maximum value.
 
         Parameters : None
+
         Return     : (bool) true if the attribute has a maximum value defined
     """)
 
@@ -1991,6 +2084,7 @@ def __doc_WAttribute():
         Retrieve the new value length (data number) for writable attribute.
 
         Parameters : None
+
         Return     : (int) the new value data length
     """)
 
@@ -2005,6 +2099,7 @@ def __doc_WAttribute():
     #                     compatible with the attribute type
     #            - dim_x : (int) the attribute set value x length. Default value is 1
     #            - dim_y : (int) the attribute set value y length. Default value is 0
+    #
     #        Return     : None
     #    """)
 
@@ -2017,6 +2112,7 @@ def __doc_WAttribute():
         Parameters :
             - extract_as: (ExtractAs)
             - lst : [out] (list) a list object that will be filled with the attribute write value (DEPRECATED)
+
         Return     : (obj) the attribute write value.
     """)
 
@@ -2041,6 +2137,7 @@ def __doc_MultiClassAttribute():
 
         Parameters :
             - attr_name : (str) attribute name
+
         Return     : (Attr) the attribute object
 
         Throws     : DevFailed If the attribute is not defined.
@@ -2095,6 +2192,7 @@ def __doc_MultiAttribute():
 
         Parameters :
             - attr_name : (str) attribute name
+
         Return     : (Attribute) the attribute object
 
         Throws     : DevFailed If the attribute is not defined.
@@ -2110,6 +2208,7 @@ def __doc_MultiAttribute():
 
         Parameters :
             - ind : (int) the attribute index
+
         Return     : (Attribute) the attribute object
     """)
 
@@ -2124,6 +2223,7 @@ def __doc_MultiAttribute():
 
         Parameters :
             - attr_name : (str) attribute name
+
         Return     : (WAttribute) the attribute object
 
         Throws     : DevFailed If the attribute is not defined.
@@ -2139,6 +2239,7 @@ def __doc_MultiAttribute():
 
         Parameters :
             - ind : (int) the attribute index
+
         Return     : (WAttribute) the attribute object
     """)
 
@@ -2153,6 +2254,7 @@ def __doc_MultiAttribute():
 
         Parameters :
             - attr_name : (str) attribute name
+
         Return     : (int) the attribute index
 
         Throws     : DevFailed If the attribute is not found in the vector.
@@ -2166,6 +2268,7 @@ def __doc_MultiAttribute():
         Get attribute number.
 
         Parameters : None
+
         Return     : (int) the number of attributes
 
         New in PyTango 7.0.0
@@ -2185,6 +2288,7 @@ def __doc_MultiAttribute():
         Parameters :
             - attr_name : (str) attribute name
             - ind : (int) the attribute index
+
         Return     : (bool) True if at least one attribute is in alarm condition
 
         Throws     : DevFailed If at least one attribute does not have any alarm level defined
@@ -2202,6 +2306,7 @@ def __doc_MultiAttribute():
 
         Parameters :
             - status : (str) a string (should be the device status)
+
         Return     : None
 
         New in PyTango 7.0.0
@@ -2233,6 +2338,7 @@ def __doc_Attr():
 
         Parameters :
             - attr_prop : (UserDefaultAttrProp) the user default property class
+
         Return     : None
     """)
 
@@ -2243,6 +2349,7 @@ def __doc_Attr():
 
         Parameters :
             - disp_level : (DispLevel) the new display level
+
         Return     : None
     """)
 
@@ -2253,6 +2360,7 @@ def __doc_Attr():
 
         Parameters :
             - period : (int) the attribute polling period (in mS)
+
         Return     : None
     """)
 
@@ -2266,6 +2374,7 @@ def __doc_Attr():
         written to the attribute during initialisation!
 
         Parameters : None
+
         Return     : None
     """)
 
@@ -2301,6 +2410,7 @@ def __doc_Attr():
             - implemented : (bool) True when the server fires change events manually.
             - detect : (bool) Triggers the verification of the change event properties
                        when set to true.
+
         Return     : None
     """)
 
@@ -2310,6 +2420,7 @@ def __doc_Attr():
         Check if the change event is fired manually for this attribute.
 
         Parameters : None
+
         Return     : (bool) true if a manual fire change event is implemented.
     """)
 
@@ -2319,6 +2430,7 @@ def __doc_Attr():
         Check if the change event criteria should be checked when firing the event manually.
 
         Parameters : None
+
         Return     : (bool) true if a change event criteria will be checked.
     """)
 
@@ -2338,6 +2450,7 @@ def __doc_Attr():
             - implemented : (bool) True when the server fires change events manually.
             - detect : (bool) Triggers the verification of the archive event properties
                        when set to true.
+
         Return     : None
     """)
 
@@ -2347,6 +2460,7 @@ def __doc_Attr():
         Check if the archive event is fired manually for this attribute.
 
         Parameters : None
+
         Return     : (bool) true if a manual fire archive event is implemented.
     """)
 
@@ -2356,6 +2470,7 @@ def __doc_Attr():
         Check if the archive event criteria should be checked when firing the event manually.
 
         Parameters : None
+
         Return     : (bool) true if a archive event criteria will be checked.
     """)
 
@@ -2366,6 +2481,7 @@ def __doc_Attr():
 
         Parameters :
             - implemented : (bool) True when the server fires data ready events
+
         Return     : None
 
         New in PyTango 7.2.0
@@ -2377,6 +2493,7 @@ def __doc_Attr():
         Check if the data ready event is fired for this attribute.
 
         Parameters : None
+
         Return     : (bool) true if firing data ready event is implemented.
 
         New in PyTango 7.2.0
@@ -2388,6 +2505,7 @@ def __doc_Attr():
         Get the attribute name.
 
         Parameters : None
+
         Return     : (str) the attribute name
     """)
 
@@ -2397,6 +2515,7 @@ def __doc_Attr():
         Get the attribute format.
 
         Parameters : None
+
         Return     : (AttrDataFormat) the attribute format
     """)
 
@@ -2406,6 +2525,7 @@ def __doc_Attr():
         Get the attribute write type.
 
         Parameters : None
+
         Return     : (AttrWriteType) the attribute write type
     """)
 
@@ -2415,6 +2535,7 @@ def __doc_Attr():
         Get the attribute data type.
 
         Parameters : None
+
         Return     : (int) the attribute data type
     """)
 
@@ -2424,6 +2545,7 @@ def __doc_Attr():
         Get the attribute display level.
 
         Parameters : None
+
         Return     : (DispLevel) the attribute display level
     """)
 
@@ -2433,6 +2555,7 @@ def __doc_Attr():
         Get the polling period (mS).
 
         Parameters : None
+
         Return     : (int) the polling period (mS)
     """)
 
@@ -2442,6 +2565,7 @@ def __doc_Attr():
         Determine if the attribute is memorized or not.
 
         Parameters : None
+
         Return     : (bool) True if the attribute is memorized
     """)
 
@@ -2452,6 +2576,7 @@ def __doc_Attr():
         value if it is memorized.
 
         Parameters : None
+
         Return     : (bool) True if initialized with memorized value or not
     """)
 
@@ -2461,6 +2586,7 @@ def __doc_Attr():
         Get the associated name.
 
         Parameters : None
+
         Return     : (bool) the associated name
     """)
 
@@ -2470,6 +2596,7 @@ def __doc_Attr():
         Determine if it is assoc.
 
         Parameters : None
+
         Return     : (bool) if it is assoc
     """)
 
@@ -2479,6 +2606,7 @@ def __doc_Attr():
         Returns the class name.
 
         Parameters : None
+
         Return     : (str) the class name
 
         New in PyTango 7.2.0
@@ -2491,6 +2619,7 @@ def __doc_Attr():
 
         Parameters :
             - cl : (str) new class name
+
         Return     : None
 
         New in PyTango 7.2.0
@@ -2502,6 +2631,7 @@ def __doc_Attr():
         Get the class level attribute properties.
 
         Parameters : None
+
         Return     : (sequence<AttrProperty>) the class attribute properties
     """)
 
@@ -2511,6 +2641,7 @@ def __doc_Attr():
         Get the user default attribute properties.
 
         Parameters : None
+
         Return     : (sequence<AttrProperty>) the user default attribute properties
     """)
 
@@ -2521,6 +2652,7 @@ def __doc_Attr():
 
         Parameters :
             - props : (StdAttrPropertyVector) new class level attribute properties
+
         Return     : None
     """)
 
@@ -2546,6 +2678,7 @@ def __doc_UserDefaultAttrProp():
 
         Parameters :
             - def_label : (str) the user default label property
+
         Return     : None
     """)
 
@@ -2556,6 +2689,7 @@ def __doc_UserDefaultAttrProp():
 
         Parameters :
             - def_description : (str) the user default description property
+
         Return     : None
     """)
 
@@ -2566,6 +2700,7 @@ def __doc_UserDefaultAttrProp():
 
         Parameters :
             - def_format : (str) the user default format property
+
         Return     : None
     """)
 
@@ -2576,6 +2711,7 @@ def __doc_UserDefaultAttrProp():
 
         Parameters :
             - def_unit : (str) te user default unit property
+
         Return     : None
     """)
 
@@ -2586,6 +2722,7 @@ def __doc_UserDefaultAttrProp():
 
         Parameters :
             - def_standard_unit : (str) the user default standard unit property
+
         Return     : None
     """)
 
@@ -2596,6 +2733,7 @@ def __doc_UserDefaultAttrProp():
 
         Parameters :
             - def_display_unit : (str) the user default display unit property
+
         Return     : None
     """)
 
@@ -2606,6 +2744,7 @@ def __doc_UserDefaultAttrProp():
 
         Parameters :
             - def_min_value : (str) the user default min_value property
+
         Return     : None
     """)
 
@@ -2616,6 +2755,7 @@ def __doc_UserDefaultAttrProp():
 
         Parameters :
             - def_max_value : (str) the user default max_value property
+
         Return     : None
     """)
 
@@ -2626,6 +2766,7 @@ def __doc_UserDefaultAttrProp():
 
         Parameters :
             - def_min_alarm : (str) the user default min_alarm property
+
         Return     : None
     """)
 
@@ -2636,6 +2777,7 @@ def __doc_UserDefaultAttrProp():
 
         Parameters :
             - def_max_alarm : (str) the user default max_alarm property
+
         Return     : None
     """)
 
@@ -2646,6 +2788,7 @@ def __doc_UserDefaultAttrProp():
 
         Parameters :
             - def_min_warning : (str) the user default min_warning property
+
         Return     : None
     """)
 
@@ -2656,6 +2799,7 @@ def __doc_UserDefaultAttrProp():
 
         Parameters :
             - def_max_warning : (str) the user default max_warning property
+
         Return     : None
     """)
 
@@ -2666,6 +2810,7 @@ def __doc_UserDefaultAttrProp():
 
         Parameters :
             - def_delta_t : (str) the user default RDS alarm delta_t property
+
         Return     : None
     """)
 
@@ -2676,6 +2821,7 @@ def __doc_UserDefaultAttrProp():
 
         Parameters :
             - def_delta_val : (str) the user default RDS alarm delta_val property
+
         Return     : None
     """)
 
@@ -2686,6 +2832,7 @@ def __doc_UserDefaultAttrProp():
 
         Parameters :
             - def_abs_change : (str) the user default change event abs_change property
+
         Return     : None
 
         Deprecated since PyTango 8.0. Please use set_event_abs_change instead.
@@ -2698,6 +2845,7 @@ def __doc_UserDefaultAttrProp():
 
         Parameters :
             - def_abs_change : (str) the user default change event abs_change property
+
         Return     : None
 
         New in PyTango 8.0
@@ -2710,6 +2858,7 @@ def __doc_UserDefaultAttrProp():
 
         Parameters :
             - def_rel_change : (str) the user default change event rel_change property
+
         Return     : None
 
         Deprecated since PyTango 8.0. Please use set_event_rel_change instead.
@@ -2722,6 +2871,7 @@ def __doc_UserDefaultAttrProp():
 
         Parameters :
             - def_rel_change : (str) the user default change event rel_change property
+
         Return     : None
 
         New in PyTango 8.0
@@ -2734,6 +2884,7 @@ def __doc_UserDefaultAttrProp():
 
         Parameters :
             - def_period : (str) the user default periodic event period property
+
         Return     : None
 
         Deprecated since PyTango 8.0. Please use set_event_period instead.
@@ -2746,6 +2897,7 @@ def __doc_UserDefaultAttrProp():
 
         Parameters :
             - def_period : (str) the user default periodic event period property
+
         Return     : None
 
         New in PyTango 8.0
@@ -2758,6 +2910,7 @@ def __doc_UserDefaultAttrProp():
 
         Parameters :
             - def_archive_abs_change : (str) the user default archive event abs_change property
+
         Return     : None
 
         Deprecated since PyTango 8.0. Please use set_archive_event_abs_change instead.
@@ -2770,6 +2923,7 @@ def __doc_UserDefaultAttrProp():
 
         Parameters :
             - def_archive_abs_change : (str) the user default archive event abs_change property
+
         Return     : None
 
         New in PyTango 8.0
@@ -2782,6 +2936,7 @@ def __doc_UserDefaultAttrProp():
 
         Parameters :
             - def_archive_rel_change : (str) the user default archive event rel_change property
+
         Return     : None
 
         Deprecated since PyTango 8.0. Please use set_archive_event_rel_change instead.
@@ -2794,6 +2949,7 @@ def __doc_UserDefaultAttrProp():
 
         Parameters :
             - def_archive_rel_change : (str) the user default archive event rel_change property
+
         Return     : None
 
         New in PyTango 8.0
@@ -2806,6 +2962,7 @@ def __doc_UserDefaultAttrProp():
 
         Parameters :
             - def_archive_period : (str) t
+
         Return     : None
 
         Deprecated since PyTango 8.0. Please use set_archive_event_period instead.
@@ -2818,6 +2975,7 @@ def __doc_UserDefaultAttrProp():
 
         Parameters :
             - def_archive_period : (str) t
+
         Return     : None
 
         New in PyTango 8.0


### PR DESCRIPTION
Here is few changes on your `device_server.py`  module in order to make it compliant with Sphinx.

Without it, the formatting is not fine, and there is warning on parsing.

I was not expecting to do so much changes, but basically this tries to:

- Always add a one liner short description at the beginning of func doc
- Fix indentation
- Use google style formatting https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html

Here is screenshots before and after this patch.

Notice the detection of the param/return/raise field, and the right handling of the `attr_list` argument description `attribute vector ... of`

# Before

![Capture d’écran de 2020-12-20 23-16-41](https://user-images.githubusercontent.com/7579321/102725938-e8dde900-431a-11eb-9742-735547a5156f.png)

# After

![Capture d’écran de 2020-12-20 23-18-33](https://user-images.githubusercontent.com/7579321/102725940-ee3b3380-431a-11eb-99c1-1b0eb897a1a1.png)
