### PR TITLE
Fix docs - missing DbDevExportInfos and DbDevImportInfos

### DIFF
--- a/doc/database.rst
+++ b/doc/database.rst
@@ -12,7 +12,7 @@ Database API
 .. autoclass:: tango.DbDevExportInfo
     :members:
 
-.. autoclass:: tango.DbDevExportInfo
+.. autoclass:: tango.DbDevExportInfos
     :members:
 
 .. autoclass:: tango.DbDevImportInfo

--- a/doc/database.rst
+++ b/doc/database.rst
@@ -18,6 +18,9 @@ Database API
 .. autoclass:: tango.DbDevImportInfo
     :members:
 
+.. autoclass:: tango.DbDevImportInfos
+    :members:
+
 .. autoclass:: tango.DbDevInfo
     :members:
 


### PR DESCRIPTION
There was a warning on the doc about duprication of `DbDevExportInfo`.

That's probably because one of them have to be `DbDevExportInfos`.

If that's the case, here is a fix.