### PR TITLE
[WIP] Uncomment docs of tango.Util.instance()

### DIFF
--- a/doc/mock_tango_extension.py
+++ b/doc/mock_tango_extension.py
@@ -71,6 +71,7 @@ class ExtensionMock(MagicMock):
             import tango.connection
             tango.utils.__dict__['document_enum'] = document_enum
             tango.utils.__dict__['document_method'] = document_method
+            tango.utils.__dict__['document_static_method'] = document_method
             tango.base_types.__dict__['__document_enum'] = document_enum
             tango.device_server.__dict__['__document_method'] = document_method
             tango.connection.__dict__['__document_method'] = document_method

--- a/tango/pyutil.py
+++ b/tango/pyutil.py
@@ -304,12 +304,14 @@ def __doc_Util():
 
            Static method that gets the singleton object reference.
            If the class has not been initialised with it's init method,
-           this method prints a message and aborts the device server process
+           this method prints a message and aborts the device server process.
 
        Parameters :
-           - exit : (bool)
+           - exit : (bool) exit or throw DevFailed
 
        Return     : (Util) the tango Util object
+       
+       Throws     : DevFailed instead of aborting if exit is set to False
     """)
 
     document_method("set_trace_level", """

--- a/tango/pyutil.py
+++ b/tango/pyutil.py
@@ -22,7 +22,7 @@ import copy
 
 from ._tango import Util, Except, DevFailed, DbDevInfo, EnsureOmniThread, is_omni_thread
 from .utils import document_method as __document_method
-# from utils import document_static_method as __document_static_method
+from .utils import document_static_method as __document_static_method
 from .globals import class_list, cpp_class_list, get_constructed_classes
 try:
     import collections.abc as collections_abc  # python 3.3+
@@ -296,21 +296,21 @@ def __doc_Util():
     def document_method(method_name, desc, append=True):
         return __document_method(Util, method_name, desc, append)
 
-    #    def document_static_method(method_name, desc, append=True):
-    #        return __document_static_method(_Util, method_name, desc, append)
+    def document_static_method(method_name, desc, append=True):
+        return __document_static_method(Util, method_name, desc, append)
 
-    #    document_static_method("instance", """
-    #    instance(exit = True) -> Util
-    #
-    #            Static method that gets the singleton object reference.
-    #            If the class has not been initialised with it's init method,
-    #            this method prints a message and aborts the device server process
-    #
-    #        Parameters :
-    #            - exit : (bool)
-    #
-    #        Return     : (Util) the tango Util object
-    #    """ )
+    document_static_method("instance", """
+    instance(exit = True) -> Util
+
+           Static method that gets the singleton object reference.
+           If the class has not been initialised with it's init method,
+           this method prints a message and aborts the device server process
+
+       Parameters :
+           - exit : (bool)
+
+       Return     : (Util) the tango Util object
+    """)
 
     document_method("set_trace_level", """
     set_trace_level(self, level) -> None


### PR DESCRIPTION
Hi,

Just in case it helps others, I thouht it may be useful to add to the documentation the `tango.Util.instance()` argument as it was explained in [this forum post](https://www.tango-controls.org/community/forum/c/development/python/how-to-check-if-the-code-is-being-executed-by-a-server-process/?page=1#post-4511).

I saw that it was already documented and I just tried to uncomment it. However it still does not generate the docs. Well, I just made some quick tries, but if you think it is interesting to add this to the docs, I could investigate further.

Many thanks!